### PR TITLE
Replace `unwrap` in doc examples

### DIFF
--- a/src/address/envelope.rs
+++ b/src/address/envelope.rs
@@ -32,10 +32,14 @@ impl Envelope {
     /// # use lettre::Address;
     /// # use lettre::address::Envelope;
     ///
-    /// let sender = Address::from_str("from@email.com").unwrap();
-    /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let sender = Address::from_str("from@email.com")?;
+    /// let recipients = vec![Address::from_str("to@email.com")?];
     ///
     /// let envelope = Envelope::new(Some(sender), recipients);
+    /// # Ok(())
+    /// # }
     /// ```
     ///
     /// # Errors
@@ -60,11 +64,15 @@ impl Envelope {
     /// # use lettre::Address;
     /// # use lettre::address::Envelope;
     ///
-    /// let sender = Address::from_str("from@email.com").unwrap();
-    /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let sender = Address::from_str("from@email.com")?;
+    /// let recipients = vec![Address::from_str("to@email.com")?];
     ///
-    /// let envelope = Envelope::new(Some(sender), recipients.clone()).unwrap();
+    /// let envelope = Envelope::new(Some(sender), recipients.clone())?;
     /// assert_eq!(envelope.to(), recipients.as_slice());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn to(&self) -> &[Address] {
         self.forward_path.as_slice()
@@ -79,14 +87,18 @@ impl Envelope {
     /// # use lettre::Address;
     /// # use lettre::address::Envelope;
     ///
-    /// let sender = Address::from_str("from@email.com").unwrap();
-    /// let recipients = vec![Address::from_str("to@email.com").unwrap()];
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let sender = Address::from_str("from@email.com")?;
+    /// let recipients = vec![Address::from_str("to@email.com")?];
     ///
-    /// let envelope = Envelope::new(Some(sender), recipients.clone()).unwrap();
+    /// let envelope = Envelope::new(Some(sender), recipients.clone())?;
     /// assert!(envelope.from().is_some());
     ///
-    /// let senderless = Envelope::new(None, recipients.clone()).unwrap();
+    /// let senderless = Envelope::new(None, recipients.clone())?;
     /// assert!(senderless.from().is_none());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn from(&self) -> Option<&Address> {
         self.reverse_path.as_ref()

--- a/src/address/types.rs
+++ b/src/address/types.rs
@@ -24,7 +24,11 @@ use std::{
 ///
 /// ```
 /// # use lettre::Address;
-/// let address = Address::new("example", "email.com").unwrap();
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let address = Address::new("example", "email.com")?;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// You can also create an `Address` from a string literal by parsing it:
@@ -32,7 +36,11 @@ use std::{
 /// ```
 /// use std::str::FromStr;
 /// # use lettre::Address;
-/// let address = Address::from_str("example@email.com").unwrap();
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let address = Address::from_str("example@email.com")?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Address {
@@ -86,9 +94,13 @@ impl Address {
     /// ```
     /// use lettre::Address;
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
-    /// let expected: Address = "example@email.com".parse().unwrap();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let address = Address::new("example", "email.com")?;
+    /// let expected: Address = "example@email.com".parse()?;
     /// assert_eq!(expected, address);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new<U: AsRef<str>, D: AsRef<str>>(user: U, domain: D) -> Result<Self, AddressError> {
         (user, domain).try_into()
@@ -101,8 +113,12 @@ impl Address {
     /// ```
     /// use lettre::Address;
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let address = Address::new("example", "email.com")?;
     /// assert_eq!("example", address.user());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn user(&self) -> &str {
         &self.serialized[..self.at_start]
@@ -115,8 +131,12 @@ impl Address {
     /// ```
     /// use lettre::Address;
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let address = Address::new("example", "email.com")?;
     /// assert_eq!("email.com", address.domain());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn domain(&self) -> &str {
         &self.serialized[self.at_start + 1..]

--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -21,15 +21,23 @@ use std::{
 ///
 /// ```
 /// # use lettre::{Address, message::Mailbox};
-/// let address = Address::new("example", "email.com").unwrap();
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let address = Address::new("example", "email.com")?;
 /// let mailbox = Mailbox::new(None, address);
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// You can also create one from a string literal:
 ///
 /// ```
 /// # use lettre::message::Mailbox;
-/// let mailbox: Mailbox = "John Smith <example@email.com>".parse().unwrap();
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
+/// let mailbox: Mailbox = "John Smith <example@email.com>".parse()?;
+/// # Ok(())
+/// # }
 /// ```
 #[derive(Debug, Clone, PartialOrd, Ord, PartialEq, Eq, Hash)]
 pub struct Mailbox {
@@ -48,8 +56,12 @@ impl Mailbox {
     /// ```
     /// use lettre::{Address, message::Mailbox};
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let address = Address::new("example", "email.com")?;
     /// let mailbox = Mailbox::new(None, address);
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn new(name: Option<String>, email: Address) -> Self {
         Mailbox { name, email }
@@ -153,8 +165,12 @@ impl Mailboxes {
     /// ```
     /// use lettre::{Address, message::{Mailbox, Mailboxes}};
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let address = Address::new("example", "email.com")?;
     /// let mut mailboxes = Mailboxes::new().with(Mailbox::new(None, address));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn with(mut self, mbox: Mailbox) -> Self {
         self.0.push(mbox);
@@ -168,9 +184,13 @@ impl Mailboxes {
     /// ```
     /// use lettre::{Address, message::{Mailbox, Mailboxes}};
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
+    /// let address = Address::new("example", "email.com")?;
     /// let mut mailboxes = Mailboxes::new();
     /// mailboxes.push(Mailbox::new(None, address));
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn push(&mut self, mbox: Mailbox) {
         self.0.push(mbox);
@@ -183,14 +203,18 @@ impl Mailboxes {
     /// ```
     /// use lettre::{Address, message::{Mailbox, Mailboxes}};
     ///
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let empty = Mailboxes::new();
     /// assert!(empty.into_single().is_none());
     ///
     /// let mut mailboxes = Mailboxes::new();
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// let address = Address::new("example", "email.com")?;
     ///
     /// mailboxes.push(Mailbox::new(None, address));
     /// assert!(mailboxes.into_single().is_some());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn into_single(self) -> Option<Mailbox> {
         self.into()
@@ -203,12 +227,14 @@ impl Mailboxes {
     /// ```
     /// use lettre::{Address, message::{Mailbox, Mailboxes}};
     ///
+    /// # use std::error::Error;
+    /// # fn main() -> Result<(), Box<dyn Error>> {
     /// let mut mailboxes = Mailboxes::new();
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// let address = Address::new("example", "email.com")?;
     /// mailboxes.push(Mailbox::new(None, address));
     ///
-    /// let address = Address::new("example", "email.com").unwrap();
+    /// let address = Address::new("example", "email.com")?;
     /// mailboxes.push(Mailbox::new(None, address));
     ///
     /// let mut iter = mailboxes.iter();
@@ -217,6 +243,8 @@ impl Mailboxes {
     /// assert!(iter.next().is_some());
     ///
     /// assert!(iter.next().is_none());
+    /// # Ok(())
+    /// # }
     /// ```
     pub fn iter(&self) -> Iter<'_, Mailbox> {
         self.0.iter()

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -90,10 +90,14 @@ impl Default for SinglePartBuilder {
 /// ```
 /// use lettre::message::{SinglePart, header};
 ///
+/// # use std::error::Error;
+/// # fn main() -> Result<(), Box<dyn Error>> {
 /// let part = SinglePart::builder()
-///      .header(header::ContentType("text/plain; charset=utf8".parse().unwrap()))
+///      .header(header::ContentType("text/plain; charset=utf8".parse()?))
 ///      .header(header::ContentTransferEncoding::Binary)
 ///      .body("Текст письма в уникоде");
+/// # Ok(())
+/// # }
 /// ```
 ///
 #[derive(Debug, Clone)]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -15,13 +15,16 @@
 //! ```rust
 //! use lettre::message::Message;
 //!
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! let m = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! Will produce:
@@ -46,19 +49,22 @@
 //! ```rust
 //! use lettre::message::{header, Message, SinglePart, Part};
 //!
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! let m = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
 //!     .singlepart(
 //!         SinglePart::builder()
 //!             .header(header::ContentType(
-//!                 "text/plain; charset=utf8".parse().unwrap(),
+//!                 "text/plain; charset=utf8".parse()?,
 //!             )).header(header::ContentTransferEncoding::QuotedPrintable)
 //!             .body("Привет, мир!"),
-//!     )
-//!     .unwrap();
+//!     )?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! The body will be encoded using selected `Content-Transfer-Encoding`.
@@ -83,10 +89,12 @@
 //! ```rust
 //! use lettre::message::{header, Message, MultiPart, SinglePart, Part};
 //!
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! let m = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
 //!     .multipart(
 //!         MultiPart::mixed()
@@ -94,19 +102,19 @@
 //!             MultiPart::alternative()
 //!             .singlepart(
 //!                 SinglePart::quoted_printable()
-//!                 .header(header::ContentType("text/plain; charset=utf8".parse().unwrap()))
+//!                 .header(header::ContentType("text/plain; charset=utf8".parse()?))
 //!                 .body("Привет, мир!")
 //!             )
 //!             .multipart(
 //!                MultiPart::related()
 //!                 .singlepart(
 //!                     SinglePart::eight_bit()
-//!                     .header(header::ContentType("text/html; charset=utf8".parse().unwrap()))
+//!                     .header(header::ContentType("text/html; charset=utf8".parse()?))
 //!                     .body("<p><b>Hello</b>, <i>world</i>! <img src=smile.png></p>")
 //!                 )
 //!                 .singlepart(
 //!                     SinglePart::base64()
-//!                     .header(header::ContentType("image/png".parse().unwrap()))
+//!                     .header(header::ContentType("image/png".parse()?))
 //!                     .header(header::ContentDisposition {
 //!                         disposition: header::DispositionType::Inline,
 //!                         parameters: vec![],
@@ -117,7 +125,7 @@
 //!         )
 //!         .singlepart(
 //!             SinglePart::seven_bit()
-//!             .header(header::ContentType("text/plain; charset=utf8".parse().unwrap()))
+//!             .header(header::ContentType("text/plain; charset=utf8".parse()?))
 //!             .header(header::ContentDisposition {
 //!                 disposition: header::DispositionType::Attachment,
 //!                 parameters: vec![
@@ -129,7 +137,9 @@
 //!             })
 //!             .body("int main() { return 0; }")
 //!         )
-//!     ).unwrap();
+//!     )?;
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ```sh

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -28,7 +28,7 @@
 //! ## Async tokio 0.2
 //!
 //! ```rust
-//! # # use std::error::Error;
+//! # use std::error::Error;
 //! # #[cfg(feature = "tokio02")]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -28,6 +28,7 @@
 //! ## Async tokio 0.2
 //!
 //! ```rust
+//! # # use std::error::Error;
 //! # #[cfg(feature = "tokio02")]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
@@ -51,6 +52,7 @@
 //! ## Async async-std 1.x
 //!
 //! ```rust
+//! # use std::error::Error;
 //! # #[cfg(feature = "async-std1")]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -8,40 +8,43 @@
 //! use std::env::temp_dir;
 //! use lettre::{Transport, Message, FileTransport};
 //!
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! // Write to the local temp directory
 //! let sender = FileTransport::new(temp_dir());
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Async tokio 0.2
 //!
 //! ```rust
 //! # #[cfg(feature = "tokio02")]
-//! # async fn run() {
+//! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
 //! use lettre::{Tokio02Transport, Message, FileTransport};
 //!
 //! // Write to the local temp directory
 //! let sender = FileTransport::new(temp_dir());
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
+//! # Ok(())
 //! # }
 //! ```
 //!
@@ -49,22 +52,22 @@
 //!
 //! ```rust
 //! # #[cfg(feature = "async-std1")]
-//! # async fn run() {
+//! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
 //! use lettre::{AsyncStd1Transport, Message, FileTransport};
 //!
 //! // Write to the local temp directory
 //! let sender = FileTransport::new(temp_dir());
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -5,58 +5,63 @@
 //! ```rust
 //! use lettre::{Message, Transport, SendmailTransport};
 //!
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let sender = SendmailTransport::new();
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! ## Async tokio 0.2 example
 //!
 //! ```rust
+//! # use std::error::Error;
 //! # #[cfg(feature = "tokio02")]
-//! # async fn run() {
+//! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, Tokio02Transport, SendmailTransport};
 //!
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let sender = SendmailTransport::new();
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
+//! # Ok(())
 //! # }
 //! ```
 //!
 //! ## Async async-std 1.x example
 //!
 //!```rust
+//! # use std::error::Error;
 //! # #[cfg(feature = "async-std1")]
-//! # async fn run() {
+//! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, AsyncStd1Transport, SendmailTransport};
 //!
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let sender = SendmailTransport::new();
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
+//! # Ok(())
 //! # }
 //! ```
 

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -4,20 +4,22 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(feature = "smtp-transport")]
-//! # {
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! use lettre::transport::smtp::{SMTP_PORT, extension::ClientId, commands::*, client::SmtpConnection};
 //!
 //! let hello = ClientId::Domain("my_hostname".to_string());
-//! let mut client = SmtpConnection::connect(&("localhost", SMTP_PORT), None, &hello, None).unwrap();
+//! let mut client = SmtpConnection::connect(&("localhost", SMTP_PORT), None, &hello, None)?;
 //! client.command(
-//!         Mail::new(Some("user@example.com".parse().unwrap()), vec![])
-//!     ).unwrap();
+//!         Mail::new(Some("user@example.com".parse()?), vec![])
+//!     )?;
 //! client.command(
-//!         Rcpt::new("user@example.org".parse().unwrap(), vec![])
-//!       ).unwrap();
-//! client.command(Data).unwrap();
-//! client.message("Test email".as_bytes()).unwrap();
-//! client.command(Quit).unwrap();
+//!         Rcpt::new("user@example.org".parse()?, vec![])
+//!       )?;
+//! client.command(Data)?;
+//! client.message("Test email".as_bytes())?;
+//! client.command(Quit)?;
+//! # Ok(())
 //! # }
 //! ```
 

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -32,7 +32,7 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-//! # {
+//! # fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! use lettre::{Message, Transport, SmtpTransport};
 //!
 //! let email = Message::builder()
@@ -49,6 +49,7 @@
 //! // Send the email via remote relay
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
+//! # Ok(())
 //! # }
 //! ```
 

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -31,9 +31,8 @@
 //! This is the most basic example of usage:
 //!
 //! ```rust,no_run
-//! # use std::error::Error;
 //! # #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-//! # fn main() -> Result<(), Box<dyn Error>> {
+//! # {
 //! use lettre::{Message, Transport, SmtpTransport};
 //!
 //! let email = Message::builder()
@@ -50,7 +49,6 @@
 //! // Send the email via remote relay
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
-//! # Ok(())
 //! # }
 //! ```
 

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -31,8 +31,8 @@
 //! This is the most basic example of usage:
 //!
 //! ```rust,no_run
-//! # #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 //! # use std::error::Error;
+//! # #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 //! # fn main() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, Transport, SmtpTransport};
 //!

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -32,16 +32,16 @@
 //!
 //! ```rust,no_run
 //! # #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-//! # {
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, Transport, SmtpTransport};
 //!
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! // Create TLS transport on port 465
 //! let sender = SmtpTransport::relay("smtp.example.com")
@@ -50,6 +50,7 @@
 //! // Send the email via remote relay
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
+//! # Ok(())
 //! # }
 //! ```
 
@@ -64,24 +65,24 @@
 //!
 //! let email_1 = Email::new(
 //!     Envelope::new(
-//!         Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
-//!         vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
-//!     ).unwrap(),
+//!         Some(EmailAddress::new("user@localhost".to_string())?),
+//!         vec![EmailAddress::new("root@localhost".to_string())?],
+//!     )?,
 //!     "id1".to_string(),
 //!     "Hello world".to_string().into_bytes(),
 //! );
 //!
 //! let email_2 = Email::new(
 //!     Envelope::new(
-//!         Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
-//!         vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
-//!     ).unwrap(),
+//!         Some(EmailAddress::new("user@localhost".to_string())?),
+//!         vec![EmailAddress::new("root@localhost".to_string())?],
+//!     )?,
 //!     "id2".to_string(),
 //!     "Hello world a second time".to_string().into_bytes(),
 //! );
 //!
 //! // Connect to a remote server on a custom port
-//! let mut mailer = SmtpClient::new_simple("server.tld").unwrap()
+//! let mut mailer = SmtpClient::new_simple("server.tld")?
 //!    // Set the name sent during EHLO/HELO, default is `localhost`
 //!    .hello_name(ClientId::Domain("my.hostname.tld".to_string()))
 //!    // Add credentials for authentication
@@ -120,9 +121,9 @@
 //!
 //!     let email = Email::new(
 //!         Envelope::new(
-//!             Some(EmailAddress::new("user@localhost".to_string()).unwrap()),
-//!             vec![EmailAddress::new("root@localhost".to_string()).unwrap()],
-//!         ).unwrap(),
+//!             Some(EmailAddress::new("user@localhost".to_string())?),
+//!             vec![EmailAddress::new("root@localhost".to_string())?],
+//!         )?,
 //!         "message_id".to_string(),
 //!         "Hello world".to_string().into_bytes(),
 //!     );
@@ -132,12 +133,12 @@
 //!     let tls_parameters =
 //!         ClientTlsParameters::new(
 //!             "smtp.example.com".to_string(),
-//!             tls_builder.build().unwrap()
+//!             tls_builder.build()?
 //!         );
 //!
 //!     let mut mailer = SmtpClient::new(
 //!         ("smtp.example.com", 465), ClientSecurity::Wrapper(tls_parameters)
-//!     ).unwrap()
+//!     )?
 //!         .authentication_mechanism(Mechanism::Login)
 //!         .credentials(Credentials::new(
 //!             "example_username".to_string(), "example_password".to_string()

--- a/src/transport/stub/mod.rs
+++ b/src/transport/stub/mod.rs
@@ -10,17 +10,20 @@
 //! use lettre::{Message, Transport};
 //! use lettre::transport::stub::StubTransport;
 //!
+//! # use std::error::Error;
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! let email = Message::builder()
-//!     .from("NoBody <nobody@domain.tld>".parse().unwrap())
-//!     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
-//!     .to("Hei <hei@domain.tld>".parse().unwrap())
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")
-//!     .unwrap();
+//!     .body("Be happy!")?;
 //!
 //! let mut sender = StubTransport::new_ok();
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
+//! # Ok(())
+//! # }
 //! ```
 
 use crate::address::Envelope;


### PR DESCRIPTION
To complete one of the items on the list in #467, this PR replaces any `unwrap` calls in documentation examples by `?`.