### PR TITLE
fix(all): accept `Into<SendableEmail>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ fn main() {
     // Open a local connection on port 25
     let mut mailer = SmtpClient::new_unencrypted_localhost().unwrap().transport();
     // Send the email
-    let result = mailer.send(email.into());
+    let result = mailer.send(email);
 
     if result.is_ok() {
         println!("Email sent");

--- a/lettre/src/file/mod.rs
+++ b/lettre/src/file/mod.rs
@@ -47,7 +47,9 @@ struct SerializableEmail {
 impl<'a> Transport<'a> for FileTransport {
     type Result = FileResult;
 
-    fn send(&mut self, email: SendableEmail) -> FileResult {
+    fn send<E: Into<SendableEmail>>(&mut self, email: E) -> FileResult {
+        let email = email.into();
+
         let message_id = email.message_id().to_string();
         let envelope = email.envelope().clone();
 

--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -192,5 +192,5 @@ pub trait Transport<'a> {
     type Result;
 
     /// Sends the email
-    fn send(&mut self, email: SendableEmail) -> Self::Result;
+    fn send<E: Into<SendableEmail>>(&mut self, email: E) -> Self::Result;
 }

--- a/lettre/src/sendmail/mod.rs
+++ b/lettre/src/sendmail/mod.rs
@@ -41,7 +41,9 @@ impl SendmailTransport {
 impl<'a> Transport<'a> for SendmailTransport {
     type Result = SendmailResult;
 
-    fn send(&mut self, email: SendableEmail) -> SendmailResult {
+    fn send<E: Into<SendableEmail>>(&mut self, email: E) -> SendmailResult {
+        let email = email.into();
+
         let message_id = email.message_id().to_string();
 
         // Spawn the sendmail command

--- a/lettre/src/smtp/mod.rs
+++ b/lettre/src/smtp/mod.rs
@@ -407,7 +407,9 @@ impl<'a> Transport<'a> for SmtpTransport {
         feature = "cargo-clippy",
         allow(clippy::match_same_arms, clippy::cyclomatic_complexity)
     )]
-    fn send(&mut self, email: SendableEmail) -> SmtpResult {
+    fn send<E: Into<SendableEmail>>(&mut self, email: E) -> SmtpResult {
+        let email = email.into();
+
         let message_id = email.message_id().to_string();
 
         if !self.client.is_connected() {

--- a/lettre/src/stub/mod.rs
+++ b/lettre/src/stub/mod.rs
@@ -30,7 +30,9 @@ pub type StubResult = Result<(), ()>;
 impl<'a> Transport<'a> for StubTransport {
     type Result = StubResult;
 
-    fn send(&mut self, email: SendableEmail) -> StubResult {
+    fn send<E: Into<SendableEmail>>(&mut self, email: E) -> StubResult {
+        let email = email.into();
+
         info!(
             "{}: from=<{}> to=<{:?}>",
             email.message_id(),

--- a/lettre_email/examples/local.rs
+++ b/lettre_email/examples/local.rs
@@ -22,7 +22,7 @@ fn main() {
     // Open a local connection on port 25
     let mut mailer = SmtpClient::new_unencrypted_localhost().unwrap().transport();
     // Send the email
-    let result = mailer.send(email.into());
+    let result = mailer.send(email);
 
     if result.is_ok() {
         println!("Email sent");


### PR DESCRIPTION
When sending a mail, accept not only `SendableEmail`, but also anything
that can be converted .into() a `SendableEmail`.

Fixes #362 