### PR TITLE
Add features for SMTP and sendmail transport

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -15,10 +15,10 @@ keywords = ["email", "smtp", "mailer"]
 travis-ci = { repository = "lettre/lettre" }
 
 [dependencies]
-bufstream = "^0.1"
 log = "^0.3"
-native-tls = "^0.1"
-base64 = "^0.6"
+bufstream = { version = "^0.1", optional = true }
+native-tls = { version = "^0.1", optional = true }
+base64 = { version = "^0.6", optional = true }
 hex = { version = "^0.2", optional = true }
 rust-crypto = { version = "^0.2", optional = true }
 serde = { version = "^1.0", optional = true }
@@ -29,8 +29,14 @@ serde_derive = { version = "^1.0", optional = true }
 env_logger = "^0.4"
 
 [features]
-default = ["file-transport", "crammd5-auth"]
+default = ["file-transport", "crammd5-auth", "smtp-transport", "sendmail-transport"]
 unstable = []
 serde-impls = ["serde", "serde_derive"]
 file-transport = ["serde-impls", "serde_json"]
 crammd5-auth = ["rust-crypto", "hex"]
+smtp-transport = ["bufstream", "native-tls", "base64"]
+sendmail-transport = []
+
+[[example]]
+name = "smtp"
+required-features = ["smtp-transport"]

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -8,12 +8,15 @@
 
 #[macro_use]
 extern crate log;
-extern crate base64;
 #[cfg(feature = "crammd5-auth")]
 extern crate hex;
 #[cfg(feature = "crammd5-auth")]
 extern crate crypto;
+#[cfg(feature = "smtp-transport")]
+extern crate base64;
+#[cfg(feature = "smtp-transport")]
 extern crate bufstream;
+#[cfg(feature = "smtp-transport")]
 extern crate native_tls;
 #[cfg(feature = "file-transport")]
 extern crate serde_json;
@@ -21,7 +24,9 @@ extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 
+#[cfg(feature = "smtp-transport")]
 pub mod smtp;
+#[cfg(feature = "sendmail-transport")]
 pub mod sendmail;
 pub mod stub;
 #[cfg(feature = "file-transport")]
@@ -29,8 +34,11 @@ pub mod file;
 
 #[cfg(feature = "file-transport")]
 pub use file::FileEmailTransport;
+#[cfg(feature = "sendmail-transport")]
 pub use sendmail::SendmailTransport;
+#[cfg(feature = "smtp-transport")]
 pub use smtp::{SmtpTransport, ClientSecurity};
+#[cfg(feature = "smtp-transport")]
 pub use smtp::client::net::ClientTlsParameters;
 use std::fmt::{self, Display, Formatter};
 use std::io::Read;

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -18,8 +18,6 @@ extern crate native_tls;
 #[cfg(feature = "file-transport")]
 extern crate serde_json;
 #[cfg(feature = "serde-impls")]
-extern crate serde;
-#[cfg(feature = "serde-impls")]
 #[macro_use]
 extern crate serde_derive;
 

--- a/lettre/src/stub/mod.rs
+++ b/lettre/src/stub/mod.rs
@@ -25,33 +25,30 @@
 
 use EmailTransport;
 use SendableEmail;
-use smtp::error::{Error, SmtpResult};
-use smtp::response::{Code, Response};
 use std::io::Read;
-use std::str::FromStr;
 
 /// This transport logs the message envelope and returns the given response
 #[derive(Debug)]
 pub struct StubEmailTransport {
-    response: Response,
+    response: StubResult,
 }
 
 impl StubEmailTransport {
     /// Creates a new transport that always returns the given response
-    pub fn new(response: Response) -> StubEmailTransport {
+    pub fn new(response: StubResult) -> StubEmailTransport {
         StubEmailTransport { response: response }
     }
 
     /// Creates a new transport that always returns a success response
     pub fn new_positive() -> StubEmailTransport {
         StubEmailTransport {
-            response: Response::new(Code::from_str("200").unwrap(), vec!["ok".to_string()]),
+            response: Ok(()),
         }
     }
 }
 
 /// SMTP result type
-pub type StubResult = SmtpResult;
+pub type StubResult = Result<(), ()>;
 
 impl<'a, T: Read + 'a> EmailTransport<'a, T, StubResult> for StubEmailTransport {
     fn send<U: SendableEmail<'a, T>>(&mut self, email: &'a U) -> StubResult {
@@ -62,10 +59,6 @@ impl<'a, T: Read + 'a> EmailTransport<'a, T, StubResult> for StubEmailTransport 
             email.from(),
             email.to()
         );
-        if self.response.is_positive() {
-            Ok(self.response.clone())
-        } else {
-            Err(Error::from(self.response.clone()))
-        }
+        self.response
     }
 }

