### PR TITLE
fix(email): Change as_ref() to as_str() to fix nightly bug

### DIFF
--- a/lettre_email/src/lib.rs
+++ b/lettre_email/src/lib.rs
@@ -127,7 +127,7 @@ impl PartBuilder {
 
     /// Adds a `ContentType` header with the given MIME type
     pub fn content_type(self, content_type: &Mime) -> PartBuilder {
-        self.header(("Content-Type", format!("{}", content_type).as_ref()))
+        self.header(("Content-Type", format!("{}", content_type).as_str()))
     }
 
     /// Adds a child part
@@ -299,7 +299,7 @@ impl EmailBuilder {
             .body(body)
             .header((
                 "Content-Type",
-                format!("{}", mime::TEXT_PLAIN_UTF_8).as_ref(),
+                format!("{}", mime::TEXT_PLAIN_UTF_8).as_str(),
             ))
             .build();
         self.child(text)
@@ -311,7 +311,7 @@ impl EmailBuilder {
             .body(body)
             .header((
                 "Content-Type",
-                format!("{}", mime::TEXT_HTML_UTF_8).as_ref(),
+                format!("{}", mime::TEXT_HTML_UTF_8).as_str(),
             ))
             .build();
         self.child(html)
@@ -327,7 +327,7 @@ impl EmailBuilder {
             .body(body_text)
             .header((
                 "Content-Type",
-                format!("{}", mime::TEXT_PLAIN_UTF_8).as_ref(),
+                format!("{}", mime::TEXT_PLAIN_UTF_8).as_str(),
             ))
             .build();
 
@@ -335,7 +335,7 @@ impl EmailBuilder {
             .body(body_html)
             .header((
                 "Content-Type",
-                format!("{}", mime::TEXT_HTML_UTF_8).as_ref(),
+                format!("{}", mime::TEXT_HTML_UTF_8).as_str(),
             ))
             .build();
 
@@ -375,7 +375,7 @@ impl EmailBuilder {
         }
         // Add the sender header, if any.
         if let Some(ref v) = self.sender {
-            self.message = self.message.header(("Sender", v.to_string().as_ref()));
+            self.message = self.message.header(("Sender", v.to_string().as_str()));
         }
         // Calculate the envelope
         let envelope = match self.envelope {
@@ -461,7 +461,7 @@ impl EmailBuilder {
         if !self.date_issued {
             self.message = self
                 .message
-                .header(("Date", Tm::rfc822z(&now()).to_string().as_ref()));
+                .header(("Date", Tm::rfc822z(&now()).to_string().as_str()));
         }
 
         self.message = self.message.header(("MIME-Version", "1.0"));


### PR DESCRIPTION
If you try to build `lettre` with the latest nightly (2019-05-18), you get the error illustrated below. This is probably not a bug in `lettre` but rather a bug in the latest Rust nightly. That said, changing all the `as_ref` calls to `as_str` calls in `lettre_email/src/lib.rs` (as this PR does) fixes the issue without really changing the intent of the `lettre` code.

Not sure this is worth incorporating, as, again, I suspect the problem is really with Rust nightly, not `lettre`. That being said, this little fix (changing to `as_str`) ensures `lettre` continues to work on nighty as of right now.

```
error[E0283]: type annotations required: cannot resolve `std::string::String: std::convert::AsRef<_>`
   --> lettre_email/src/lib.rs:130:66
    |
130 |         self.header(("Content-Type", format!("{}", content_type).as_ref()))
    |                                                                  ^^^^^^

error: aborting due to previous error

For more information about this error, try `rustc --explain E0283`.
error: Could not compile `lettre_email`.

To learn more, run the command again with --verbose.
```