### PR TITLE
fix(transport): set_read_timeout is called twice in smtp/client/mod.rs

### DIFF
--- a/lettre/src/smtp/client/mod.rs
+++ b/lettre/src/smtp/client/mod.rs
@@ -132,7 +132,7 @@ impl<S: Connector + Write + Read + Timeout + Debug> Client<S> {
         match self.stream {
             Some(ref mut stream) => {
                 stream.get_mut().set_read_timeout(duration)?;
-                stream.get_mut().set_read_timeout(duration)?;
+                stream.get_mut().set_write_timeout(duration)?;
                 Ok(())
             }
             None => Ok(()),


### PR DESCRIPTION
set_read_timeout is called twice. I've replaced the second one with a call to set_write_timeout. Probably a copy/paste error.