### PR TITLE
feat(transport): Remove support for CRAM-MD5

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -24,10 +24,7 @@ nom = { version = "^3.2", optional = true }
 bufstream = { version = "^0.1", optional = true }
 native-tls = { version = "^0.1", optional = true }
 base64 = { version = "^0.9", optional = true }
-hex = { version = "^0.3", optional = true }
 hostname = { version = "^0.1", optional = true }
-md-5 = { version = "^0.7", optional = true }
-hmac = { version = "^0.6", optional = true }
 serde = { version = "^1.0", optional = true }
 serde_json = { version = "^1.0", optional = true }
 serde_derive = { version = "^1.0", optional = true }
@@ -41,7 +38,6 @@ default = ["file-transport", "smtp-transport", "sendmail-transport"]
 unstable = []
 serde-impls = ["serde", "serde_derive"]
 file-transport = ["serde-impls", "serde_json"]
-crammd5-auth = ["md-5", "hmac", "hex"]
 smtp-transport = ["bufstream", "native-tls", "base64", "nom", "hostname"]
 sendmail-transport = []
 

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -10,16 +10,10 @@
 extern crate base64;
 #[cfg(feature = "smtp-transport")]
 extern crate bufstream;
-#[cfg(feature = "crammd5-auth")]
-extern crate hex;
-#[cfg(feature = "crammd5-auth")]
-extern crate hmac;
 #[cfg(feature = "smtp-transport")]
 extern crate hostname;
 #[macro_use]
 extern crate log;
-#[cfg(feature = "crammd5-auth")]
-extern crate md5;
 #[cfg(feature = "smtp-transport")]
 extern crate native_tls;
 #[cfg(feature = "smtp-transport")]

--- a/lettre/src/smtp/commands.rs
+++ b/lettre/src/smtp/commands.rs
@@ -313,8 +313,6 @@ impl AuthCommand {
 mod test {
     use super::*;
     use smtp::extension::MailBodyParameter;
-    #[cfg(feature = "crammd5-auth")]
-    use smtp::response::{Category, Code, Detail, Severity};
 
     #[test]
     fn test_display() {
@@ -391,43 +389,12 @@ mod test {
             ),
             "AUTH PLAIN AHVzZXIAcGFzc3dvcmQ=\r\n"
         );
-        #[cfg(feature = "crammd5-auth")]
-        assert_eq!(
-            format!(
-                "{}",
-                AuthCommand::new(
-                    Mechanism::CramMd5,
-                    credentials.clone(),
-                    Some("test".to_string()),
-                ).unwrap()
-            ),
-            "dXNlciAzMTYxY2NmZDdmMjNlMzJiYmMzZTQ4NjdmYzk0YjE4Nw==\r\n"
-        );
         assert_eq!(
             format!(
                 "{}",
                 AuthCommand::new(Mechanism::Login, credentials.clone(), None).unwrap()
             ),
             "AUTH LOGIN\r\n"
-        );
-        #[cfg(feature = "crammd5-auth")]
-        assert_eq!(
-            format!(
-                "{}",
-                AuthCommand::new_from_response(
-                    Mechanism::CramMd5,
-                    credentials.clone(),
-                    &Response::new(
-                        Code::new(
-                            Severity::PositiveIntermediate,
-                            Category::Unspecified3,
-                            Detail::Four,
-                        ),
-                        vec!["dGVzdAo=".to_string()],
-                    ),
-                ).unwrap()
-            ),
-            "dXNlciA1NTIzNThiMzExOWFjOWNkYzM2YWRiN2MxNWRmMWJkNw==\r\n"
         );
     }
 }

--- a/lettre/src/smtp/extension.rs
+++ b/lettre/src/smtp/extension.rs
@@ -145,10 +145,6 @@ impl ServerInfo {
                         "LOGIN" => {
                             features.insert(Extension::Authentication(Mechanism::Login));
                         }
-                        #[cfg(feature = "crammd5-auth")]
-                        "CRAM-MD5" => {
-                            features.insert(Extension::Authentication(Mechanism::CramMd5));
-                        }
                         _ => (),
                     }
                 },
@@ -357,8 +353,6 @@ mod test {
 
         assert!(server_info.supports_feature(Extension::EightBitMime));
         assert!(!server_info.supports_feature(Extension::StartTls));
-        #[cfg(feature = "crammd5-auth")]
-        assert!(!server_info.supports_auth_mechanism(Mechanism::CramMd5));
 
         let response2 = Response::new(
             Code::new(
@@ -377,8 +371,6 @@ mod test {
         let mut features2 = HashSet::new();
         assert!(features2.insert(Extension::EightBitMime));
         assert!(features2.insert(Extension::Authentication(Mechanism::Plain),));
-        #[cfg(feature = "crammd5-auth")]
-        assert!(features2.insert(Extension::Authentication(Mechanism::CramMd5),));
 
         let server_info2 = ServerInfo {
             name: "me".to_string(),
@@ -389,8 +381,6 @@ mod test {
 
         assert!(server_info2.supports_feature(Extension::EightBitMime));
         assert!(server_info2.supports_auth_mechanism(Mechanism::Plain));
-        #[cfg(feature = "crammd5-auth")]
-        assert!(server_info2.supports_auth_mechanism(Mechanism::CramMd5));
         assert!(!server_info2.supports_feature(Extension::StartTls));
     }
 }

--- a/lettre/src/smtp/mod.rs
+++ b/lettre/src/smtp/mod.rs
@@ -8,8 +8,7 @@
 //! It implements the following extensions:
 //!
 //! * 8BITMIME ([RFC 6152](https://tools.ietf.org/html/rfc6152))
-//! * AUTH ([RFC 4954](http://tools.ietf.org/html/rfc4954)) with PLAIN, LOGIN and
-//! CRAM-MD5 mechanisms
+//! * AUTH ([RFC 4954](http://tools.ietf.org/html/rfc4954)) with PLAIN, LOGIN mechanisms
 //! * STARTTLS ([RFC 2487](http://tools.ietf.org/html/rfc2487))
 //! * SMTPUTF8 ([RFC 6531](http://tools.ietf.org/html/rfc6531))
 //!


### PR DESCRIPTION
It is obsolete and may give a false sense of security.
We may add a better mechanism later.