### PR TITLE
docs(transport-smtp): Gmail transport simple example

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -47,3 +47,7 @@ sendmail-transport = []
 [[example]]
 name = "smtp"
 required-features = ["smtp-transport"]
+
+[[example]]
+name = "smtp_gmail"
+required-features = ["smtp-transport"]

--- a/lettre/examples/smtp_gmail.rs
+++ b/lettre/examples/smtp_gmail.rs
@@ -1,0 +1,38 @@
+extern crate lettre;
+
+use lettre::smtp::authentication::Credentials;
+use lettre::{EmailAddress, Envelope, SendableEmail, SmtpClient, Transport};
+
+fn main() {
+    let email = SendableEmail::new(
+        Envelope::new(
+            Some(EmailAddress::new("from@gmail.com".to_string()).unwrap()),
+            vec![EmailAddress::new("to@example.com".to_string()).unwrap()],
+        )
+        .unwrap(),
+        "id".to_string(),
+        "Hello example".to_string().into_bytes(),
+    );
+
+    let creds = Credentials::new(
+        "example_username".to_string(),
+        "example_password".to_string(),
+    );
+
+    // Open a remote connection to gmail
+    let mut mailer = SmtpClient::new_simple("smtp.gmail.com")
+        .unwrap()
+        .credentials(creds)
+        .transport();
+
+    // Send the email
+    let result = mailer.send(email);
+
+    if result.is_ok() {
+        println!("Email sent");
+    } else {
+        println!("Could not send email: {:?}", result);
+    }
+
+    assert!(result.is_ok());
+}

--- a/lettre_email/examples/smtp_gmail.rs
+++ b/lettre_email/examples/smtp_gmail.rs
@@ -1,0 +1,38 @@
+extern crate lettre;
+extern crate lettre_email;
+
+use lettre::smtp::authentication::Credentials;
+use lettre::{SmtpClient, Transport};
+use lettre_email::Email;
+
+fn main() {
+    let email = Email::builder()
+        .to("to@example.org")
+        .from("from@example.com")
+        .subject("subject")
+        .text("message")
+        .build()
+        .unwrap();
+
+    let creds = Credentials::new(
+        "example_username".to_string(),
+        "example_password".to_string(),
+    );
+
+    // Open connection to gmail
+    let mut mailer = SmtpClient::new_simple("smtp.gmail.com")
+        .unwrap()
+        .credentials(creds)
+        .transport();
+
+    // Send the email
+    let result = mailer.send(email.into());
+
+    if result.is_ok() {
+        println!("Email sent");
+    } else {
+        println!("Could not send email: {:?}", result);
+    }
+
+    assert!(result.is_ok());
+}


### PR DESCRIPTION
Adds 2 gmail examples, one for lettre and the other for lettre_email. 
* Closes #288 
* Closes #289.