### PR TITLE
Allow configuring a custom root certificate in TlsParametersBuilder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,6 +104,10 @@ name = "smtp_starttls"
 required-features = ["smtp-transport", "native-tls"]
 
 [[example]]
+name = "smtp_selfsigned"
+required-features = ["smtp-transport", "native-tls"]
+
+[[example]]
 name = "tokio02_smtp_tls"
 required-features = ["smtp-transport", "tokio02", "tokio02-native-tls"]
 

--- a/examples/smtp_selfsigned.rs
+++ b/examples/smtp_selfsigned.rs
@@ -1,0 +1,40 @@
+use std::fs;
+
+use lettre::{
+    transport::smtp::authentication::Credentials,
+    transport::smtp::client::{Certificate, Tls, TlsParameters},
+    Message, SmtpTransport, Transport,
+};
+
+fn main() {
+    tracing_subscriber::fmt::init();
+
+    let email = Message::builder()
+        .from("NoBody <nobody@domain.tld>".parse().unwrap())
+        .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
+        .to("Hei <hei@domain.tld>".parse().unwrap())
+        .subject("Happy new year")
+        .body("Be happy!")
+        .unwrap();
+
+    let pem_cert = fs::read("certificate.pem").unwrap();
+    let cert = Certificate::from_pem(&pem_cert).unwrap();
+    let mut tls = TlsParameters::builder("smtp.server.com".into());
+    tls.add_root_certificate(cert);
+    let tls = tls.build().unwrap();
+
+    let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
+
+    // Open a remote connection to gmail
+    let mailer = SmtpTransport::builder_dangerous("smtp.server.com")
+        .port(465)
+        .tls(Tls::Wrapper(tls))
+        .credentials(creds)
+        .build();
+
+    // Send the email
+    match mailer.send(&email) {
+        Ok(_) => println!("Email sent successfully!"),
+        Err(e) => panic!("Could not send email: {:?}", e),
+    }
+}

--- a/examples/smtp_selfsigned.rs
+++ b/examples/smtp_selfsigned.rs
@@ -17,15 +17,16 @@ fn main() {
         .body("Be happy!")
         .unwrap();
 
+    // Use a custom certificate stored on disk to securely verify the server's certificate
     let pem_cert = fs::read("certificate.pem").unwrap();
     let cert = Certificate::from_pem(&pem_cert).unwrap();
-    let mut tls = TlsParameters::builder("smtp.server.com".into());
+    let mut tls = TlsParameters::builder("smtp.server.com".to_string());
     tls.add_root_certificate(cert);
     let tls = tls.build().unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
-    // Open a remote connection to gmail
+    // Open a remote connection to the smtp server
     let mailer = SmtpTransport::builder_dangerous("smtp.server.com")
         .port(465)
         .tls(Tls::Wrapper(tls))

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -34,7 +34,7 @@ pub(super) use self::tls::InnerTlsParameters;
 pub use self::{
     connection::SmtpConnection,
     mock::MockStream,
-    tls::{Tls, TlsParameters, TlsParametersBuilder},
+    tls::{Certificate, Tls, TlsParameters, TlsParametersBuilder},
 };
 
 #[cfg(feature = "tokio02")]

--- a/src/transport/smtp/error.rs
+++ b/src/transport/smtp/error.rs
@@ -41,6 +41,8 @@ pub enum Error {
     /// Invalid hostname
     #[cfg(feature = "rustls-tls")]
     InvalidDNSName(webpki::InvalidDNSNameError),
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    InvalidCertificate,
     #[cfg(feature = "r2d2")]
     Pool(r2d2::Error),
 }
@@ -69,6 +71,8 @@ impl Display for Error {
             Parsing(ref err) => fmt.write_str(err.description()),
             #[cfg(feature = "rustls-tls")]
             InvalidDNSName(ref err) => err.fmt(fmt),
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            InvalidCertificate => fmt.write_str("invalid certificate"),
             #[cfg(feature = "r2d2")]
             Pool(ref err) => err.fmt(fmt),
         }


### PR DESCRIPTION
Fixes #472 and should probably remove the last remaining concern with not being able to use a preconfigured TLS client anymore since #448 