### PR TITLE
Get 'from' from envelope

### DIFF
--- a/lettre_email/src/lib.rs
+++ b/lettre_email/src/lib.rs
@@ -430,6 +430,10 @@ impl EmailBuilder {
         if !self.from.is_empty() {
             self.message = self.message
                 .header(Header::new_with_value("From".into(), self.from).unwrap());
+        } else if let Some(from) = envelope.from() {
+            let from = vec![Address::new_mailbox(from.to_string())];
+            self.message = self.message
+                .header(Header::new_with_value("From".into(), from).unwrap());
         } else {
             Err(EmailError::Envelope {
                 error: LettreError::MissingFrom,

--- a/lettre_email/tests/build_with_envelope.rs
+++ b/lettre_email/tests/build_with_envelope.rs
@@ -1,0 +1,18 @@
+extern crate lettre_email;
+extern crate lettre;
+use lettre_email::EmailBuilder;
+use lettre::{EmailAddress, Envelope};
+
+#[test]
+fn build_with_envelope_test() {
+    let e = Envelope::new(
+        Some(EmailAddress::new("from@example.org".to_string()).unwrap()),
+        vec![EmailAddress::new("to@example.org".to_string()).unwrap()],
+    ).unwrap();
+    let _email = EmailBuilder::new()
+        .envelope(e)
+        .subject("subject")
+        .text("message")
+        .build()
+        .unwrap();
+}

--- a/lettre_email/tests/build_with_envelope.rs
+++ b/lettre_email/tests/build_with_envelope.rs
@@ -16,3 +16,17 @@ fn build_with_envelope_test() {
         .build()
         .unwrap();
 }
+
+#[test]
+fn build_with_envelope_without_from_test() {
+    let e = Envelope::new(
+        None,
+        vec![EmailAddress::new("to@example.org".to_string()).unwrap()],
+    ).unwrap();
+    let _email = EmailBuilder::new()
+        .envelope(e)
+        .subject("subject")
+        .text("message")
+        .build()
+        .unwrap_err();
+}


### PR DESCRIPTION
This would fix #318 by checking for a 'from' in envelope before returning MissingFrom. It also adds the found 'from' to the message headers. The latter might be undesired behavior; I'm not sure. If this is undesired, it is easy to fix.

Also added two test cases to show that 1) Building with 'from' only in the envelope works, and 2) Building without a 'from', either in the envelope or otherwise, still fails.