### PR TITLE
Use native-tls as the default tls backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ name = "transport_smtp"
 [features]
 async = ["async-std", "async-trait", "async-attributes"]
 builder = ["mime", "base64", "hyperx", "textnonce", "quoted_printable"]
-default = ["file-transport", "smtp-transport", "rustls-tls", "hostname", "r2d2", "sendmail-transport", "builder"]
+default = ["file-transport", "smtp-transport", "native-tls", "hostname", "r2d2", "sendmail-transport", "builder"]
 file-transport = ["serde", "serde_json"]
 rustls-tls = ["webpki", "webpki-roots", "rustls"]
 sendmail-transport = []


### PR DESCRIPTION
This had already been fixed in #377 but was changed back to rustls by https://github.com/lettre/lettre/commit/b3414bd1ff729684308d4935aae86ee7ee405577, probably by mistake?

This already created some confusion in https://github.com/rust-lang/crates.io/pull/2631 since users expect native-tls to be the default tls backend.