### PR TITLE
fix(transport-smtp): Use 127.0.0.1 literal as EHLO parameter when we have no hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,7 +33,7 @@ Several breaking changes were made between 0.9 and 0.10, but changes should be s
 * Merge `Email` and `SendableEmail` into `lettre::Email` ([ce37464](https://github.com/lettre/lettre/commit/ce37464))
 * When the hostname feature is disabled or hostname cannot be fetched, `127.0.0.1` is used instead of `localhost` as
   EHLO parameter (for better RFC compliance and mail server compatibility)
-* The `new` method of `ClientId` is renamed to `new_domain`
+* The `new` method of `ClientId` is deprecated
 
 #### Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Several breaking changes were made between 0.9 and 0.10, but changes should be s
 * Change website url schemes to https ([6014f5c](https://github.com/lettre/lettre/commit/6014f5c))
 * Use serde's `derive` feature instead of the `serde_derive` crate ([4fbe700](https://github.com/lettre/lettre/commit/4fbe700))
 * Merge `Email` and `SendableEmail` into `lettre::Email` ([ce37464](https://github.com/lettre/lettre/commit/ce37464))
+* When the hostname feature is disabled or hostname cannot be fetched, `127.0.0.1` is used instead of `localhost` as
+  EHLO parameter (for better RFC compliance and mail server compatibility)
+* The `new` method of `ClientId` is renamed to `new_domain`
 
 #### Bug Fixes
 

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -1,5 +1,4 @@
-use std::fmt::Display;
-use std::io;
+use std::{fmt::Display, io};
 
 use futures_util::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 
@@ -7,14 +6,16 @@ use futures_util::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use log::debug;
 
 use super::{AsyncNetworkStream, ClientCodec, TlsParameters};
-use crate::transport::smtp::authentication::{Credentials, Mechanism};
-use crate::transport::smtp::commands::*;
-use crate::transport::smtp::error::Error;
-use crate::transport::smtp::extension::{
-    ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo,
+use crate::{
+    transport::smtp::{
+        authentication::{Credentials, Mechanism},
+        commands::*,
+        error::Error,
+        extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},
+        response::{parse_response, Response},
+    },
+    Envelope,
 };
-use crate::transport::smtp::response::{parse_response, Response};
-use crate::Envelope;
 
 #[cfg(feature = "log")]
 use super::escape_crlf;
@@ -144,11 +145,7 @@ impl AsyncSmtpConnection {
 
     /// Send EHLO and update server info
     async fn ehlo(&mut self, hello_name: &ClientId) -> Result<(), Error> {
-        let ehlo_response = try_smtp!(
-            self.command(Ehlo::new(ClientId::new(hello_name.to_string())))
-                .await,
-            self
-        );
+        let ehlo_response = try_smtp!(self.command(Ehlo::new(hello_name.clone())).await, self);
         self.server_info = try_smtp!(ServerInfo::from_response(&ehlo_response), self);
         Ok(())
     }

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -1,20 +1,24 @@
-use std::fmt::Display;
-use std::io::{self, BufRead, BufReader, Write};
-use std::net::ToSocketAddrs;
-use std::time::Duration;
+use std::{
+    fmt::Display,
+    io::{self, BufRead, BufReader, Write},
+    net::ToSocketAddrs,
+    time::Duration,
+};
 
 #[cfg(feature = "log")]
 use log::debug;
 
 use super::{ClientCodec, NetworkStream, TlsParameters};
-use crate::transport::smtp::authentication::{Credentials, Mechanism};
-use crate::transport::smtp::commands::*;
-use crate::transport::smtp::error::Error;
-use crate::transport::smtp::extension::{
-    ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo,
+use crate::{
+    transport::smtp::{
+        authentication::{Credentials, Mechanism},
+        commands::*,
+        error::Error,
+        extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},
+        response::{parse_response, Response},
+    },
+    Envelope,
 };
-use crate::transport::smtp::response::{parse_response, Response};
-use crate::Envelope;
 
 #[cfg(feature = "log")]
 use super::escape_crlf;
@@ -138,10 +142,7 @@ impl SmtpConnection {
 
     /// Send EHLO and update server info
     fn ehlo(&mut self, hello_name: &ClientId) -> Result<(), Error> {
-        let ehlo_response = try_smtp!(
-            self.command(Ehlo::new(ClientId::new(hello_name.to_string()))),
-            self
-        );
+        let ehlo_response = try_smtp!(self.command(Ehlo::new(hello_name.clone())), self);
         self.server_info = try_smtp!(ServerInfo::from_response(&ehlo_response), self);
         Ok(())
     }

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -7,12 +7,14 @@ use std::fmt::Debug;
 pub(crate) use self::async_connection::AsyncSmtpConnection;
 #[cfg(feature = "tokio02")]
 pub(crate) use self::async_net::AsyncNetworkStream;
-pub use self::connection::SmtpConnection;
-pub use self::mock::MockStream;
 use self::net::NetworkStream;
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 pub(super) use self::tls::InnerTlsParameters;
-pub use self::tls::{Tls, TlsParameters};
+pub use self::{
+    connection::SmtpConnection,
+    mock::MockStream,
+    tls::{Tls, TlsParameters},
+};
 
 #[cfg(feature = "tokio02")]
 mod async_connection;

--- a/src/transport/smtp/client/net.rs
+++ b/src/transport/smtp/client/net.rs
@@ -1,8 +1,10 @@
-use std::io::{self, Read, Write};
-use std::net::{Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4, TcpStream, ToSocketAddrs};
 #[cfg(feature = "rustls-tls")]
 use std::sync::Arc;
-use std::time::Duration;
+use std::{
+    io::{self, Read, Write},
+    net::{Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4, TcpStream, ToSocketAddrs},
+    time::Duration,
+};
 
 #[cfg(feature = "native-tls")]
 use native_tls::TlsStream;

--- a/src/transport/smtp/extension.rs
+++ b/src/transport/smtp/extension.rs
@@ -57,6 +57,12 @@ impl Display for ClientId {
 }
 
 impl ClientId {
+    #[deprecated(since = "0.10.0", note = "Please use the new_domain function instead")]
+    /// Creates a new `ClientId` from a fully qualified domain name
+    pub fn new(domain: String) -> Self {
+        Self::Domain(domain)
+    }
+
     /// Creates a new `ClientId` from a fully qualified domain name
     pub fn new_domain(domain: String) -> Self {
         Self::Domain(domain)

--- a/src/transport/smtp/extension.rs
+++ b/src/transport/smtp/extension.rs
@@ -13,6 +13,7 @@ use std::{
 /// Client identifier, the parameter to `EHLO`
 #[derive(PartialEq, Eq, Clone, Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[non_exhaustive]
 pub enum ClientId {
     /// A fully-qualified domain name
     Domain(String),
@@ -57,14 +58,9 @@ impl Display for ClientId {
 }
 
 impl ClientId {
-    #[deprecated(since = "0.10.0", note = "Please use the new_domain function instead")]
+    #[deprecated(since = "0.10.0", note = "Please use ClientId::Domain(domain) instead")]
     /// Creates a new `ClientId` from a fully qualified domain name
     pub fn new(domain: String) -> Self {
-        Self::Domain(domain)
-    }
-
-    /// Creates a new `ClientId` from a fully qualified domain name
-    pub fn new_domain(domain: String) -> Self {
         Self::Domain(domain)
     }
 }
@@ -296,7 +292,7 @@ mod test {
     #[test]
     fn test_clientid_fmt() {
         assert_eq!(
-            format!("{}", ClientId::new_domain("test".to_string())),
+            format!("{}", ClientId::Domain("test".to_string())),
             "test".to_string()
         );
         assert_eq!(format!("{}", LOCALHOST_CLIENT), "[127.0.0.1]".to_string());

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -162,7 +162,7 @@
 //! # {
 //! use lettre::transport::smtp::{SMTP_PORT, extension::ClientId, commands::*, client::SmtpConnection};
 //!
-//! let hello = ClientId::new("my_hostname".to_string());
+//! let hello = ClientId::new_domain("my_hostname".to_string());
 //! let mut client = SmtpConnection::connect(&("localhost", SMTP_PORT), None, &hello, None).unwrap();
 //! client.command(
 //!         Mail::new(Some("user@example.com".parse().unwrap()), vec![])
@@ -249,7 +249,7 @@ impl Default for SmtpInfo {
         Self {
             server: "localhost".to_string(),
             port: SMTP_PORT,
-            hello_name: ClientId::hostname(),
+            hello_name: ClientId::default(),
             credentials: None,
             authentication: DEFAULT_MECHANISMS.into(),
             timeout: Some(DEFAULT_TIMEOUT),

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -162,7 +162,7 @@
 //! # {
 //! use lettre::transport::smtp::{SMTP_PORT, extension::ClientId, commands::*, client::SmtpConnection};
 //!
-//! let hello = ClientId::new_domain("my_hostname".to_string());
+//! let hello = ClientId::Domain("my_hostname".to_string());
 //! let mut client = SmtpConnection::connect(&("localhost", SMTP_PORT), None, &hello, None).unwrap();
 //! client.command(
 //!         Mail::new(Some("user@example.com".parse().unwrap()), vec![])


### PR DESCRIPTION
Also fix formatting of address literals

Comes from https://github.com/async-email/async-smtp/commit/2275fd8d13e39b2c58d6605c786ff06ff9e05708
with a different approach for default value.