### PR TITLE
feat(email): Support binary file as attachment

### DIFF
--- a/lettre_email/Cargo.toml
+++ b/lettre_email/Cargo.toml
@@ -28,3 +28,4 @@ mime = "^0.3"
 time = "^0.1"
 uuid = { version = "^0.6", features = ["v4"] }
 lettre = { version = "^0.8", path = "../lettre", default-features = false }
+base64 = "0.9.0"

--- a/lettre_email/src/lib.rs
+++ b/lettre_email/src/lib.rs
@@ -9,6 +9,7 @@ extern crate lettre;
 extern crate mime;
 extern crate time;
 extern crate uuid;
+extern crate base64;
 
 pub mod error;
 
@@ -559,8 +560,8 @@ impl EmailBuilder {
         let file = File::open(path);
         let body = match file {
             Ok(mut f) => {
-                let mut data = String::new();
-                let read = f.read_to_string(&mut data);
+                let mut data = Vec::new();
+                let read = f.read_to_end(&mut data);
                 match read {
                     Ok(_) => data,
                     Err(e) => {
@@ -588,11 +589,13 @@ impl EmailBuilder {
             }
         };
 
-        let content = PartBuilder::new().body(body)
+        let encoded_body = base64::encode(&body);
+        let content = PartBuilder::new().body(encoded_body)
                                         .header(("Content-Disposition",
                                                 format!("attachment; filename=\"{}\"",
                                                          actual_filename)))
                                         .header(("Content-Type", content_type.to_string()))
+                                        .header(("Content-Transfer-Encoding", "base64"))
                                         .build();
 
         self.set_message_type(MimeMultipartType::Mixed);


### PR DESCRIPTION
A pretty easy fix by using base64 encoding
worked pretty well in my project
https://github.com/SpiderPigSpy/accounting/blob/934fb660b726a0034a8cce1ca1ee65c0bdcf90a4/src/bot/email.rs

Closes issue
https://github.com/lettre/lettre/issues/224