### PR TITLE
Tokio 0.3 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,6 +44,10 @@ jobs:
         with:
           command: test
           args: --features=tokio02
+      - uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --features=tokio03
 
   check:
     name: Check

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,8 +92,8 @@ tokio02 = ["tokio02_crate", "async-trait", "futures-io", "futures-util"]
 tokio02-native-tls = ["tokio02", "native-tls", "tokio02_native_tls_crate"]
 tokio02-rustls-tls = ["tokio02", "rustls-tls", "tokio02_rustls"]
 tokio03 = ["tokio03_crate", "async-trait", "futures-io", "futures-util"]
-tokio03-native-tls = ["tokio03", "native-tls", "tokio02_native_tls_crate"]
-tokio03-rustls-tls = ["tokio03", "rustls-tls", "tokio02_rustls"]
+tokio03-native-tls = ["tokio03", "native-tls", "tokio03_native_tls_crate"]
+tokio03-rustls-tls = ["tokio03", "rustls-tls", "tokio03_rustls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,3 +122,12 @@ required-features = ["smtp-transport", "tokio02", "tokio02-native-tls"]
 [[example]]
 name = "tokio02_smtp_starttls"
 required-features = ["smtp-transport", "tokio02", "tokio02-native-tls"]
+
+[[example]]
+name = "tokio03_smtp_tls"
+required-features = ["smtp-transport", "tokio03", "tokio03-native-tls"]
+
+[[example]]
+name = "tokio03_smtp_starttls"
+required-features = ["smtp-transport", "tokio03", "tokio03-native-tls"]
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ async-trait = { version = "0.1", optional = true }
 tokio02_crate = { package = "tokio", version = "0.2.7", features = ["fs", "process", "tcp", "dns", "io-util"], optional = true }
 tokio02_native_tls_crate = { package = "tokio-native-tls", version = "0.1", optional = true }
 tokio02_rustls = { package = "tokio-rustls", version = "0.14", optional = true }
+tokio03_crate = { package = "tokio", version = "0.3", features = ["fs", "process", "net", "io-util"], optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -65,6 +66,7 @@ tracing-subscriber = "0.2.10"
 glob = "0.3"
 walkdir = "2"
 tokio02_crate = { package = "tokio", version = "0.2.7", features = ["macros", "rt-threaded"] }
+tokio03_crate = { package = "tokio", version = "0.3", features = ["macros", "rt-multi-thread"] }
 
 [[bench]]
 harness = false
@@ -87,6 +89,7 @@ async-std1 = ["async-std", "async-trait", "async-attributes"]
 tokio02 = ["tokio02_crate", "async-trait", "futures-io", "futures-util"]
 tokio02-native-tls = ["tokio02", "native-tls", "tokio02_native_tls_crate"]
 tokio02-rustls-tls = ["tokio02", "rustls-tls", "tokio02_rustls"]
+tokio03 = ["tokio03_crate", "async-trait", "futures-io", "futures-util"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,8 @@ tokio02_crate = { package = "tokio", version = "0.2.7", features = ["fs", "proce
 tokio02_native_tls_crate = { package = "tokio-native-tls", version = "0.1", optional = true }
 tokio02_rustls = { package = "tokio-rustls", version = "0.14", optional = true }
 tokio03_crate = { package = "tokio", version = "0.3", features = ["fs", "process", "net", "io-util"], optional = true }
+tokio03_native_tls_crate = { package = "tokio-native-tls", version = "0.2", optional = true }
+tokio03_rustls = { package = "tokio-rustls", version = "0.20", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -90,6 +92,8 @@ tokio02 = ["tokio02_crate", "async-trait", "futures-io", "futures-util"]
 tokio02-native-tls = ["tokio02", "native-tls", "tokio02_native_tls_crate"]
 tokio02-rustls-tls = ["tokio02", "rustls-tls", "tokio02_rustls"]
 tokio03 = ["tokio03_crate", "async-trait", "futures-io", "futures-util"]
+tokio03-native-tls = ["tokio03", "native-tls", "tokio02_native_tls_crate"]
+tokio03-rustls-tls = ["tokio03", "rustls-tls", "tokio02_rustls"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/examples/tokio03_smtp_starttls.rs
+++ b/examples/tokio03_smtp_starttls.rs
@@ -1,0 +1,36 @@
+// This line is only to make it compile from lettre's examples folder,
+// since it uses Rust 2018 crate renaming to import tokio.
+// Won't be needed in user's code.
+use tokio03_crate as tokio;
+
+use lettre::{
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio03Connector,
+    Tokio03Transport,
+};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let email = Message::builder()
+        .from("NoBody <nobody@domain.tld>".parse().unwrap())
+        .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
+        .to("Hei <hei@domain.tld>".parse().unwrap())
+        .subject("Happy new async year")
+        .body("Be happy with async!")
+        .unwrap();
+
+    let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
+
+    // Open a remote connection to gmail using STARTTLS
+    let mailer = AsyncSmtpTransport::<Tokio03Connector>::starttls_relay("smtp.gmail.com")
+        .unwrap()
+        .credentials(creds)
+        .build();
+
+    // Send the email
+    match mailer.send(email).await {
+        Ok(_) => println!("Email sent successfully!"),
+        Err(e) => panic!("Could not send email: {:?}", e),
+    }
+}

--- a/examples/tokio03_smtp_tls.rs
+++ b/examples/tokio03_smtp_tls.rs
@@ -1,0 +1,36 @@
+// This line is only to make it compile from lettre's examples folder,
+// since it uses Rust 2018 crate renaming to import tokio.
+// Won't be needed in user's code.
+use tokio03_crate as tokio;
+
+use lettre::{
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio03Connector,
+    Tokio03Transport,
+};
+
+#[tokio::main]
+async fn main() {
+    tracing_subscriber::fmt::init();
+
+    let email = Message::builder()
+        .from("NoBody <nobody@domain.tld>".parse().unwrap())
+        .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
+        .to("Hei <hei@domain.tld>".parse().unwrap())
+        .subject("Happy new async year")
+        .body("Be happy with async!")
+        .unwrap();
+
+    let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
+
+    // Open a remote connection to gmail
+    let mailer = AsyncSmtpTransport::<Tokio03Connector>::relay("smtp.gmail.com")
+        .unwrap()
+        .credentials(creds)
+        .build();
+
+    // Send the email
+    match mailer.send(email).await {
+        Ok(_) => println!("Email sent successfully!"),
+        Err(e) => panic!("Could not send email: {:?}", e),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,8 @@
 //! * **tokio02-rustls-tls**: Async TLS support with the `rustls` crate using tokio 0.2
 //! * **tokio02-native-tls**: Async TLS support with the `native-tls` crate using tokio 0.2
 //! * **tokio03**: Allow to asyncronously send emails using tokio 0.3.x
+//! * **tokio03-rustls-tls**: Async TLS support with the `rustls` crate using tokio 0.3
+//! * **tokio03-native-tls**: Async TLS support with the `native-tls` crate using tokio 0.3
 //! * **async-std1**: Allow to asyncronously send emails using async-std 1.x (SMTP isn't supported yet)
 //! * **r2d2**: Connection pool for SMTP transport
 //! * **tracing**: Logging using the `tracing` crate

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,10 +64,17 @@ pub use crate::transport::file::FileTransport;
 pub use crate::transport::sendmail::SendmailTransport;
 #[cfg(all(feature = "smtp-transport", feature = "connection-pool"))]
 pub use crate::transport::smtp::r2d2::SmtpConnectionManager;
+#[cfg(all(
+    feature = "smtp-transport",
+    any(feature = "tokio02", feature = "tokio03")
+))]
+pub use crate::transport::smtp::AsyncSmtpTransport;
 #[cfg(feature = "smtp-transport")]
 pub use crate::transport::smtp::SmtpTransport;
 #[cfg(all(feature = "smtp-transport", feature = "tokio02"))]
-pub use crate::transport::smtp::{AsyncSmtpTransport, Tokio02Connector};
+pub use crate::transport::smtp::Tokio02Connector;
+#[cfg(all(feature = "smtp-transport", feature = "tokio03"))]
+pub use crate::transport::smtp::Tokio03Connector;
 pub use crate::{address::Address, transport::stub::StubTransport};
 #[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio03"))]
 use async_trait::async_trait;

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -93,7 +93,7 @@ use crate::Tokio02Transport;
 #[cfg(feature = "tokio03")]
 use crate::Tokio03Transport;
 use crate::{Envelope, Transport};
-#[cfg(any(feature = "async-std1", feature = "tokio03"))]
+#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio03"))]
 use async_trait::async_trait;
 use std::{
     path::{Path, PathBuf},

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -90,8 +90,10 @@ pub use self::error::Error;
 use crate::AsyncStd1Transport;
 #[cfg(feature = "tokio02")]
 use crate::Tokio02Transport;
+#[cfg(feature = "tokio03")]
+use crate::Tokio03Transport;
 use crate::{Envelope, Transport};
-#[cfg(any(feature = "async-std1", feature = "tokio02"))]
+#[cfg(any(feature = "async-std1", feature = "tokio03"))]
 use async_trait::async_trait;
 use std::{
     path::{Path, PathBuf},
@@ -192,6 +194,22 @@ impl Tokio02Transport for FileTransport {
 
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
         use tokio02_crate::fs;
+
+        let (email_id, file, serialized) = self.send_raw_impl(envelope, email)?;
+
+        fs::write(file, serialized).await?;
+        Ok(email_id.to_string())
+    }
+}
+
+#[cfg(feature = "tokio03")]
+#[async_trait]
+impl Tokio03Transport for FileTransport {
+    type Ok = Id;
+    type Error = Error;
+
+    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
+        use tokio03_crate::fs;
 
         let (email_id, file, serialized) = self.send_raw_impl(envelope, email)?;
 

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -64,11 +64,16 @@ where
     ///
     /// Creates an encrypted transport over submissions port, using the provided domain
     /// to validate TLS certificates.
-    #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
+    #[cfg(any(
+        feature = "tokio02-native-tls",
+        feature = "tokio02-rustls-tls",
+        feature = "tokio03-native-tls",
+        feature = "tokio03-rustls-tls"
+    ))]
     pub fn relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         use super::{TlsParameters, SUBMISSIONS_PORT};
 
-        let tls_parameters = TlsParameters::builder(relay.into()).build_tokio02()?;
+        let tls_parameters = TlsParameters::new(relay.into())?;
 
         Ok(Self::builder_dangerous(relay)
             .port(SUBMISSIONS_PORT)
@@ -86,7 +91,12 @@ where
     ///
     /// An error is returned if the connection can't be upgraded. No credentials
     /// or emails will be sent to the server, protecting from downgrade attacks.
-    #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
+    #[cfg(any(
+        feature = "tokio02-native-tls",
+        feature = "tokio02-rustls-tls",
+        feature = "tokio03-native-tls",
+        feature = "tokio03-rustls-tls"
+    ))]
     pub fn starttls_relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         use super::{TlsParameters, SUBMISSION_PORT};
 
@@ -156,7 +166,12 @@ impl AsyncSmtpTransportBuilder {
     }
 
     /// Set the TLS settings to use
-    #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
+    #[cfg(any(
+        feature = "tokio02-native-tls",
+        feature = "tokio02-rustls-tls",
+        feature = "tokio03-native-tls",
+        feature = "tokio03-rustls-tls"
+    ))]
     pub fn tls(mut self, tls: Tls) -> Self {
         self.info.tls = tls;
         self

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -45,11 +45,10 @@ impl AsyncSmtpConnection {
         &self.server_info
     }
 
-    // FIXME add simple connect and rename this one
-
     /// Connects to the configured server
     ///
     /// Sends EHLO and parses server information
+    #[cfg(feature = "tokio02")]
     pub async fn connect_tokio02(
         hostname: &str,
         port: u16,
@@ -57,6 +56,20 @@ impl AsyncSmtpConnection {
         tls_parameters: Option<TlsParameters>,
     ) -> Result<AsyncSmtpConnection, Error> {
         let stream = AsyncNetworkStream::connect_tokio02(hostname, port, tls_parameters).await?;
+        Self::connect_impl(stream, hello_name).await
+    }
+
+    /// Connects to the configured server
+    ///
+    /// Sends EHLO and parses server information
+    #[cfg(feature = "tokio03")]
+    pub async fn connect_tokio03(
+        hostname: &str,
+        port: u16,
+        hello_name: &ClientId,
+        tls_parameters: Option<TlsParameters>,
+    ) -> Result<AsyncSmtpConnection, Error> {
+        let stream = AsyncNetworkStream::connect_tokio03(hostname, port, tls_parameters).await?;
         Self::connect_impl(stream, hello_name).await
     }
 

--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -26,7 +26,12 @@ use tokio02_rustls::client::TlsStream as Tokio02RustlsTlsStream;
 #[cfg(feature = "tokio03-rustls-tls")]
 use tokio03_rustls::client::TlsStream as Tokio03RustlsTlsStream;
 
-#[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
+#[cfg(any(
+    feature = "tokio02-native-tls",
+    feature = "tokio02-rustls-tls",
+    feature = "tokio03-native-tls",
+    feature = "tokio03-rustls-tls"
+))]
 use super::InnerTlsParameters;
 use super::TlsParameters;
 use crate::transport::smtp::Error;

