### PR TITLE
Remove line-wrap crate and replace it with slice.chunks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,6 @@ bufstream = { version = "0.1", optional = true }
 hostname = { version = "0.3", optional = true }
 hyperx = { version = "1", optional = true, features = ["headers"] }
 idna = "0.2"
-line-wrap = "0.1"
 log = { version = "0.4", optional = true }
 mime = { version = "0.3", optional = true }
 native-tls = { version = "0.2", optional = true }


### PR DESCRIPTION
This replaces the `line-wrap` crate, which hasn't been updated in 2 years, with our own implementation.