### PR TITLE
feat(transport-smtp): Change default authentication mecanism default handling

### DIFF
--- a/src/email/mod.rs
+++ b/src/email/mod.rs
@@ -72,7 +72,7 @@ pub struct EmailBuilder {
     date_issued: bool,
 }
 
-/// todo
+/// Simple email enveloppe representation
 #[derive(PartialEq,Eq,Clone,Debug)]
 pub struct Envelope {
     /// The envelope recipients' addresses

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,8 +144,8 @@
 //!     .security_level(SecurityLevel::AlwaysEncrypt)
 //!     // Enable SMTPUTF8 if the server supports it
 //!     .smtp_utf8(true)
-//!     // Configure accepted authentication mechanisms
-//!     .authentication_mechanisms(vec![Mechanism::CramMd5])
+//!     // Configure expected authentication mechanism
+//!     .authentication_mechanism(Mechanism::CramMd5)
 //!     // Enable connection reuse
 //!     .connection_reuse(true).build();
 //!

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -82,7 +82,15 @@ impl<S: Connector + Write + Read + Debug + Clone> Client<S> {
     pub fn upgrade_tls_stream(&mut self, ssl_context: &SslContext) -> io::Result<()> {
         match self.stream {
             Some(ref mut stream) => stream.get_mut().upgrade_tls(ssl_context),
-            None => Ok(())
+            None => Ok(()),
+        }
+    }
+
+    /// Tells if the underlying stream is currently encrypted
+    pub fn is_encrypted(&self) -> bool {
+        match self.stream {
+            Some(ref stream) => stream.get_ref().is_encrypted(),
+            None => false,
         }
     }
 

--- a/src/transport/smtp/client/net.rs
+++ b/src/transport/smtp/client/net.rs
@@ -14,6 +14,8 @@ pub trait Connector: Sized {
     fn connect(addr: &SocketAddr, ssl_context: Option<&SslContext>) -> io::Result<Self>;
     /// Upgrades to TLS connection
     fn upgrade_tls(&mut self, ssl_context: &SslContext) -> io::Result<()>;
+    /// Is the NetworkStream encrypted
+    fn is_encrypted(&self) -> bool;
 }
 
 impl Connector for NetworkStream {
@@ -42,6 +44,13 @@ impl Connector for NetworkStream {
             NetworkStream::Ssl(stream) => NetworkStream::Ssl(stream),
         };
         Ok(())
+    }
+    
+    fn is_encrypted(&self) -> bool {
+        match *self {
+            NetworkStream::Plain(_) => false,
+            NetworkStream::Ssl(_) => true,
+        }
     }
 }
 


### PR DESCRIPTION
Change the default authentication mechanism selection check if the
connection is encrypted, and only test PLAIN when it is the case.
Also make the .authentication_mechnaism only take one mechanism, as
a user will specify it he wants to ensure one particular method will
be used.

Closes #65