### PR TITLE
Mention SmtpClient::new_simple in the docs for SmtpClient::new

### DIFF
--- a/lettre/src/smtp/mod.rs
+++ b/lettre/src/smtp/mod.rs
@@ -103,6 +103,8 @@ impl SmtpClient {
     /// * No authentication
     /// * No SMTPUTF8 support
     /// * A 60 seconds timeout for smtp commands
+    /// 
+    /// Consider using [`SmtpClient::new_simple`] instead, if possible.
     pub fn new<A: ToSocketAddrs>(addr: A, security: ClientSecurity) -> Result<SmtpClient, Error> {
         let mut addresses = addr.to_socket_addrs()?;
 


### PR DESCRIPTION
For some reason `SmtpClient::new_simple` doesn't render as a link, while it should. [1] Do you have any idea why? 

[1] https://github.com/rust-lang/rfcs/blob/master/text/1946-intra-rustdoc-links.md#implied-shortcut-reference-links