### PR TITLE
feat(transport): Use md-5 and hmac instead of rust-crypto

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ rust:
 - stable
 - beta
 - nightly
-- 1.18.0
+- 1.20.0
 matrix:
   allow_failures:
   - rust: nightly

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Crate](https://img.shields.io/crates/v/lettre.svg)](https://crates.io/crates/lettre)
 [![Docs](https://docs.rs/lettre/badge.svg)](https://docs.rs/lettre/)
-[![Required Rust version](https://img.shields.io/badge/rustc-1.18-green.svg)]()
+[![Required Rust version](https://img.shields.io/badge/rustc-1.20-green.svg)]()
 [![MIT licensed](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 [![Gitter](https://badges.gitter.im/lettre/lettre.svg)](https://gitter.im/lettre/lettre?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
@@ -34,7 +34,7 @@ Lettre provides the following features:
 
 ## Example
 
-This library requires Rust 1.18 or newer.
+This library requires Rust 1.20 or newer.
 To use this library, add the following to your `Cargo.toml`:
 
 ```toml

--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -26,7 +26,8 @@ native-tls = { version = "^0.1", optional = true }
 base64 = { version = "^0.9", optional = true }
 hex = { version = "^0.3", optional = true }
 hostname = { version = "^0.1", optional = true }
-rust-crypto = { version = "^0.2", optional = true }
+md-5 = { version = "^0.7", optional = true }
+hmac = { version = "^0.6", optional = true }
 serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
@@ -40,7 +41,7 @@ default = ["file-transport", "crammd5-auth", "smtp-transport", "sendmail-transpo
 unstable = []
 serde-impls = ["serde", "serde_derive"]
 file-transport = ["serde-impls", "serde_json"]
-crammd5-auth = ["rust-crypto", "hex"]
+crammd5-auth = ["md-5", "hmac", "hex"]
 smtp-transport = ["bufstream", "native-tls", "base64", "nom", "hostname"]
 sendmail-transport = []
 

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -13,13 +13,15 @@ extern crate base64;
 #[cfg(feature = "smtp-transport")]
 extern crate bufstream;
 #[cfg(feature = "crammd5-auth")]
-extern crate crypto;
-#[cfg(feature = "crammd5-auth")]
 extern crate hex;
+#[cfg(feature = "crammd5-auth")]
+extern crate hmac;
 #[cfg(feature = "smtp-transport")]
 extern crate hostname;
 #[macro_use]
 extern crate log;
+#[cfg(feature = "crammd5-auth")]
+extern crate md5;
 #[cfg(feature = "smtp-transport")]
 extern crate native_tls;
 #[cfg(feature = "smtp-transport")]

--- a/lettre/src/smtp/authentication.rs
+++ b/lettre/src/smtp/authentication.rs
@@ -1,11 +1,9 @@
 //! Provides authentication mechanisms
 
 #[cfg(feature = "crammd5-auth")]
-use crypto::hmac::Hmac;
+use md5::Md5;
 #[cfg(feature = "crammd5-auth")]
-use crypto::mac::Mac;
-#[cfg(feature = "crammd5-auth")]
-use crypto::md5::Md5;
+use hmac::{Hmac, Mac};
 #[cfg(feature = "crammd5-auth")]
 use hex;
 use smtp::NUL;
@@ -146,7 +144,8 @@ impl Mechanism {
                     None => return Err(Error::Client("This mechanism does expect a challenge")),
                 };
 
-                let mut hmac = Hmac::new(Md5::new(), credentials.password.as_bytes());
+                let mut hmac: Hmac<Md5> = Hmac::new_varkey(credentials.password.as_bytes())
+                    .expect("md5 should support variable key size");
                 hmac.input(decoded_challenge.as_bytes());
 
                 Ok(format!(

--- a/website/content/README.md
+++ b/website/content/README.md
@@ -10,7 +10,7 @@ Lettre is an email library that allows creating and sending messages. It provide
 The `lettre_email` crate allows you to compose messages, and the `lettre`
 provide transports to send them.
 
-Lettre requires Rust 1.18 or newer. Add the following to your `Cargo.toml`:
+Lettre requires Rust 1.20 or newer. Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]


### PR DESCRIPTION
RustCrypto is not supported anymore, and this avoids
compiling useless code.