### PR TITLE
Replace textnonce with rand (reduce dependencies)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,11 +33,11 @@ nom = { version = "5", optional = true }
 once_cell = "1"
 quoted_printable = { version = "0.4", optional = true }
 r2d2 = { version = "0.8", optional = true }
+rand = { version = "0.7", optional = true, default-features = false }
 regex = "1"
 rustls = { version = "0.17", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
-textnonce = { version = "0.7", optional = true }
 uuid = { version = "0.8", features = ["v4"] }
 webpki = { version = "0.21", optional = true }
 webpki-roots = { version = "0.19", optional = true }
@@ -54,7 +54,7 @@ name = "transport_smtp"
 
 [features]
 async = ["async-std", "async-trait", "async-attributes"]
-builder = ["mime", "base64", "hyperx", "textnonce", "quoted_printable"]
+builder = ["mime", "base64", "hyperx", "rand", "quoted_printable"]
 default = ["file-transport", "smtp-transport", "rustls-tls", "hostname", "r2d2", "sendmail-transport", "builder"]
 file-transport = ["serde", "serde_json"]
 rustls-tls = ["webpki", "webpki-roots", "rustls"]


### PR DESCRIPTION
The textnonce dependency pulls in quite a few transitive dependencies.

```
├── textnonce v0.7.1
│   ├── base64 v0.12.3
│   ├── byteorder v1.3.4
│   ├── chrono v0.4.12
│   │   ├── num-integer v0.1.43
│   │   │   └── num-traits v0.2.12
│   │   │       [build-dependencies]
│   │   │       └── autocfg v1.0.0
│   │   │   [build-dependencies]
│   │   │   └── autocfg v1.0.0
│   │   ├── num-traits v0.2.12 (*)
│   │   └── time v0.1.43 (*)
│   ├── rand v0.7.3
│   │   ├── getrandom v0.1.14
│   │   │   ├── cfg-if v0.1.10
│   │   │   └── libc v0.2.71
│   │   ├── libc v0.2.71
│   │   ├── rand_chacha v0.2.2
│   │   │   ├── ppv-lite86 v0.2.8
│   │   │   └── rand_core v0.5.1
│   │   │       └── getrandom v0.1.14 (*)
│   │   └── rand_core v0.5.1 (*)
│   └── serde v1.0.114 (*)
```

However, we only use textnonce in a single location, to generate MIME boundaries. For this, we can use `rand` directly (which is already a transitive dependency anyways, since it's required by uuid).

This reduces the dependency count for a standard build from 117 to 105.

Here are some random boundaries generated:

```
boundary: gAYsFH7KRCgSW3uJkyKIiBJuJ4gUqZokJu8FIpbpo5UCwD7g8aGd8kwkgLsZ7aL5zddh
boundary: VciMYYXqgjNU0Fjo15k3BtedU2x5mQGtSbaLwkkge3BQFXacfRWuJAUwytpPpGkU25NN
boundary: OjfdZWSIE4VIrKKjjrwZE7T0tzVO8DvXCRVhhLfzSz5DN9LGVNVDAss3ODa0bmvFxyUX
boundary: oJZWQuwNlXyE17qRr093o6rTmZteHAsSvgyNqDjDWG9CgOnUGDS3zaAxnv3hRjPvJT1N
boundary: kcAQwffzeyhRt8kqNzmUdqCFCZ83PEUnOC3Eb9sNQIWooG5i0pvouzRJovNbO0AKUcxR
boundary: jdoGYfuuRsgqNgCStV9neilRUMTwbV4qdxMQGh2YXZhUhVwTRS3zZJsxLPUxOTJpKKiC
boundary: LA7cYFPdoTFIQ7o6EqF1GX1cHg0LBe1aX0d2vt4Sjr13rVHQpqociqOX911L7YmUpUNm
boundary: tT30iEnwLmXxiBPnFqiawFDnpZjRxTHz7WTZnyFQhv7UST47ayulZ0yFYKM6rtt4P0u1
boundary: 1dfvMbDqOPjsaqyjXzDVbpZWvckkjxHwC95DfhUVyVoWWeayZcTokJHPTzeYZGJNDvvw
boundary: rmgSfVv8Jw6eeozoUjKA9HUogdlYFFRnbkXQSEqW2oZnkg6ZE3RcAb1KUZJ2p06VCcDj
...
```