--- a/lettre/tests/transport_file.rs
+++ b/lettre/tests/transport_file.rs
@@ -5,7 +5,6 @@ extern crate lettre;
 mod test {
 
     use lettre::{EmailAddress, EmailTransport, SendableEmail, SimpleSendableEmail};
-    #[cfg(feature = "file-transport")]
     use lettre::file::FileEmailTransport;
     use std::env::temp_dir;
     use std::fs::File;
@@ -13,7 +12,6 @@ mod test {
     use std::io::Read;
 
     #[test]
-    #[cfg(feature = "file-transport")]
     fn file_transport() {
         let mut sender = FileEmailTransport::new(temp_dir());
         let email = SimpleSendableEmail::new(
@@ -39,4 +37,5 @@ mod test {
 
         remove_file(file).unwrap();
     }
+
 }

--- a/lettre/tests/transport_sendmail.rs
+++ b/lettre/tests/transport_sendmail.rs
@@ -1,19 +1,25 @@
 extern crate lettre;
 
-use lettre::{EmailAddress, EmailTransport, SimpleSendableEmail};
-use lettre::sendmail::SendmailTransport;
+#[cfg(test)]
+#[cfg(feature = "sendmail-transport")]
+mod test {
 
-#[test]
-fn sendmail_transport_simple() {
-    let mut sender = SendmailTransport::new();
-    let email = SimpleSendableEmail::new(
-        EmailAddress::new("user@localhost".to_string()),
-        vec![EmailAddress::new("root@localhost".to_string())],
-        "sendmail_id".to_string(),
-        "Hello sendmail".to_string(),
-    );
+    use lettre::{EmailAddress, EmailTransport, SimpleSendableEmail};
+    use lettre::sendmail::SendmailTransport;
 
-    let result = sender.send(&email);
-    println!("{:?}", result);
-    assert!(result.is_ok());
+    #[test]
+    fn sendmail_transport_simple() {
+        let mut sender = SendmailTransport::new();
+        let email = SimpleSendableEmail::new(
+            EmailAddress::new("user@localhost".to_string()),
+            vec![EmailAddress::new("root@localhost".to_string())],
+            "sendmail_id".to_string(),
+            "Hello sendmail".to_string(),
+        );
+
+        let result = sender.send(&email);
+        println!("{:?}", result);
+        assert!(result.is_ok());
+    }
+
 }

--- a/lettre/tests/transport_smtp.rs
+++ b/lettre/tests/transport_smtp.rs
@@ -1,19 +1,24 @@
 extern crate lettre;
 
-use lettre::{ClientSecurity, EmailAddress, EmailTransport, SimpleSendableEmail, SmtpTransport};
+#[cfg(test)]
+#[cfg(feature = "smtp-transport")]
+mod test {
 
-#[test]
-fn smtp_transport_simple() {
-    let mut sender = SmtpTransport::builder("127.0.0.1:2525", ClientSecurity::None)
-        .unwrap()
-        .build();
-    let email = SimpleSendableEmail::new(
-        EmailAddress::new("user@localhost".to_string()),
-        vec![EmailAddress::new("root@localhost".to_string())],
-        "smtp_id".to_string(),
-        "Hello smtp".to_string(),
-    );
+    use lettre::{ClientSecurity, EmailAddress, EmailTransport, SimpleSendableEmail, SmtpTransport};
 
-    let result = sender.send(&email);
-    assert!(result.is_ok());
+    #[test]
+    fn smtp_transport_simple() {
+        let mut sender = SmtpTransport::builder("127.0.0.1:2525", ClientSecurity::None)
+            .unwrap()
+            .build();
+        let email = SimpleSendableEmail::new(
+            EmailAddress::new("user@localhost".to_string()),
+            vec![EmailAddress::new("root@localhost".to_string())],
+            "smtp_id".to_string(),
+            "Hello smtp".to_string(),
+        );
+
+        sender.send(&email).unwrap();
+    }
+
 }

--- a/lettre/tests/transport_stub.rs
+++ b/lettre/tests/transport_stub.rs
@@ -1,16 +1,12 @@
 extern crate lettre;
 
 use lettre::{EmailAddress, EmailTransport, SimpleSendableEmail};
-use lettre::smtp::response::{Code, Response};
 use lettre::stub::StubEmailTransport;
-use std::str::FromStr;
 
 #[test]
 fn stub_transport() {
     let mut sender_ok = StubEmailTransport::new_positive();
-    let response_ok = Response::new(Code::from_str("200").unwrap(), vec!["ok".to_string()]);
-    let response_ko = Response::new(Code::from_str("510").unwrap(), vec!["ko".to_string()]);
-    let mut sender_ko = StubEmailTransport::new(response_ko);
+    let mut sender_ko = StubEmailTransport::new(Err(()));
 
     let email = SimpleSendableEmail::new(
         EmailAddress::new("user@localhost".to_string()),
@@ -19,10 +15,6 @@ fn stub_transport() {
         "Hello stub".to_string(),
     );
 
-    let result_ok = sender_ok.send(&email).unwrap();
-    let result_ko = sender_ko.send(&email);
-
-    assert_eq!(result_ok, response_ok);
-    assert!(result_ko.is_err());
-
+    sender_ok.send(&email).unwrap();
+    sender_ko.send(&email).unwrap_err();
 }

--- a/lettre_email/Cargo.toml
+++ b/lettre_email/Cargo.toml
@@ -16,10 +16,11 @@ travis-ci = { repository = "lettre/lettre_email" }
 
 [dev-dependencies]
 env_logger = "*"
+lettre = { path = "../lettre", features = ["smtp-transport"] }
 
 [dependencies]
 email = "^0.0"
 mime = "^0.3"
 time = "^0.1"
 uuid = { version = ">=0.4, <0.6", features = ["v4"] }
-lettre = { path = "../lettre" }
+lettre = { path = "../lettre", default-features = false }


### PR DESCRIPTION
`lettre_email` depends on `lettre` for various types. This PR moves all actual transports to features, which can be disabled if you just want email formatting.

Depends on https://github.com/lettre/lettre/pull/192