### PR TITLE
docs(transport-smtp): fix docs for `domain` field

### DIFF
--- a/lettre/src/smtp/client/net.rs
+++ b/lettre/src/smtp/client/net.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 pub struct ClientTlsParameters {
     /// A connector from `native-tls`
     pub connector: TlsConnector,
-    /// The domain to send during the TLS handshake
+    /// The domain name which is expected in the TLS certificate from the server
     pub domain: String,
 }
 


### PR DESCRIPTION
The `domain` field does not get “send to the server”, but is used to
check the authenticity of the server.

Fixes #363 