### PR TITLE
Add Content-ID header for inline attachments

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ pub mod error;
 pub mod message;
 pub mod transport;
 
+#[macro_use]
+extern crate hyperx;
+
 use crate::error::Error;
 #[cfg(feature = "builder")]
 pub use crate::message::{

--- a/src/message/header/content.rs
+++ b/src/message/header/content.rs
@@ -7,6 +7,8 @@ use std::{
     str::{from_utf8, FromStr},
 };
 
+header! { (ContentId, "Content-ID") => [String] }
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ContentTransferEncoding {
     SevenBit,


### PR DESCRIPTION
This PR adds a new header that was handled in the previous version.

When you want to send an image as an inline content, you need to set the Content-ID header so it can be used as a reference in the HTML part. This header was missing.

Example:
```
html_part.singlepart(
    SinglePart::base64()
        .header(header::ContentType("image/png"))
        .header(header::ContentDisposition {
            disposition: header::DispositionType::Inline,
            parameters: vec![],
        })
        .header(header::ContentId("<image.png>"))
        .body(data),
)
```