### PR TITLE
fix(smtp) Allow forcing of a specific auth

### DIFF
--- a/lettre/src/smtp/extension.rs
+++ b/lettre/src/smtp/extension.rs
@@ -127,8 +127,6 @@ impl ServerInfo {
 
         let mut features: HashSet<Extension> = HashSet::new();
 
-        let mut supports_any_auth = false;
-
         for line in response.message.as_slice() {
             if line.is_empty() {
                 continue;
@@ -150,15 +148,12 @@ impl ServerInfo {
                         match mechanism {
                             "PLAIN" => {
                                 features.insert(Extension::Authentication(Mechanism::Plain));
-                                supports_any_auth = true;
                             }
                             "LOGIN" => {
                                 features.insert(Extension::Authentication(Mechanism::Login));
-                                supports_any_auth = true;
                             }
                             "XOAUTH2" => {
                                 features.insert(Extension::Authentication(Mechanism::Xoauth2));
-                                supports_any_auth = true;
                             }
                             _ => (),
                         }
@@ -166,11 +161,6 @@ impl ServerInfo {
                 }
                 _ => (),
             };
-        }
-
-        // If the server did not send any `AUTH` features, assume Plain is supported
-        if !supports_any_auth {
-            features.insert(Extension::Authentication(Mechanism::Plain));
         }
 
         Ok(ServerInfo {


### PR DESCRIPTION
Also mark Plain auth as accepted if the server
didn't specify any auth mechanisms to be supported.

fixes #357