### PR TITLE
refactor: TlsParameters to not expose the inner tls library

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ smtp-transport = ["base64", "nom"]
 unstable = []
 
 [package.metadata.docs.rs]
-features = ["async-std1", "tokio02"]
+all-features = true
 
 [[example]]
 name = "smtp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,12 +48,10 @@ pub use crate::message::{
 pub use crate::transport::file::FileTransport;
 #[cfg(feature = "sendmail-transport")]
 pub use crate::transport::sendmail::SendmailTransport;
-#[cfg(feature = "smtp-transport")]
-pub use crate::transport::smtp::client::TlsParameters;
 #[cfg(all(feature = "smtp-transport", feature = "connection-pool"))]
 pub use crate::transport::smtp::r2d2::SmtpConnectionManager;
 #[cfg(feature = "smtp-transport")]
-pub use crate::transport::smtp::{client::Tls, SmtpTransport};
+pub use crate::transport::smtp::SmtpTransport;
 pub use crate::{address::Address, transport::stub::StubTransport};
 #[cfg(any(feature = "async-std1", feature = "tokio02"))]
 use async_trait::async_trait;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,11 @@ pub use crate::transport::file::FileTransport;
 #[cfg(feature = "sendmail-transport")]
 pub use crate::transport::sendmail::SendmailTransport;
 #[cfg(feature = "smtp-transport")]
-pub use crate::transport::smtp::client::net::TlsParameters;
+pub use crate::transport::smtp::client::TlsParameters;
 #[cfg(all(feature = "smtp-transport", feature = "connection-pool"))]
 pub use crate::transport::smtp::r2d2::SmtpConnectionManager;
 #[cfg(feature = "smtp-transport")]
-pub use crate::transport::smtp::{SmtpTransport, Tls};
+pub use crate::transport::smtp::{client::Tls, SmtpTransport};
 pub use crate::{address::Address, transport::stub::StubTransport};
 #[cfg(any(feature = "async-std1", feature = "tokio02"))]
 use async_trait::async_trait;

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -1,18 +1,5 @@
 //! SMTP client
 
-use crate::{
-    transport::smtp::{
-        authentication::{Credentials, Mechanism},
-        client::net::{NetworkStream, TlsParameters},
-        commands::*,
-        error::Error,
-        extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},
-        response::{parse_response, Response},
-    },
-    Envelope,
-};
-#[cfg(feature = "log")]
-use log::debug;
 #[cfg(feature = "serde")]
 use std::fmt::Debug;
 use std::{
@@ -23,8 +10,29 @@ use std::{
     time::Duration,
 };
 
-pub mod mock;
-pub mod net;
+#[cfg(feature = "log")]
+use log::debug;
+
+use crate::{
+    transport::smtp::{
+        authentication::{Credentials, Mechanism},
+        client::net::NetworkStream,
+        commands::*,
+        error::Error,
+        extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},
+        response::{parse_response, Response},
+    },
+    Envelope,
+};
+
+pub use self::mock::MockStream;
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+pub(super) use self::tls::InnerTlsParameters;
+pub use self::tls::{Tls, TlsParameters};
+
+mod mock;
+mod net;
+mod tls;
 
 /// The codec used for transparency
 #[derive(Default, Clone, Copy, Debug)]

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -1,0 +1,89 @@
+#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+use crate::transport::smtp::error::Error;
+
+#[cfg(feature = "native-tls")]
+use native_tls::{Protocol, TlsConnector};
+#[cfg(feature = "rustls-tls")]
+use rustls::ClientConfig;
+
+/// Accepted protocols by default.
+/// This removes TLS 1.0 and 1.1 compared to tls-native defaults.
+// This is also rustls' default behavior
+#[cfg(feature = "native-tls")]
+const DEFAULT_TLS_MIN_PROTOCOL: Protocol = Protocol::Tlsv12;
+
+/// How to apply TLS to a client connection
+#[derive(Clone)]
+#[allow(missing_copy_implementations)]
+pub enum Tls {
+    /// Insecure connection only (for testing purposes)
+    None,
+    /// Start with insecure connection and use `STARTTLS` when available
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    Opportunistic(TlsParameters),
+    /// Start with insecure connection and require `STARTTLS`
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    Required(TlsParameters),
+    /// Use TLS wrapped connection
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    Wrapper(TlsParameters),
+}
+
+/// Parameters to use for secure clients
+#[derive(Clone)]
+#[allow(missing_debug_implementations)]
+pub struct TlsParameters {
+    pub(crate) connector: InnerTlsParameters,
+    /// The domain name which is expected in the TLS certificate from the server
+    domain: String,
+}
+
+#[derive(Clone)]
+pub enum InnerTlsParameters {
+    #[cfg(feature = "native-tls")]
+    NativeTls(TlsConnector),
+    #[cfg(feature = "rustls-tls")]
+    RustlsTls(ClientConfig),
+}
+
+impl TlsParameters {
+    /// Creates a new `TlsParameters` using native-tls or rustls
+    /// depending on which one is available
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    pub fn new(domain: String) -> Result<Self, Error> {
+        #[cfg(feature = "native-tls")]
+        return Self::new_native(domain);
+
+        #[cfg(not(feature = "native-tls"))]
+        return Self::new_rustls(domain);
+    }
+
+    /// Creates a new `TlsParameters` using native-tls
+    #[cfg(feature = "native-tls")]
+    pub fn new_native(domain: String) -> Result<Self, Error> {
+        let mut tls_builder = TlsConnector::builder();
+        tls_builder.min_protocol_version(Some(DEFAULT_TLS_MIN_PROTOCOL));
+        let connector = tls_builder.build()?;
+        Ok(Self {
+            connector: InnerTlsParameters::NativeTls(connector),
+            domain,
+        })
+    }
+
+    /// Creates a new `TlsParameters` using rustls
+    #[cfg(feature = "rustls-tls")]
+    pub fn new_rustls(domain: String) -> Result<Self, Error> {
+        use webpki_roots::TLS_SERVER_ROOTS;
+
+        let mut tls = ClientConfig::new();
+        tls.root_store.add_server_trust_anchors(&TLS_SERVER_ROOTS);
+        Ok(Self {
+            connector: InnerTlsParameters::RustlsTls(tls),
+            domain,
+        })
+    }
+
+    pub fn domain(&self) -> &str {
+        &self.domain
+    }
+}


### PR DESCRIPTION
...as discussed in #443. There are probably other places where we expose them, but that will be for another PR.

Fixes #428

Also made it compile with both TLS libraries enabled.