--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -17,10 +17,14 @@ use tokio03_crate::io::{AsyncRead as _, AsyncWrite as _, ReadBuf as Tokio03ReadB
 use tokio03_crate::net::TcpStream as Tokio03TcpStream;
 
 #[cfg(feature = "tokio02-native-tls")]
-use tokio02_native_tls_crate::TlsStream;
+use tokio02_native_tls_crate::TlsStream as Tokio02TlsStream;
+#[cfg(feature = "tokio03-native-tls")]
+use tokio03_native_tls_crate::TlsStream as Tokio03TlsStream;
 
 #[cfg(feature = "tokio02-rustls-tls")]
-use tokio02_rustls::client::TlsStream as RustlsTlsStream;
+use tokio02_rustls::client::TlsStream as Tokio02RustlsTlsStream;
+#[cfg(feature = "tokio03-rustls-tls")]
+use tokio03_rustls::client::TlsStream as Tokio03RustlsTlsStream;
 
 #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
 use super::InnerTlsParameters;
@@ -38,15 +42,21 @@ enum InnerAsyncNetworkStream {
     /// Plain Tokio 0.2 TCP stream
     #[cfg(feature = "tokio02")]
     Tokio02Tcp(Tokio02TcpStream),
-    /// Encrypted TCP stream
+    /// Encrypted Tokio 0.2 TCP stream
     #[cfg(feature = "tokio02-native-tls")]
-    Tokio02NativeTls(TlsStream<Tokio02TcpStream>),
-    /// Encrypted TCP stream
+    Tokio02NativeTls(Tokio02TlsStream<Tokio02TcpStream>),
+    /// Encrypted Tokio 0.2 TCP stream
     #[cfg(feature = "tokio02-rustls-tls")]
-    Tokio02RustlsTls(Box<RustlsTlsStream<Tokio02TcpStream>>),
+    Tokio02RustlsTls(Box<Tokio02RustlsTlsStream<Tokio02TcpStream>>),
     /// Plain Tokio 0.3 TCP stream
     #[cfg(feature = "tokio03")]
     Tokio03Tcp(Tokio03TcpStream),
+    /// Encrypted Tokio 0.3 TCP stream
+    #[cfg(feature = "tokio03-native-tls")]
+    Tokio03NativeTls(Tokio03TlsStream<Tokio03TcpStream>),
+    /// Encrypted Tokio 0.3 TCP stream
+    #[cfg(feature = "tokio03-rustls-tls")]
+    Tokio03RustlsTls(Box<Tokio03RustlsTlsStream<Tokio03TcpStream>>),
     /// Can't be built
     None,
 }
@@ -73,6 +83,12 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio02RustlsTls(ref s) => s.get_ref().0.peer_addr(),
             #[cfg(feature = "tokio03")]
             InnerAsyncNetworkStream::Tokio03Tcp(ref s) => s.peer_addr(),
+            #[cfg(feature = "tokio03-native-tls")]
+            InnerAsyncNetworkStream::Tokio03NativeTls(ref s) => {
+                s.get_ref().get_ref().get_ref().peer_addr()
+            }
+            #[cfg(feature = "tokio03-rustls-tls")]
+            InnerAsyncNetworkStream::Tokio03RustlsTls(ref s) => s.get_ref().0.peer_addr(),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
                 Err(IoError::new(
@@ -96,6 +112,12 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio02RustlsTls(ref s) => s.get_ref().0.shutdown(how),
             #[cfg(feature = "tokio03")]
             InnerAsyncNetworkStream::Tokio03Tcp(ref s) => s.shutdown(how),
+            #[cfg(feature = "tokio03-native-tls")]
+            InnerAsyncNetworkStream::Tokio03NativeTls(ref s) => {
+                s.get_ref().get_ref().get_ref().shutdown(how)
+            }
+            #[cfg(feature = "tokio03-rustls-tls")]
+            InnerAsyncNetworkStream::Tokio03RustlsTls(ref s) => s.get_ref().0.shutdown(how),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
                 Ok(())
@@ -156,8 +178,27 @@ impl AsyncNetworkStream {
                 self.inner = Self::upgrade_tokio02_tls(tcp_stream, tls_parameters).await?;
                 Ok(())
             }
-            #[cfg(feature = "tokio03")]
-            InnerAsyncNetworkStream::Tokio03Tcp(_) => unimplemented!(),
+            #[cfg(all(
+                feature = "tokio03",
+                not(any(feature = "tokio03-native-tls", feature = "tokio03-rustls-tls"))
+            ))]
+            InnerAsyncNetworkStream::Tokio03Tcp(_) => {
+                let _ = tls_parameters;
+                panic!("Trying to upgrade an AsyncNetworkStream without having enabled either the tokio03-native-tls or the tokio03-rustls-tls feature");
+            }
+
+            #[cfg(any(feature = "tokio03-native-tls", feature = "tokio03-rustls-tls"))]
+            InnerAsyncNetworkStream::Tokio03Tcp(_) => {
+                // get owned TcpStream
+                let tcp_stream = std::mem::replace(&mut self.inner, InnerAsyncNetworkStream::None);
+                let tcp_stream = match tcp_stream {
+                    InnerAsyncNetworkStream::Tokio03Tcp(tcp_stream) => tcp_stream,
+                    _ => unreachable!(),
+                };
+
+                self.inner = Self::upgrade_tokio03_tls(tcp_stream, tls_parameters).await?;
+                Ok(())
+            }
             _ => Ok(()),
         }
     }
