### PR TITLE
ci: skip async-std build on 1.40.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
           args: --no-default-features --features=builder,smtp-transport,file-transport,sendmail-transport
       - run: rm target/debug/deps/liblettre-*
       - uses: actions-rs/cargo@v1
+        if: matrix.rust != '1.40.0'
         with:
           command: test
           args: --features=async-std1


### PR DESCRIPTION
async-mutex 1.3.0 broke our MSRV