### PR TITLE
style(all): use serde derive feature

### DIFF
--- a/lettre/Cargo.toml
+++ b/lettre/Cargo.toml
@@ -26,9 +26,8 @@ bufstream = { version = "^0.1", optional = true }
 native-tls = { version = "^0.2", optional = true }
 base64 = { version = "^0.11", optional = true }
 hostname = { version = "^0.2", optional = true }
-serde = { version = "^1.0", optional = true }
+serde = { version = "^1.0", optional = true, features = ["derive"] }
 serde_json = { version = "^1.0", optional = true }
-serde_derive = { version = "^1.0", optional = true }
 fast_chemail = "^0.9"
 r2d2 = { version = "^0.8", optional = true}
 
@@ -44,7 +43,7 @@ harness = false
 [features]
 default = ["file-transport", "smtp-transport", "sendmail-transport"]
 unstable = []
-serde-impls = ["serde", "serde_derive"]
+serde-impls = ["serde"]
 file-transport = ["serde-impls", "serde_json"]
 smtp-transport = ["bufstream", "native-tls", "base64", "nom", "hostname"]
 sendmail-transport = []

--- a/lettre/src/file/mod.rs
+++ b/lettre/src/file/mod.rs
@@ -18,7 +18,7 @@ pub mod error;
 #[derive(Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct FileTransport {
     path: PathBuf,
@@ -36,7 +36,7 @@ impl FileTransport {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 struct SerializableEmail {
     envelope: Envelope,

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -46,7 +46,7 @@ use std::str::FromStr;
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct EmailAddress(String);
 
@@ -91,7 +91,7 @@ impl AsRef<OsStr> for EmailAddress {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct Envelope {
     /// The envelope recipients' addresses

--- a/lettre/src/sendmail/mod.rs
+++ b/lettre/src/sendmail/mod.rs
@@ -16,7 +16,7 @@ pub mod error;
 #[derive(Debug, Default)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct SendmailTransport {
     command: String,

--- a/lettre/src/smtp/authentication.rs
+++ b/lettre/src/smtp/authentication.rs
@@ -33,7 +33,7 @@ impl<S: Into<String>, T: Into<String>> IntoCredentials for (S, T) {
 #[derive(PartialEq, Eq, Clone, Hash, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct Credentials {
     authentication_identity: String,
@@ -54,7 +54,7 @@ impl Credentials {
 #[derive(PartialEq, Eq, Copy, Clone, Hash, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum Mechanism {
     /// PLAIN authentication mechanism

--- a/lettre/src/smtp/client/mod.rs
+++ b/lettre/src/smtp/client/mod.rs
@@ -20,7 +20,7 @@ pub mod net;
 #[derive(Default, Clone, Copy, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct ClientCodec {
     escape_count: u8,

--- a/lettre/src/smtp/commands.rs
+++ b/lettre/src/smtp/commands.rs
@@ -15,7 +15,7 @@ use std::fmt::{self, Display, Formatter};
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct EhloCommand {
     client_id: ClientId,
@@ -38,7 +38,7 @@ impl EhloCommand {
 #[derive(PartialEq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct StarttlsCommand;
 
@@ -52,7 +52,7 @@ impl Display for StarttlsCommand {
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct MailCommand {
     sender: Option<EmailAddress>,
@@ -84,7 +84,7 @@ impl MailCommand {
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct RcptCommand {
     recipient: EmailAddress,
@@ -115,7 +115,7 @@ impl RcptCommand {
 #[derive(PartialEq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct DataCommand;
 
@@ -129,7 +129,7 @@ impl Display for DataCommand {
 #[derive(PartialEq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct QuitCommand;
 
@@ -143,7 +143,7 @@ impl Display for QuitCommand {
 #[derive(PartialEq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct NoopCommand;
 
@@ -157,7 +157,7 @@ impl Display for NoopCommand {
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct HelpCommand {
     argument: Option<String>,
@@ -184,7 +184,7 @@ impl HelpCommand {
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct VrfyCommand {
     argument: String,
@@ -208,7 +208,7 @@ impl VrfyCommand {
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct ExpnCommand {
     argument: String,
@@ -231,7 +231,7 @@ impl ExpnCommand {
 #[derive(PartialEq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct RsetCommand;
 
@@ -245,7 +245,7 @@ impl Display for RsetCommand {
 #[derive(PartialEq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct AuthCommand {
     mechanism: Mechanism,

--- a/lettre/src/smtp/extension.rs
+++ b/lettre/src/smtp/extension.rs
@@ -16,7 +16,7 @@ const DEFAULT_DOMAIN_CLIENT_ID: &str = "localhost";
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum ClientId {
     /// A fully-qualified domain name
@@ -59,7 +59,7 @@ impl ClientId {
 #[derive(PartialEq, Eq, Hash, Copy, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum Extension {
     /// 8BITMIME keyword
@@ -93,7 +93,7 @@ impl Display for Extension {
 #[derive(Clone, Debug, Eq, PartialEq)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct ServerInfo {
     /// Server name
@@ -189,7 +189,7 @@ impl ServerInfo {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum MailParameter {
     /// `BODY` parameter
@@ -229,7 +229,7 @@ impl Display for MailParameter {
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum MailBodyParameter {
     /// `7BIT`
@@ -251,7 +251,7 @@ impl Display for MailBodyParameter {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum RcptParameter {
     /// Custom parameter

--- a/lettre/src/smtp/mod.rs
+++ b/lettre/src/smtp/mod.rs
@@ -67,7 +67,7 @@ pub enum ClientSecurity {
 #[derive(Clone, Debug, Copy)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum ConnectionReuseParameters {
     /// Unlimited connection reuse

--- a/lettre/src/smtp/response.rs
+++ b/lettre/src/smtp/response.rs
@@ -19,7 +19,7 @@ use std::string::ToString;
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum Severity {
     /// 2yx
@@ -42,7 +42,7 @@ impl Display for Severity {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum Category {
     /// x0z
@@ -69,7 +69,7 @@ impl Display for Category {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum Detail {
     #[allow(missing_docs)]
@@ -104,7 +104,7 @@ impl Display for Detail {
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct Code {
     /// First digit of the response code
@@ -138,7 +138,7 @@ impl Code {
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct Response {
     /// Response code

--- a/lettre/src/smtp/util.rs
+++ b/lettre/src/smtp/util.rs
@@ -6,7 +6,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 #[derive(Debug)]
 #[cfg_attr(
     feature = "serde-impls",
-    derive(serde_derive::Serialize, serde_derive::Deserialize)
+    derive(serde::Serialize, serde::Deserialize)
 )]
 pub struct XText<'a>(pub &'a str);
 


### PR DESCRIPTION
The serde docs suggest using the `derive` feature instead of importing
`serde_derive` directly: https://serde.rs/derive.html