### PR TITLE
lettre_email: add build_body

### DIFF
--- a/lettre_email/src/lib.rs
+++ b/lettre_email/src/lib.rs
@@ -354,6 +354,12 @@ impl EmailBuilder {
         self
     }
 
+    /// Only builds the body, this can be used to encrypt or sign
+    /// using S/MIME
+    pub fn build_body(self) -> Result<Vec<u8>, Error> {
+        Ok(self.message.build().as_string().into_bytes())
+    }
+
     /// Builds the Email
     pub fn build(mut self) -> Result<Email, Error> {
         // If there are multiple addresses in "From", the "Sender" is required.
@@ -586,6 +592,24 @@ mod test {
             )
         );
     }
+
+    #[test]
+    fn test_email_builder_body() {
+        let date_now = now();
+        let email_builder = EmailBuilder::new()
+            .text("TestTest")
+            .subject("A Subject")
+            .to("user@localhost")
+            .date(&date_now);
+
+        let body_res = email_builder.build_body();
+        assert_eq!(body_res.is_ok(), true);
+
+        let string_res = std::string::String::from_utf8(body_res.unwrap());
+        assert_eq!(string_res.is_ok(), true);
+        assert!(string_res.unwrap().starts_with("Subject: A Subject"));
+    }
+
 
     #[test]
     fn test_email_sendable() {


### PR DESCRIPTION
This adds a small method to extract the body before using it in i.e. `SendableEmail`.

Why?
------

This makes it possible to sign / encrypt the resulting `Vec<u8>` in another function using i.e. `openssl`.
The resulting S/MIME attachment can then be used as the actual message body.
Of course, in this use case you should omit the `Subject`, `To` etc.
An example how to build a body with a message and a single attachment is here:

```rust
 pub fn build_email_body(message: &str, payload_filename: &str, payload: &Vec<u8>) -> Result<Vec<u8>, std::string::String> {
        let mut email = EmailBuilder::new().text(message);
        email = match email.attachment(payload.as_ref(), payload_filename, &mime::TEXT_PLAIN) {
            Ok(em) => em,
            Err(_) => return Err("Could not attach payload.".to_owned())
        };

        match email.build_body() {
            Ok(v) => {
                Ok(v)
            },
            Err(_) => Err("Could not build email.".to_owned())
        }
    }
```