### PR TITLE
Add deps.rs badge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "lettre"
-version = "0.10.0-alpha.3" # remember to update html_root_url and README.md
+# remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
+version = "0.10.0-alpha.3"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@
   </a>
 </div>
 
+<div align="center">
+  <a href="https://deps.rs/crate/lettre/0.10.0-alpha.3">
+    <img src="https://deps.rs/crate/lettre/0.10.0-alpha.3/status.svg"
+      alt="dependency status" />
+  </a>
+</div>
+
 ---
 
 **NOTE**: this readme refers to the 0.10 version of lettre, which is


### PR DESCRIPTION
[deps.rs](https://deps.rs) has recently been resurrected, and we depend on many dependencies, so we probably want to keep track of the dependency status