### PR TITLE
pool: use better defaults

### DIFF
--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -145,7 +145,14 @@ impl SmtpTransportBuilder {
         SmtpTransport { inner: pool }
     }
 
-    /// Build the transport (with default pool if enabled)
+    /// Build the transport
+    ///
+    /// If the `r2d2` feature is enabled an `Arc` wrapped pool is be created.
+    /// Defaults:
+    ///
+    /// * 60 seconds idle timeout
+    /// * 30 minutes max connection lifetime
+    /// * max pool size of 10 connections
     pub fn build(self) -> SmtpTransport {
         let client = self.build_client();
         SmtpTransport {

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -150,7 +150,10 @@ impl SmtpTransportBuilder {
         let client = self.build_client();
         SmtpTransport {
             #[cfg(feature = "r2d2")]
-            inner: Pool::builder().max_size(5).build_unchecked(client),
+            inner: Pool::builder()
+                .min_idle(Some(0))
+                .idle_timeout(Some(Duration::from_secs(60)))
+                .build_unchecked(client),
             #[cfg(not(feature = "r2d2"))]
             inner: client,
         }


### PR DESCRIPTION
* increases the max_size to r2d2' default of 10
* decreases the min_idle number of connections to 0 (was equal to max_size before)
* decreases the idle timeout from 10 minutes to 1 minute