### PR TITLE
Improve docs for SmtpTransport methods and remove SmtpClient from the public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! * **hostname**: Ability to try to use actual hostname in SMTP transaction
 
 #![doc(html_root_url = "https://docs.rs/lettre/0.10.0")]
-#![doc(html_favicon_url = "https://lettre.at/favicon.png")]
+#![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![deny(
     missing_copy_implementations,

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -180,10 +180,10 @@ use std::time::Duration;
 
 #[cfg(feature = "tokio02")]
 pub use self::async_transport::{
-    AsyncSmtpClient, AsyncSmtpConnector, AsyncSmtpTransport, AsyncSmtpTransportBuilder,
-    Tokio02Connector,
+    AsyncSmtpConnector, AsyncSmtpTransport, AsyncSmtpTransportBuilder, Tokio02Connector,
 };
-pub use self::transport::{SmtpClient, SmtpTransport, SmtpTransportBuilder};
+pub(crate) use self::transport::SmtpClient;
+pub use self::transport::{SmtpTransport, SmtpTransportBuilder};
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 use crate::transport::smtp::client::TlsParameters;
 use crate::transport::smtp::{

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
 #[cfg(feature = "r2d2")]
-use r2d2::{Builder, Pool};
+use r2d2::Pool;
 
 use super::{ClientId, Credentials, Error, Mechanism, Response, SmtpConnection, SmtpInfo};
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
@@ -148,13 +148,6 @@ impl SmtpTransportBuilder {
     /// Build the client
     fn build_client(self) -> SmtpClient {
         SmtpClient { info: self.info }
-    }
-
-    /// Build the transport with custom pool settings
-    #[cfg(feature = "r2d2")]
-    pub fn build_with_pool(self, pool: Builder<SmtpClient>) -> SmtpTransport {
-        let pool = pool.build_unchecked(self.build_client());
-        SmtpTransport { inner: pool }
     }
 
     /// Build the transport

--- a/tests/transport_smtp_pool.rs
+++ b/tests/transport_smtp_pool.rs
@@ -1,7 +1,6 @@
 #[cfg(all(test, feature = "smtp-transport", feature = "r2d2"))]
 mod test {
     use lettre::{Envelope, SmtpTransport, Transport};
-    use r2d2::Pool;
     use std::{sync::mpsc, thread};
 
     fn envelope() -> Envelope {
@@ -14,10 +13,9 @@ mod test {
 
     #[test]
     fn send_one() {
-        let pool = Pool::builder().max_size(1);
         let mailer = SmtpTransport::builder_dangerous("127.0.0.1")
             .port(2525)
-            .build_with_pool(pool);
+            .build();
 
         let result = mailer.send_raw(&envelope(), b"test");
         assert!(result.is_ok());
@@ -25,11 +23,9 @@ mod test {
 
     #[test]
     fn send_from_thread() {
-        let pool = Pool::builder().max_size(1);
-
         let mailer = SmtpTransport::builder_dangerous("127.0.0.1")
             .port(2525)
-            .build_with_pool(pool);
+            .build();
 
         let (s1, r1) = mpsc::channel();
         let (s2, r2) = mpsc::channel();


### PR DESCRIPTION
I believe after this and #461 get merged we should be ready to release alpha 2. Or maybe even call it beta 1.