@@ -204,6 +245,48 @@ impl AsyncNetworkStream {
         }
     }
 
+    #[allow(unused_variables)]
+    #[cfg(any(feature = "tokio03-native-tls", feature = "tokio03-rustls-tls"))]
+    async fn upgrade_tokio03_tls(
+        tcp_stream: Tokio03TcpStream,
+        mut tls_parameters: TlsParameters,
+    ) -> Result<InnerAsyncNetworkStream, Error> {
+        let domain = std::mem::take(&mut tls_parameters.domain);
+
+        match tls_parameters.connector {
+            #[cfg(feature = "native-tls")]
+            InnerTlsParameters::NativeTls(connector) => {
+                #[cfg(not(feature = "tokio03-native-tls"))]
+                panic!("built without the tokio03-native-tls feature");
+
+                #[cfg(feature = "tokio03-native-tls")]
+                return {
+                    use tokio03_native_tls_crate::TlsConnector;
+
+                    let connector = TlsConnector::from(connector);
+                    let stream = connector.connect(&domain, tcp_stream).await?;
+                    Ok(InnerAsyncNetworkStream::Tokio03NativeTls(stream))
+                };
+            }
+            #[cfg(feature = "rustls-tls")]
+            InnerTlsParameters::RustlsTls(config) => {
+                #[cfg(not(feature = "tokio03-rustls-tls"))]
+                panic!("built without the tokio03-rustls-tls feature");
+
+                #[cfg(feature = "tokio03-rustls-tls")]
+                return {
+                    use tokio03_rustls::{webpki::DNSNameRef, TlsConnector};
+
+                    let domain = DNSNameRef::try_from_ascii_str(&domain)?;
+
+                    let connector = TlsConnector::from(Arc::new(config));
+                    let stream = connector.connect(domain, tcp_stream).await?;
+                    Ok(InnerAsyncNetworkStream::Tokio03RustlsTls(Box::new(stream)))
+                };
+            }
+        }
+    }
+
     pub fn is_encrypted(&self) -> bool {
         match self.inner {
             #[cfg(feature = "tokio02")]
@@ -214,6 +297,10 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio02RustlsTls(_) => true,
             #[cfg(feature = "tokio03")]
             InnerAsyncNetworkStream::Tokio03Tcp(_) => false,
+            #[cfg(feature = "tokio03-native-tls")]
+            InnerAsyncNetworkStream::Tokio03NativeTls(_) => true,
+            #[cfg(feature = "tokio03-rustls-tls")]
+            InnerAsyncNetworkStream::Tokio03RustlsTls(_) => true,
             InnerAsyncNetworkStream::None => false,
         }
     }
