### PR TITLE
fix(transport-stub): Explain that a logger is needed to get logs, and…

### DIFF
--- a/lettre/examples/smtp.rs
+++ b/lettre/examples/smtp.rs
@@ -1,8 +1,11 @@
 extern crate lettre;
+extern crate env_logger;
 
 use lettre::{EmailAddress, EmailTransport, SimpleSendableEmail, SmtpTransport};
 
 fn main() {
+    env_logger::init().unwrap();
+
     let email = SimpleSendableEmail::new(
         EmailAddress::new("user@localhost".to_string()),
         vec![EmailAddress::new("root@localhost".to_string())],

--- a/lettre/src/stub/mod.rs
+++ b/lettre/src/stub/mod.rs
@@ -17,7 +17,7 @@
 //! assert!(result.is_ok());
 //! ```
 //!
-//! Will log the line:
+//! Will log (when using a logger like `env_logger`):
 //!
 //! ```text
 //! b7c211bc-9811-45ce-8cd9-68eab575d695: from=<user@localhost> to=<root@localhost>


### PR DESCRIPTION
… add env_logger to the example (fixes #181)