### PR TITLE
refactor: optimize parts of the code

### DIFF
--- a/src/message/encoder.rs
+++ b/src/message/encoder.rs
@@ -23,11 +23,9 @@ impl SevenBitCodec {
 
 impl EncoderCodec for SevenBitCodec {
     fn encode(&mut self, input: &[u8]) -> Vec<u8> {
-        if input.iter().all(u8::is_ascii) {
-            self.line_wrapper.encode(input)
-        } else {
-            panic!("")
-        }
+        assert!(input.is_ascii(), "input must be valid ascii");
+
+        self.line_wrapper.encode(input)
     }
 }
 
@@ -126,16 +124,13 @@ impl EncoderCodec for BinaryCodec {
 
 pub fn codec(encoding: Option<&ContentTransferEncoding>) -> Box<dyn EncoderCodec> {
     use self::ContentTransferEncoding::*;
-    if let Some(encoding) = encoding {
-        match encoding {
-            SevenBit => Box::new(SevenBitCodec::new()),
-            QuotedPrintable => Box::new(QuotedPrintableCodec::new()),
-            Base64 => Box::new(Base64Codec::new()),
-            EightBit => Box::new(EightBitCodec::new()),
-            Binary => Box::new(BinaryCodec::new()),
-        }
-    } else {
-        Box::new(BinaryCodec::new())
+
+    match encoding {
+        Some(SevenBit) => Box::new(SevenBitCodec::new()),
+        Some(QuotedPrintable) => Box::new(QuotedPrintableCodec::new()),
+        Some(Base64) => Box::new(Base64Codec::new()),
+        Some(EightBit) => Box::new(EightBitCodec::new()),
+        Some(Binary) | None => Box::new(BinaryCodec::new()),
     }
 }
 

--- a/src/message/utf8_b.rs
+++ b/src/message/utf8_b.rs
@@ -1,5 +1,3 @@
-use std::str::from_utf8;
-
 // https://tools.ietf.org/html/rfc1522
 
 fn allowed_char(c: char) -> bool {
@@ -18,13 +16,16 @@ pub fn encode(s: &str) -> String {
 }
 
 pub fn decode(s: &str) -> Option<String> {
+    const PREFIX: &str = "=?utf-8?b?";
+    const SUFFIX: &str = "?=";
+
     let s = s.trim();
-    if s.starts_with("=?utf-8?b?") && s.ends_with("?=") {
-        let s = s.split_at(10).1;
-        let s = s.split_at(s.len() - 2).0;
+    if s.starts_with(PREFIX) && s.ends_with(SUFFIX) {
+        let s = &s[PREFIX.len()..];
+        let s = &s[..s.len() - SUFFIX.len()];
         base64::decode(s)
             .ok()
-            .and_then(|v| from_utf8(&v).ok().map(|s| s.into()))
+            .and_then(|v| String::from_utf8(v).ok())
     } else {
         Some(s.into())
     }

--- a/src/transport/smtp/commands.rs
+++ b/src/transport/smtp/commands.rs
@@ -222,10 +222,7 @@ pub struct Auth {
 
 impl Display for Auth {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        let encoded_response = self
-            .response
-            .as_ref()
-            .map(|r| base64::encode_config(r.as_bytes(), base64::STANDARD));
+        let encoded_response = self.response.as_ref().map(base64::encode);
 
         if self.mechanism.supports_initial_response() {
             write!(f, "AUTH {} {}", self.mechanism, encoded_response.unwrap())?;


### PR DESCRIPTION
Uses the much faster `slice::is_ascii` implementation and avoids copying `v` in `utf8_b.rs`