### PR TITLE
Bump our MSRV to 1.45.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.40.0
+          - 1.45.2
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1
@@ -37,7 +37,6 @@ jobs:
           args: --no-default-features --features=builder,smtp-transport,file-transport,sendmail-transport
       - run: rm target/debug/deps/liblettre-*
       - uses: actions-rs/cargo@v1
-        if: matrix.rust != '1.40.0'
         with:
           command: test
           args: --features=async-std1
@@ -54,7 +53,7 @@ jobs:
         rust:
           - stable
           - beta
-          - 1.40.0
+          - 1.45.2
     steps:
       - uses: actions/checkout@v1
       - uses: actions-rs/toolchain@v1

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Lettre does not provide (for now):
 
 ## Example
 
-This library requires Rust 1.40 or newer.
+This library requires Rust 1.45 or newer.
 To use this library, add the following to your `Cargo.toml`:
 
 

--- a/src/address.rs
+++ b/src/address.rs
@@ -156,7 +156,7 @@ impl Address {
 }
 
 impl Display for Address {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         f.write_str(&self.serialized)
     }
 }
@@ -202,7 +202,7 @@ pub enum AddressError {
 impl Error for AddressError {}
 
 impl Display for AddressError {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {
             AddressError::MissingParts => f.write_str("Missing domain or user"),
             AddressError::Unbalanced => f.write_str("Unbalanced angle bracket"),
@@ -254,7 +254,7 @@ mod serde {
                     impl<'de> Visitor<'de> for FieldVisitor {
                         type Value = Field;
 
-                        fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+                        fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                             formatter.write_str("'user' or 'domain'")
                         }
 
@@ -279,7 +279,7 @@ mod serde {
             impl<'de> Visitor<'de> for AddressVisitor {
                 type Value = Address;
 
-                fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+                fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                     formatter.write_str("email address string or object")
                 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,13 +27,14 @@
 #![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-alpha.2")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
+#![forbid(unsafe_code)]
 #![deny(
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,
     unstable_features,
     unused_import_braces,
-    unsafe_code
+    rust_2018_idioms
 )]
 
 pub mod address;

--- a/src/message/header/content.rs
+++ b/src/message/header/content.rs
@@ -26,7 +26,7 @@ impl Default for ContentTransferEncoding {
 }
 
 impl Display for ContentTransferEncoding {
-    fn fmt(&self, f: &mut FmtFormatter) -> FmtResult {
+    fn fmt(&self, f: &mut FmtFormatter<'_>) -> FmtResult {
         use self::ContentTransferEncoding::*;
         f.write_str(match *self {
             SevenBit => "7bit",
@@ -73,7 +73,7 @@ impl Header for ContentTransferEncoding {
             })
     }
 
-    fn fmt_header(&self, f: &mut HeaderFormatter) -> FmtResult {
+    fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
         f.fmt_line(&format!("{}", self))
     }
 }

--- a/src/message/header/mailbox.rs
+++ b/src/message/header/mailbox.rs
@@ -35,7 +35,7 @@ macro_rules! mailbox_header {
                     }).map($type_name)
             }
 
-            fn fmt_header(&self, f: &mut HeaderFormatter) -> FmtResult {
+            fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
                 f.fmt_line(&self.0.recode_name(utf8_b::encode))
             }
         }
@@ -70,7 +70,7 @@ macro_rules! mailboxes_header {
                     .map($type_name)
             }
 
-            fn fmt_header(&self, f: &mut HeaderFormatter) -> FmtResult {
+            fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
                 format_mailboxes(self.0.iter(), f)
             }
         }
@@ -155,7 +155,7 @@ fn parse_mailboxes(raw: &[u8]) -> HyperResult<Mailboxes> {
     Err(HeaderError::Header)
 }
 
-fn format_mailboxes<'a>(mbs: Iter<'a, Mailbox>, f: &mut HeaderFormatter) -> FmtResult {
+fn format_mailboxes<'a>(mbs: Iter<'a, Mailbox>, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
     f.fmt_line(&Mailboxes::from(
         mbs.map(|mb| mb.recode_name(utf8_b::encode))
             .collect::<Vec<_>>(),

--- a/src/message/header/special.rs
+++ b/src/message/header/special.rs
@@ -45,7 +45,7 @@ impl Header for MimeVersion {
         })
     }
 
-    fn fmt_header(&self, f: &mut HeaderFormatter) -> FmtResult {
+    fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
         f.fmt_line(&format!("{}.{}", self.major, self.minor))
     }
 }

--- a/src/message/header/textual.rs
+++ b/src/message/header/textual.rs
@@ -26,7 +26,7 @@ macro_rules! text_header {
                     .map($type_name)
             }
 
-            fn fmt_header(&self, f: &mut HeaderFormatter) -> FmtResult {
+            fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
                 fmt_text(&self.0, f)
             }
         }
