### PR TITLE
Using orginal email dependency

### DIFF
--- a/lettre_email/Cargo.toml
+++ b/lettre_email/Cargo.toml
@@ -23,7 +23,7 @@ lettre = { version = "^0.9", path = "../lettre", features = ["smtp-transport"] }
 glob = "0.2"
 
 [dependencies]
-email = { git = "https://github.com/lettre/rust-email" }
+email = "^0.0.20"
 mime = "^0.3"
 time = "^0.1"
 uuid = { version = "^0.7", features = ["v4"] }


### PR DESCRIPTION
Current version of email crate has changes from [PR42](https://github.com/niax/rust-email/pull/42) and [lettre/rust-email](https://github.com/lettre/rust-email) repository has older version of crate than in original repository