### PR TITLE
docs(email): Add doctests/examples

### DIFF
--- a/src/address.rs
+++ b/src/address.rs
@@ -12,11 +12,28 @@ use std::{
     str::FromStr,
 };
 
-/// Email address
+/// Represents an email address with a user and a domain name.
 ///
 /// This type contains email in canonical form (_user@domain.tld_).
 ///
 /// **NOTE**: Enable feature "serde" to be able serialize/deserialize it using [serde](https://serde.rs/).
+///
+/// # Examples
+///
+/// You can create an `Address` from a user and a domain:
+///
+/// ```
+/// # use lettre::Address;
+/// let address = Address::new("example", "email.com").unwrap();
+/// ```
+///
+/// You can also create an `Address` from a string literal by parsing it:
+///
+/// ```
+/// use std::str::FromStr;
+/// # use lettre::Address;
+/// let address = Address::from_str("example@email.com").unwrap();
+/// ```
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Address {
     /// Complete address
@@ -62,17 +79,45 @@ static DOMAIN_RE: Lazy<Regex> = Lazy::new(|| {
 static LITERAL_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r"(?i)\[([A-f0-9:\.]+)\]\z").unwrap());
 
 impl Address {
-    /// Create email address from parts
+    /// Creates a new email address from a user and domain.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::Address;
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// let expected: Address = "example@email.com".parse().unwrap();
+    /// assert_eq!(expected, address);
+    /// ```
     pub fn new<U: AsRef<str>, D: AsRef<str>>(user: U, domain: D) -> Result<Self, AddressError> {
         (user, domain).try_into()
     }
 
-    /// Get the user part of this `Address`
+    /// Gets the user portion of the `Address`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::Address;
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// assert_eq!("example", address.user());
+    /// ```
     pub fn user(&self) -> &str {
         &self.serialized[..self.at_start]
     }
 
-    /// Get the domain part of this `Address`
+    /// Gets the domain portion of the `Address`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::Address;
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// assert_eq!("email.com", address.domain());
+    /// ```
     pub fn domain(&self) -> &str {
         &self.serialized[self.at_start + 1..]
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ impl Envelope {
     /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
     ///
     /// let envelope = Envelope::new(Some(sender), recipients.clone()).unwrap();
-    /// assert_eq!(envelope.to(), recipients);
+    /// assert_eq!(envelope.to(), recipients.as_slice());
     /// ```
     pub fn to(&self) -> &[Address] {
         self.forward_path.as_slice()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,22 @@ pub struct Envelope {
 
 impl Envelope {
     /// Creates a new envelope, which may fail if `to` is empty.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// # use lettre::{Address, Envelope};
+    ///
+    /// let sender = Address::from_str("from@email.com").unwrap();
+    /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
+    ///
+    /// let envelope = Envelope::new(Some(sender), recipients);
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// If `to` has no elements in it.
     pub fn new(from: Option<Address>, to: Vec<Address>) -> Result<Envelope, Error> {
         if to.is_empty() {
             return Err(Error::MissingTo);
@@ -93,12 +109,41 @@ impl Envelope {
         })
     }
 
-    /// Destination addresses of the envelope
+    /// Gets the destination addresses of the envelope.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// # use lettre::{Address, Envelope};
+    ///
+    /// let sender = Address::from_str("from@email.com").unwrap();
+    /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
+    ///
+    /// let envelope = Envelope::new(Some(sender), recipients.clone()).unwrap();
+    /// assert_eq!(envelope.to(), recipients);
+    /// ```
     pub fn to(&self) -> &[Address] {
         self.forward_path.as_slice()
     }
 
-    /// Source address of the envelope
+    /// Gets the sender of the envelope.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::str::FromStr;
+    /// # use lettre::{Address, Envelope};
+    ///
+    /// let sender = Address::from_str("from@email.com").unwrap();
+    /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
+    ///
+    /// let envelope = Envelope::new(Some(sender), recipients.clone()).unwrap();
+    /// assert!(envelope.from().is_some());
+    ///
+    /// let senderless = Envelope::new(None, recipients.clone()).unwrap();
+    /// assert!(senderless.from().is_none());
+    /// ```
     pub fn from(&self) -> Option<&Address> {
         self.reverse_path.as_ref()
     }

--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -9,22 +9,48 @@ use std::{
     str::FromStr,
 };
 
-/// Email address with optional addressee name
+/// Represents an email address with an optional name for the sender/recipient.
 ///
 /// This type contains email address and the sender/recipient name (_Some Name \<user@domain.tld\>_ or _withoutname@domain.tld_).
 ///
 /// **NOTE**: Enable feature "serde" to be able serialize/deserialize it using [serde](https://serde.rs/).
+///
+/// # Examples
+///
+/// You can create a `Mailbox` from a string and an [`Address`]:
+///
+/// ```
+/// # use lettre::{Address, Mailbox};
+/// let address = Address::new("example", "email.com").unwrap();
+/// let mailbox = Mailbox::new(None, address);
+/// ```
+///
+/// You can also create one from a string literal:
+///
+/// ```
+/// # use lettre::Mailbox;
+/// let mailbox: Mailbox = "John Smith <example@email.com>".parse().unwrap();
+/// ```
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Mailbox {
-    /// User name part
+    /// The name associated with the address.
     pub name: Option<String>,
 
-    /// Email address part
+    /// The email address itself.
     pub email: Address,
 }
 
 impl Mailbox {
-    /// Create new mailbox using email address and addressee name
+    /// Creates a new `Mailbox` using an email address and the name of the recipient if there is one.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::{Address, Mailbox};
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// let mailbox = Mailbox::new(None, address);
+    /// ```
     pub fn new(name: Option<String>, email: Address) -> Self {
         Mailbox { name, email }
     }
@@ -99,7 +125,7 @@ impl FromStr for Mailbox {
     }
 }
 
-/// List or email mailboxes
+/// Represents a sequence of [`Mailbox`] instances.
 ///
 /// This type contains a sequence of mailboxes (_Some Name \<user@domain.tld\>, Another Name \<other@domain.tld\>, withoutname@domain.tld, ..._).
 ///
@@ -108,28 +134,90 @@ impl FromStr for Mailbox {
 pub struct Mailboxes(Vec<Mailbox>);
 
 impl Mailboxes {
-    /// Create mailboxes list
+    /// Creates a new list of [`Mailbox`] instances.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::Mailboxes;
+    /// let mailboxes = Mailboxes::new();
+    /// ```
     pub fn new() -> Self {
         Mailboxes(Vec::new())
     }
 
-    /// Add mailbox to a list
+    /// Adds a new [`Mailbox`] to the list, in a builder style pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::{Address, Mailbox, Mailboxes};
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// let mut mailboxes = Mailboxes::new().with(Mailbox::new(None, address));
+    /// ```
     pub fn with(mut self, mbox: Mailbox) -> Self {
         self.0.push(mbox);
         self
     }
 
-    /// Add mailbox to a list
+    /// Adds a new [`Mailbox`] to the list, in a Vec::push style pattern.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::{Address, Mailbox, Mailboxes};
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// let mut mailboxes = Mailboxes::new();
+    /// mailboxes.push(Mailbox::new(None, address));
+    /// ```
     pub fn push(&mut self, mbox: Mailbox) {
         self.0.push(mbox);
     }
 
-    /// Extract first mailbox
+    /// Extracts the first [`Mailbox`] if it exists.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::{Address, Mailbox, Mailboxes};
+    ///
+    /// let empty = Mailboxes::new();
+    /// assert!(empty.into_single().is_none());
+    ///
+    /// let mut mailboxes = Mailboxes::new();
+    /// let address = Address::new("example", "email.com").unwrap();
+    ///
+    /// mailboxes.push(Mailbox::new(None, address));
+    /// assert!(mailboxes.into_single().is_some());
+    /// ```
     pub fn into_single(self) -> Option<Mailbox> {
         self.into()
     }
 
-    /// Iterate over mailboxes
+    /// Creates an iterator over the [`Mailbox`] instances that are currently stored.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use lettre::{Address, Mailbox, Mailboxes};
+    ///
+    /// let mut mailboxes = Mailboxes::new();
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// mailboxes.push(Mailbox::new(None, address));
+    ///
+    /// let address = Address::new("example", "email.com").unwrap();
+    /// mailboxes.push(Mailbox::new(None, address));
+    ///
+    /// let mut iter = mailboxes.iter();
+    ///
+    /// assert!(iter.next().is_some());
+    /// assert!(iter.next().is_some());
+    ///
+    /// assert!(iter.next().is_none());
+    /// ```
     pub fn iter(&self) -> Iter<Mailbox> {
         self.0.iter()
     }


### PR DESCRIPTION
Add doctests/examples for `Address`, `Mailbox`, `Mailboxes` and
`Envelope`.