### PR TITLE
Box a large enum variant, minor code cleanup

### DIFF
--- a/lettre/src/lib.rs
+++ b/lettre/src/lib.rs
@@ -86,7 +86,7 @@ impl AsRef<str> for EmailAddress {
 
 impl AsRef<OsStr> for EmailAddress {
     fn as_ref(&self) -> &OsStr {
-        &self.0.as_ref()
+        self.0.as_ref()
     }
 }
 

--- a/lettre/src/smtp/client/mod.rs
+++ b/lettre/src/smtp/client/mod.rs
@@ -28,9 +28,7 @@ impl ClientCodec {
     pub fn new() -> Self {
         ClientCodec::default()
     }
-}
 
-impl ClientCodec {
     /// Adds transparency
     /// TODO: replace CR and LF by CRLF
     fn encode(&mut self, frame: &[u8], buf: &mut Vec<u8>) -> Result<(), Error> {

--- a/lettre/src/smtp/mod.rs
+++ b/lettre/src/smtp/mod.rs
@@ -470,7 +470,7 @@ impl<'a> Transport<'a> for SmtpTransport {
         // Message content
         let result = self.client.message(Box::new(email.message()));
 
-        if result.is_ok() {
+        if let Ok(ref result) = result {
             // Increment the connection reuse counter
             self.state.connection_reuse_count += 1;
 
@@ -480,9 +480,6 @@ impl<'a> Transport<'a> for SmtpTransport {
                 message_id,
                 self.state.connection_reuse_count,
                 result
-                    .as_ref()
-                    .ok()
-                    .unwrap()
                     .message
                     .iter()
                     .next()


### PR DESCRIPTION
Box a large enum variant, minor code cleanup

Also, why is `lettre` divided into two crates?