@@ -50,7 +50,7 @@ fn parse_text(raw: &[u8]) -> HyperResult<String> {
     Err(HeaderError::Header)
 }
 
-fn fmt_text(s: &str, f: &mut HeaderFormatter) -> FmtResult {
+fn fmt_text(s: &str, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
     f.fmt_line(&utf8_b::encode(s))
 }
 

--- a/src/message/mailbox/serde.rs
+++ b/src/message/mailbox/serde.rs
@@ -37,7 +37,7 @@ impl<'de> Deserialize<'de> for Mailbox {
                 impl<'de> Visitor<'de> for FieldVisitor {
                     type Value = Field;
 
-                    fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+                    fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                         formatter.write_str("'name' or 'email'")
                     }
 
@@ -62,7 +62,7 @@ impl<'de> Deserialize<'de> for Mailbox {
         impl<'de> Visitor<'de> for MailboxVisitor {
             type Value = Mailbox;
 
-            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                 formatter.write_str("mailbox string or object")
             }
 
@@ -123,7 +123,7 @@ impl<'de> Deserialize<'de> for Mailboxes {
         impl<'de> Visitor<'de> for MailboxesVisitor {
             type Value = Mailboxes;
 
-            fn expecting(&self, formatter: &mut Formatter) -> FmtResult {
+            fn expecting(&self, formatter: &mut Formatter<'_>) -> FmtResult {
                 formatter.write_str("mailboxes string or sequence")
             }
 

--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -65,7 +65,7 @@ impl Mailbox {
 }
 
 impl Display for Mailbox {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         if let Some(ref name) = self.name {
             let name = name.trim();
             if !name.is_empty() {
@@ -218,7 +218,7 @@ impl Mailboxes {
     ///
     /// assert!(iter.next().is_none());
     /// ```
-    pub fn iter(&self) -> Iter<Mailbox> {
+    pub fn iter(&self) -> Iter<'_, Mailbox> {
         self.0.iter()
     }
 }
@@ -271,7 +271,7 @@ impl Extend<Mailbox> for Mailboxes {
 }
 
 impl Display for Mailboxes {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut iter = self.iter();
 
         if let Some(mbox) = iter.next() {

--- a/src/message/utf8_b.rs
+++ b/src/message/utf8_b.rs
@@ -16,19 +16,16 @@ pub fn encode(s: &str) -> String {
 }
 
 pub fn decode(s: &str) -> Option<String> {
-    const PREFIX: &str = "=?utf-8?b?";
-    const SUFFIX: &str = "?=";
-
-    let s = s.trim();
-    if s.starts_with(PREFIX) && s.ends_with(SUFFIX) {
-        let s = &s[PREFIX.len()..];
-        let s = &s[..s.len() - SUFFIX.len()];
-        base64::decode(s)
-            .ok()
-            .and_then(|v| String::from_utf8(v).ok())
-    } else {
-        Some(s.into())
-    }
+    s.strip_prefix("=?utf-8?b?")
+        .and_then(|stripped| stripped.strip_suffix("?="))
+        .map_or_else(
+            || Some(s.into()),
+            |stripped| {
+                let decoded = base64::decode(stripped).ok()?;
+                let decoded = String::from_utf8(decoded).ok()?;
+                Some(decoded)
+            },
+        )
 }
 
 #[cfg(test)]

--- a/src/transport/file/error.rs
+++ b/src/transport/file/error.rs
@@ -19,7 +19,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             Client(err) => fmt.write_str(err),
             Io(ref err) => err.fmt(fmt),

--- a/src/transport/sendmail/error.rs
+++ b/src/transport/sendmail/error.rs
@@ -20,7 +20,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             Client(ref err) => err.fmt(fmt),
             Utf8Parsing(ref err) => err.fmt(fmt),

--- a/src/transport/smtp/authentication.rs
+++ b/src/transport/smtp/authentication.rs
@@ -52,7 +52,7 @@ pub enum Mechanism {
 }
 
 impl Display for Mechanism {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(match *self {
             Mechanism::Plain => "PLAIN",
             Mechanism::Login => "LOGIN",

--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -189,7 +189,7 @@ impl AsyncNetworkStream {
 impl futures_io::AsyncRead for AsyncNetworkStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
-        cx: &mut Context,
+        cx: &mut Context<'_>,
         buf: &mut [u8],
     ) -> Poll<IoResult<usize>> {
         match self.inner {
@@ -208,7 +208,11 @@ impl futures_io::AsyncRead for AsyncNetworkStream {
 }
 
 impl futures_io::AsyncWrite for AsyncNetworkStream {
-    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context, buf: &[u8]) -> Poll<IoResult<usize>> {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<IoResult<usize>> {
         match self.inner {
             #[cfg(feature = "tokio02")]
             InnerAsyncNetworkStream::Tokio02Tcp(ref mut s) => Pin::new(s).poll_write(cx, buf),
@@ -223,7 +227,7 @@ impl futures_io::AsyncWrite for AsyncNetworkStream {
         }
     }
 
-    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<IoResult<()>> {
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<IoResult<()>> {
         match self.inner {
             #[cfg(feature = "tokio02")]
             InnerAsyncNetworkStream::Tokio02Tcp(ref mut s) => Pin::new(s).poll_flush(cx),
@@ -238,7 +242,7 @@ impl futures_io::AsyncWrite for AsyncNetworkStream {
         }
     }
 
-    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<IoResult<()>> {
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<IoResult<()>> {
         Poll::Ready(self.shutdown(Shutdown::Write))
     }
 }

--- a/src/transport/smtp/commands.rs
+++ b/src/transport/smtp/commands.rs
@@ -19,7 +19,7 @@ pub struct Ehlo {
 }
 
 impl Display for Ehlo {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "EHLO {}\r\n", self.client_id)
     }
 }
@@ -37,7 +37,7 @@ impl Ehlo {
 pub struct Starttls;
 
 impl Display for Starttls {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("STARTTLS\r\n")
     }
 }
@@ -51,7 +51,7 @@ pub struct Mail {
 }
 
 impl Display for Mail {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(
             f,
             "MAIL FROM:<{}>",
@@ -80,7 +80,7 @@ pub struct Rcpt {
 }
 
 impl Display for Rcpt {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "RCPT TO:<{}>", self.recipient)?;
         for parameter in &self.parameters {
             write!(f, " {}", parameter)?;
@@ -105,7 +105,7 @@ impl Rcpt {
 pub struct Data;
 
 impl Display for Data {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("DATA\r\n")
     }
 }
@@ -116,7 +116,7 @@ impl Display for Data {
 pub struct Quit;
 
 impl Display for Quit {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("QUIT\r\n")
     }
 }
@@ -127,7 +127,7 @@ impl Display for Quit {
 pub struct Noop;
 
 impl Display for Noop {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("NOOP\r\n")
     }
 }
@@ -140,7 +140,7 @@ pub struct Help {
 }
 
 impl Display for Help {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("HELP")?;
         if let Some(argument) = &self.argument {
             write!(f, " {}", argument)?;
@@ -164,7 +164,7 @@ pub struct Vrfy {
 }
 
 impl Display for Vrfy {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "VRFY {}\r\n", self.argument)
     }
 }
@@ -184,7 +184,7 @@ pub struct Expn {
 }
 
 impl Display for Expn {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "EXPN {}\r\n", self.argument)
     }
 }
@@ -202,7 +202,7 @@ impl Expn {
 pub struct Rset;
 
 impl Display for Rset {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str("RSET\r\n")
     }
 }
@@ -218,7 +218,7 @@ pub struct Auth {
 }
 
 impl Display for Auth {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let encoded_response = self.response.as_ref().map(base64::encode);
 
         if self.mechanism.supports_initial_response() {

--- a/src/transport/smtp/error.rs
+++ b/src/transport/smtp/error.rs
@@ -48,7 +48,7 @@ pub enum Error {
 }
 
 impl Display for Error {
-    fn fmt(&self, fmt: &mut Formatter) -> Result<(), fmt::Error> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
         match *self {
             // Try to display the first line of the server's response that usually
             // contains a short humanly readable error message

--- a/src/transport/smtp/extension.rs
+++ b/src/transport/smtp/extension.rs
@@ -48,7 +48,7 @@ impl Default for ClientId {
 }
 
 impl Display for ClientId {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Self::Domain(ref value) => f.write_str(value),
             Self::Ipv4(ref value) => write!(f, "[{}]", value),
@@ -86,7 +86,7 @@ pub enum Extension {
 }
 
 impl Display for Extension {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             Extension::EightBitMime => f.write_str("8BITMIME"),
             Extension::SmtpUtfEight => f.write_str("SMTPUTF8"),
@@ -111,7 +111,7 @@ pub struct ServerInfo {
 }
 
 impl Display for ServerInfo {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let features = if self.features.is_empty() {
             "no supported features".to_string()
         } else {
@@ -215,7 +215,7 @@ pub enum MailParameter {
 }
 
 impl Display for MailParameter {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             MailParameter::Body(ref value) => write!(f, "BODY={}", value),
             MailParameter::Size(size) => write!(f, "SIZE={}", size),
@@ -243,7 +243,7 @@ pub enum MailBodyParameter {
 }
 
 impl Display for MailBodyParameter {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             MailBodyParameter::SevenBit => f.write_str("7BIT"),
             MailBodyParameter::EightBitMime => f.write_str("8BITMIME"),
@@ -265,7 +265,7 @@ pub enum RcptParameter {
 }
 
 impl Display for RcptParameter {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match *self {
             RcptParameter::Other {
                 ref keyword,

--- a/src/transport/smtp/response.rs
+++ b/src/transport/smtp/response.rs
@@ -151,10 +151,10 @@ impl Response {
 
     /// Tells if the response is positive
     pub fn is_positive(&self) -> bool {
-        match self.code.severity {
-            Severity::PositiveCompletion | Severity::PositiveIntermediate => true,
-            _ => false,
-        }
+        matches!(
+            self.code.severity,
+            Severity::PositiveCompletion | Severity::PositiveIntermediate
+        )
     }
 
     /// Tests code equality

--- a/src/transport/smtp/response.rs
+++ b/src/transport/smtp/response.rs
@@ -32,7 +32,7 @@ pub enum Severity {
 }
 
 impl Display for Severity {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", *self as u8)
     }
 }
@@ -56,7 +56,7 @@ pub enum Category {
 }
 
 impl Display for Category {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", *self as u8)
     }
 }
@@ -88,7 +88,7 @@ pub enum Detail {
 }
 
 impl Display for Detail {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}", *self as u8)
     }
 }
@@ -106,7 +106,7 @@ pub struct Code {
 }
 
 impl Display for Code {
-    fn fmt(&self, f: &mut Formatter) -> Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         write!(f, "{}{}{}", self.severity, self.category, self.detail)
     }
 }

--- a/src/transport/smtp/util.rs
+++ b/src/transport/smtp/util.rs
@@ -8,7 +8,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 pub struct XText<'a>(pub &'a str);
 
 impl<'a> Display for XText<'a> {
-    fn fmt(&self, f: &mut Formatter) -> FmtResult {
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         let mut rest = self.0;
         while let Some(idx) = rest.find(|c| c < '!' || c == '+' || c == '=') {
             let (start, end) = rest.split_at(idx);


### PR DESCRIPTION
* [Tokio bumped the MSRV to 1.45 on master](https://github.com/tokio-rs/tokio/blob/2e05399f4b6be41680036cc158348973689840ca/.github/workflows/ci.yml#L13), so the 0.3 will require Rust 1.45 if not greater
* Other crates we depend on also bumped their MSRV (see #481 and #462)
* 1.45 was also the version that stabilized function-like procedural macros and expressions, so a lot of crates are probably going to update to it soon