### PR TITLE
Stop exposing internal encoder implementation

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -174,7 +174,6 @@
 //!
 //! ```
 
-pub use encoder::*;
 pub use mailbox::*;
 pub use mimebody::*;
 


### PR DESCRIPTION
I feel like this doesn't need to be part of the public API, and only makes it impossible to refactor it in the future without introducing a breaking change