### PR TITLE
Add doc_cfg attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,7 @@ tokio02-rustls-tls = ["tokio02", "rustls-tls", "tokio02_rustls"]
 
 [package.metadata.docs.rs]
 all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
 
 [[example]]
 name = "smtp"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,6 +198,7 @@ pub trait Transport {
 
     /// Sends the email
     #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
     fn send(&self, message: &Message) -> Result<Self::Ok, Self::Error> {
         let raw = message.formatted();
         self.send_raw(message.envelope(), &raw)
@@ -208,6 +209,7 @@ pub trait Transport {
 
 /// async-std 1.x based Transport method for emails
 #[cfg(feature = "async-std1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
 #[async_trait]
 pub trait AsyncStd1Transport {
     /// Response produced by the Transport
@@ -217,6 +219,7 @@ pub trait AsyncStd1Transport {
 
     /// Sends the email
     #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
     // TODO take &Message
     async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
         let raw = message.formatted();
@@ -229,6 +232,7 @@ pub trait AsyncStd1Transport {
 
 /// tokio 0.2.x based Transport method for emails
 #[cfg(feature = "tokio02")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
 #[async_trait]
 pub trait Tokio02Transport {
     /// Response produced by the Transport
@@ -238,6 +242,7 @@ pub trait Tokio02Transport {
 
     /// Sends the email
     #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
     // TODO take &Message
     async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
         let raw = message.formatted();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,7 @@
 pub mod address;
 pub mod error;
 #[cfg(feature = "builder")]
+#[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
 pub mod message;
 pub mod transport;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@
     unused_import_braces,
     unsafe_code
 )]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 pub mod address;
 pub mod error;

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -17,9 +17,12 @@
 //!   logs.
 
 #[cfg(feature = "file-transport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "file-transport")))]
 pub mod file;
 #[cfg(feature = "sendmail-transport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "sendmail-transport")))]
 pub mod sendmail;
 #[cfg(feature = "smtp-transport")]
+#[cfg_attr(docsrs, doc(cfg(feature = "smtp-transport")))]
 pub mod smtp;
 pub mod stub;

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -195,6 +195,7 @@ pub trait AsyncSmtpConnector: Default + private::Sealed {
 
 #[derive(Debug, Copy, Clone, Default)]
 #[cfg(feature = "tokio02")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
 pub struct Tokio02Connector;
 
 #[async_trait]

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -84,6 +84,7 @@ impl TlsParametersBuilder {
     ///
     /// Hostname verification can only be disabled with the `native-tls` TLS backend.
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn dangerous_accept_invalid_hostnames(
         &mut self,
         accept_invalid_hostnames: bool,
@@ -116,6 +117,7 @@ impl TlsParametersBuilder {
     /// Creates a new `TlsParameters` using native-tls or rustls
     /// depending on which one is available
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
     pub fn build(self) -> Result<TlsParameters, Error> {
         #[cfg(feature = "native-tls")]
         return self.build_native();
@@ -135,6 +137,7 @@ impl TlsParametersBuilder {
 
     /// Creates a new `TlsParameters` using native-tls with the provided configuration
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn build_native(self) -> Result<TlsParameters, Error> {
         let mut tls_builder = TlsConnector::builder();
 
@@ -154,6 +157,7 @@ impl TlsParametersBuilder {
 
     /// Creates a new `TlsParameters` using rustls with the provided configuration
     #[cfg(feature = "rustls-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn build_rustls(self) -> Result<TlsParameters, Error> {
         use webpki_roots::TLS_SERVER_ROOTS;
 
@@ -191,6 +195,7 @@ impl TlsParameters {
     /// Creates a new `TlsParameters` using native-tls or rustls
     /// depending on which one is available
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
     pub fn new(domain: String) -> Result<Self, Error> {
         TlsParametersBuilder::new(domain).build()
     }
@@ -201,12 +206,14 @@ impl TlsParameters {
 
     /// Creates a new `TlsParameters` using native-tls
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     pub fn new_native(domain: String) -> Result<Self, Error> {
         TlsParametersBuilder::new(domain).build_native()
     }
 
     /// Creates a new `TlsParameters` using rustls
     #[cfg(feature = "rustls-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     pub fn new_rustls(domain: String) -> Result<Self, Error> {
         TlsParametersBuilder::new(domain).build_rustls()
     }

--- a/src/transport/smtp/error.rs
+++ b/src/transport/smtp/error.rs
@@ -35,15 +35,19 @@ pub enum Error {
     Io(io::Error),
     /// TLS error
     #[cfg(feature = "native-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]
     Tls(native_tls::Error),
     /// Parsing error
     Parsing(nom::error::ErrorKind),
     /// Invalid hostname
     #[cfg(feature = "rustls-tls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
     InvalidDNSName(webpki::InvalidDNSNameError),
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
     InvalidCertificate,
     #[cfg(feature = "r2d2")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "r2d2")))]
     Pool(r2d2::Error),
 }
 

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -182,6 +182,7 @@ pub mod commands;
 mod error;
 pub mod extension;
 #[cfg(feature = "r2d2")]
+#[cfg_attr(docsrs, doc(cfg(feature = "r2d2")))]
 pub mod pool;
 pub mod response;
 mod transport;


### PR DESCRIPTION
This pull request adds doc_cfg attributes mentioned in #451 
I started with annotating only the public-facing items. Would you prefer doc_cfg on all private items as well?

Please let me know if there's anything else I've missed or you would like improved. 😃