### PR TITLE
Replace unmaintained bufstream crate with std::io::BufReader

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ async-attributes = { version = "1.1", optional = true }
 async-std = { version = "1.5", optional = true, features = ["unstable"] }
 async-trait = { version = "0.1", optional = true }
 base64 = { version = "0.12", optional = true }
-bufstream = { version = "0.1", optional = true }
 hostname = { version = "0.3", optional = true }
 hyperx = { version = "1", optional = true, features = ["headers"] }
 idna = "0.2"
@@ -59,7 +58,7 @@ default = ["file-transport", "smtp-transport", "rustls-tls", "hostname", "r2d2",
 file-transport = ["serde", "serde_json"]
 rustls-tls = ["webpki", "webpki-roots", "rustls"]
 sendmail-transport = []
-smtp-transport = ["bufstream", "base64", "nom"]
+smtp-transport = ["base64", "nom"]
 unstable = []
 
 [[example]]


### PR DESCRIPTION
The `bufstream` crate is unmaintained and having a BufWriter didn't make sense anyway, since we are flushing it after each write.