@@ -234,6 +321,24 @@ impl futures_io::AsyncRead for AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio02RustlsTls(ref mut s) => Pin::new(s).poll_read(cx, buf),
             #[cfg(feature = "tokio03")]
             InnerAsyncNetworkStream::Tokio03Tcp(ref mut s) => {
+                let mut b = Tokio03ReadBuf::new(buf);
+                match Pin::new(s).poll_read(cx, &mut b) {
+                    Poll::Ready(Ok(())) => Poll::Ready(Ok(b.filled().len())),
+                    Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+            #[cfg(feature = "tokio03-native-tls")]
+            InnerAsyncNetworkStream::Tokio03NativeTls(ref mut s) => {
+                let mut b = Tokio03ReadBuf::new(buf);
+                match Pin::new(s).poll_read(cx, &mut b) {
+                    Poll::Ready(Ok(())) => Poll::Ready(Ok(b.filled().len())),
+                    Poll::Ready(Err(err)) => Poll::Ready(Err(err)),
+                    Poll::Pending => Poll::Pending,
+                }
+            }
+            #[cfg(feature = "tokio03-rustls-tls")]
+            InnerAsyncNetworkStream::Tokio03RustlsTls(ref mut s) => {
                 let mut b = Tokio03ReadBuf::new(buf);
                 match Pin::new(s).poll_read(cx, &mut b) {
                     Poll::Ready(Ok(())) => Poll::Ready(Ok(b.filled().len())),
@@ -264,6 +369,10 @@ impl futures_io::AsyncWrite for AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio02RustlsTls(ref mut s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(feature = "tokio03")]
             InnerAsyncNetworkStream::Tokio03Tcp(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "tokio03-native-tls")]
+            InnerAsyncNetworkStream::Tokio03NativeTls(ref mut s) => Pin::new(s).poll_write(cx, buf),
+            #[cfg(feature = "tokio03-rustls-tls")]
+            InnerAsyncNetworkStream::Tokio03RustlsTls(ref mut s) => Pin::new(s).poll_write(cx, buf),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
                 Poll::Ready(Ok(0))
@@ -281,6 +390,10 @@ impl futures_io::AsyncWrite for AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio02RustlsTls(ref mut s) => Pin::new(s).poll_flush(cx),
             #[cfg(feature = "tokio03")]
             InnerAsyncNetworkStream::Tokio03Tcp(ref mut s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "tokio03-native-tls")]
+            InnerAsyncNetworkStream::Tokio03NativeTls(ref mut s) => Pin::new(s).poll_flush(cx),
+            #[cfg(feature = "tokio03-rustls-tls")]
+            InnerAsyncNetworkStream::Tokio03RustlsTls(ref mut s) => Pin::new(s).poll_flush(cx),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
                 Poll::Ready(Ok(()))

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -24,9 +24,9 @@
 #[cfg(feature = "serde")]
 use std::fmt::Debug;
 
-#[cfg(feature = "tokio02")]
+#[cfg(any(feature = "tokio02", feature = "tokio03"))]
 pub(crate) use self::async_connection::AsyncSmtpConnection;
-#[cfg(feature = "tokio02")]
+#[cfg(any(feature = "tokio02", feature = "tokio03"))]
 pub(crate) use self::async_net::AsyncNetworkStream;
 use self::net::NetworkStream;
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
@@ -37,9 +37,9 @@ pub use self::{
     tls::{Certificate, Tls, TlsParameters, TlsParametersBuilder},
 };
 
-#[cfg(feature = "tokio02")]
+#[cfg(any(feature = "tokio02", feature = "tokio03"))]
 mod async_connection;
-#[cfg(feature = "tokio02")]
+#[cfg(any(feature = "tokio02", feature = "tokio03"))]
 mod async_net;
 mod connection;
 mod mock;

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -126,15 +126,6 @@ impl TlsParametersBuilder {
         return self.build_rustls();
     }
 
-    #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
-    pub(crate) fn build_tokio02(self) -> Result<TlsParameters, Error> {
-        #[cfg(feature = "tokio02-native-tls")]
-        return self.build_native();
-
-        #[cfg(not(feature = "tokio02-native-tls"))]
-        return self.build_rustls();
-    }
-
     /// Creates a new `TlsParameters` using native-tls with the provided configuration
     #[cfg(feature = "native-tls")]
     #[cfg_attr(docsrs, doc(cfg(feature = "native-tls")))]

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -155,8 +155,12 @@
 //!
 
 #[cfg(feature = "tokio02")]
+pub use self::async_transport::Tokio02Connector;
+#[cfg(feature = "tokio03")]
+pub use self::async_transport::Tokio03Connector;
+#[cfg(any(feature = "tokio02", feature = "tokio03"))]
 pub use self::async_transport::{
-    AsyncSmtpConnector, AsyncSmtpTransport, AsyncSmtpTransportBuilder, Tokio02Connector,
+    AsyncSmtpConnector, AsyncSmtpTransport, AsyncSmtpTransportBuilder,
 };
 #[cfg(feature = "r2d2")]
 pub use self::pool::PoolConfig;
@@ -176,7 +180,7 @@ use crate::transport::smtp::{
 use client::Tls;
 use std::time::Duration;
 
-#[cfg(feature = "tokio02")]
+#[cfg(any(feature = "tokio02", feature = "tokio03"))]
 mod async_transport;
 pub mod authentication;
 pub mod client;


### PR DESCRIPTION
Depends on the following crates being released:

* [x] `tokio-native-tls`
* [x] `tokio-rustls`

Yes, there is a lot of duplication with supporting both tokio 0.2 and tokio0.3, and even more if we end-up supporting async-std in the future. I have a few ideas for a future PR to improve the situation.