### PR TITLE
Fix WebPKIError(UnknownIssuer) when sending with rustls

### DIFF
--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -29,6 +29,8 @@ use native_tls::{Protocol, TlsConnector};
 use rustls::ClientConfig;
 use std::net::{SocketAddr, ToSocketAddrs};
 use std::time::Duration;
+#[cfg(feature = "rustls")]
+use webpki_roots::TLS_SERVER_ROOTS;
 
 pub mod authentication;
 pub mod client;
@@ -158,7 +160,12 @@ impl SmtpClient {
 
     #[cfg(feature = "rustls")]
     pub fn new_simple(domain: &str) -> Result<SmtpClient, Error> {
-        let tls_parameters = ClientTlsParameters::new(domain.to_string(), ClientConfig::new());
+        let mut tls = ClientConfig::new();
+        tls.config
+            .root_store
+            .add_server_trust_anchors(&TLS_SERVER_ROOTS);
+
+        let tls_parameters = ClientTlsParameters::new(domain.to_string(), tls);
 
         SmtpClient::new(
             (domain, SUBMISSIONS_PORT),


### PR DESCRIPTION
Sending would return `Err`:
```rust
    Io(Custom { kind: InvalidData, error: WebPKIError(UnknownIssuer) })
```