### PR TITLE
Bump openssl major version: 0.9 -> 0.10 for the old lettre v0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "lettre"
-version = "0.6.2"
+version = "0.6.3"
 description = "Email client"
 readme = "README.md"
 documentation = "https://lettre.github.io/lettre/"
@@ -15,7 +15,7 @@ bufstream = "^0.1"
 email = "^0.0"
 log = "^0.3"
 mime = "^0.2"
-openssl = "^0.9"
+openssl = "> 0.9, < 0.11"
 rustc-serialize = "^0.3"
 rust-crypto = "^0.2"
 time = "^0.1"


### PR DESCRIPTION
This is an update to the old lettre v0.6 which my ancient codebase is still using at the moment. v0.6 depends on the version 0.9 of the openssl crate, which doesn't support the newer OpenSSL versions. I don't know whether this old version of lettre is maintained in any sense anymore, but accepting this would make my life easier.

# Details
* Bump openssl minor version: 0.9 -> 0.10 to allow upgrading OpenSSL.
  * Tested lettre with openssl 0.10 to build without problems with my own code.
* Leave the range to continue including 0.9, so crates depending on lettre 0.6 are able to stay at openssl 0.9 if they so choose.
  * Because the minimum version of openssl was not restricted, this should be a backwards compatible change.
* Bump lettre patch version to 0.6.3.
* A `cargo publish` after merging this would be very nice!