### PR TITLE
Use the original rust-email instead of the lettre fork

### DIFF
--- a/lettre_email/Cargo.toml
+++ b/lettre_email/Cargo.toml
@@ -23,7 +23,7 @@ lettre = { version = "^0.9", path = "../lettre", features = ["smtp-transport"] }
 glob = "0.2"
 
 [dependencies]
-email = { git = "https://github.com/lettre/rust-email" }
+email = { git = "https://github.com/niax/rust-email" }
 mime = "^0.3"
 time = "^0.1"
 uuid = { version = "^0.7", features = ["v4"] }


### PR DESCRIPTION
The fork is 10 commits behind the original repo, I don't see a point in
using it as the rest of the history is the same