### PR TITLE
Allow multiple To addresses in SimpleSendableMail

### DIFF
--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -219,10 +219,10 @@ pub struct SimpleSendableEmail {
 
 impl SimpleSendableEmail {
     /// Returns a new email
-    pub fn new(from_address: &str, to_address: &str, message: &str) -> SimpleSendableEmail {
+    pub fn new(from_address: &str, to_address: Vec<String>, message: &str) -> SimpleSendableEmail {
         SimpleSendableEmail {
             from: from_address.to_string(),
-            to: vec![to_address.to_string()],
+            to: to_address,
             message: message.to_string(),
         }
     }


### PR DESCRIPTION
Because the struct internally stores a `Vec<String>` it would be nice to be able to construct messages with multiple To addresses.
This is in its current form a breaking API change, so feel free to change the way it's implemented.