### PR TITLE
fix (transport): Sendmail transport: Fix to-list manipulation

### DIFF
--- a/lettre/src/sendmail/mod.rs
+++ b/lettre/src/sendmail/mod.rs
@@ -49,8 +49,8 @@ impl<'a> Transport<'a> for SendmailTransport {
                     Some(address) => address.to_string(),
                     None => "\"\"".to_string(),
                 },
-                &to_addresses.join(" "),
             ])
+            .args(&to_addresses)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
             .spawn()?;


### PR DESCRIPTION
Hi, this is a small fix that allows adding many recipients in the to-list for the Sendmail transport.