### PR TITLE
bump base64 version to 0.13.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ mime = { version = "0.3", optional = true }
 uuid = { version = "0.8", features = ["v4"] }
 rand = { version = "0.7", optional = true }
 quoted_printable = { version = "0.4", optional = true }
-base64 = { version = "0.12", optional = true }
+base64 = { version = "0.13", optional = true }
 once_cell = "1"
 regex = "1"
 


### PR DESCRIPTION
This is part of #467 with the [matching bump on hyperx](https://github.com/dekellum/hyperx/pull/23)