### PR TITLE
Better document that SmtpTransport::builder shouldn't be used

### DIFF
--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -12,7 +12,7 @@ mod test {
             .subject("Happy new year")
             .body("Be happy!")
             .unwrap();
-        SmtpTransport::builder("127.0.0.1")
+        SmtpTransport::builder_dangerous("127.0.0.1")
             .port(2525)
             .build()
             .send(&email)

--- a/tests/transport_smtp_pool.rs
+++ b/tests/transport_smtp_pool.rs
@@ -15,7 +15,7 @@ mod test {
     #[test]
     fn send_one() {
         let pool = Pool::builder().max_size(1);
-        let mailer = SmtpTransport::builder("127.0.0.1")
+        let mailer = SmtpTransport::builder_dangerous("127.0.0.1")
             .port(2525)
             .build_with_pool(pool);
 
@@ -27,7 +27,7 @@ mod test {
     fn send_from_thread() {
         let pool = Pool::builder().max_size(1);
 
-        let mailer = SmtpTransport::builder("127.0.0.1")
+        let mailer = SmtpTransport::builder_dangerous("127.0.0.1")
             .port(2525)
             .build_with_pool(pool);
 


### PR DESCRIPTION
Looking back at the mistake I originally made in https://github.com/lettre/lettre/pull/437#discussion_r460503340, issue #431 that lead to this mistake in https://github.com/rust-lang/crates.io/pull/2631#discussion_r460506335, I think we should better clarify that `SmtpTransport::builder` shouldn't be used.

#428 should also benefit from this?