### PR TITLE
feat(transport-smtp): Disallow unencrypted connection by default

### DIFF
--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -102,7 +102,7 @@ impl SmtpTransportBuilder {
                 Ok(SmtpTransportBuilder {
                        server_addr: addr,
                        ssl_context: SslContext::builder(SslMethod::tls()).unwrap().build(),
-                       security_level: SecurityLevel::Opportunistic,
+                       security_level: SecurityLevel::AlwaysEncrypt,
                        smtp_utf8: false,
                        credentials: None,
                        connection_reuse_count_limit: 100,


### PR DESCRIPTION
By default, do not silently use unencrypted transport.