### PR TITLE
fix(all): rename remaining 'serde-impls' features gates to 'serde'

### DIFF
--- a/src/smtp/client/mod.rs
+++ b/src/smtp/client/mod.rs
@@ -8,7 +8,7 @@ use crate::smtp::error::{Error, SmtpResult};
 use crate::smtp::response::Response;
 use bufstream::BufStream;
 use log::debug;
-#[cfg(feature = "serde-impls")]
+#[cfg(feature = "serde")]
 use std::fmt::Debug;
 use std::fmt::Display;
 use std::io::{self, BufRead, BufReader, Read, Write};
@@ -21,7 +21,7 @@ pub mod net;
 
 /// The codec used for transparency
 #[derive(Default, Clone, Copy, Debug)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ClientCodec {
     escape_count: u8,
 }

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -73,7 +73,7 @@ pub enum ClientSecurity {
 
 /// Configures connection reuse behavior
 #[derive(Clone, Debug, Copy)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ConnectionReuseParameters {
     /// Unlimited connection reuse
     ReuseUnlimited,

--- a/src/smtp/response.rs
+++ b/src/smtp/response.rs
@@ -17,7 +17,7 @@ use std::string::ToString;
 
 /// First digit indicates severity
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Severity {
     /// 2yx
     PositiveCompletion = 2,
@@ -37,7 +37,7 @@ impl Display for Severity {
 
 /// Second digit
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Category {
     /// x0z
     Syntax = 0,
@@ -61,7 +61,7 @@ impl Display for Category {
 
 /// The detail digit of a response code (third digit)
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Detail {
     #[allow(missing_docs)]
     Zero = 0,
@@ -93,7 +93,7 @@ impl Display for Detail {
 
 /// Represents a 3 digit SMTP response code
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Code {
     /// First digit of the response code
     pub severity: Severity,
@@ -124,7 +124,7 @@ impl Code {
 ///
 /// The text message is optional, only the code is mandatory
 #[derive(PartialEq, Eq, Clone, Debug)]
-#[cfg_attr(feature = "serde-impls", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Response {
     /// Response code
     pub code: Code,


### PR DESCRIPTION
This renames the remaining 'serde-impls' features I forgot to change in aac3e00 to 'serde'