### PR TITLE
feat(transport-smtp): Upgrade to 0.2 version of native-tls crate

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -22,7 +22,7 @@ is-it-maintained-open-issues = { repository = "lettre/lettre" }
 log = "^0.4"
 nom = { version = "^3.2", optional = true }
 bufstream = { version = "^0.1", optional = true }
-native-tls = { version = "^0.1", optional = true }
+native-tls = { version = "^0.2", optional = true }
 base64 = { version = "^0.9", optional = true }
 hostname = { version = "^0.1", optional = true }
 serde = { version = "^1.0", optional = true }

--- a/lettre/src/smtp/mod.rs
+++ b/lettre/src/smtp/mod.rs
@@ -125,8 +125,8 @@ impl SmtpClient {
     /// Creates an encrypted transport over submissions port, using the provided domain
     /// to validate TLS certificates.
     pub fn new_simple(domain: &str) -> Result<SmtpClient, Error> {
-        let mut tls_builder = TlsConnector::builder()?;
-        tls_builder.supported_protocols(DEFAULT_TLS_PROTOCOLS)?;
+        let mut tls_builder = TlsConnector::builder();
+        tls_builder.min_protocol_version(Some(DEFAULT_TLS_PROTOCOLS[0]));
 
         let tls_parameters =
             ClientTlsParameters::new(domain.to_string(), tls_builder.build().unwrap());


### PR DESCRIPTION
Upgrades project to use 0.2 version of `native-tls` crate.

This allows use of [`danger_accept_invalid_hostnames()`](https://docs.rs/native-tls/0.2.0/native_tls/struct.TlsConnectorBuilder.html#method.danger_accept_invalid_hostnames) and [`danger_accept_invalid_certs()`](https://docs.rs/native-tls/0.2.0/native_tls/struct.TlsConnectorBuilder.html#method.danger_accept_invalid_certs) for `TlsConnectorBuilder`, which is convenient for testing purposes to not mess with self-signed CAs.