### PR TITLE
feat(email): relax email version requirement in 0.9 series

### DIFF
--- a/lettre_email/Cargo.toml
+++ b/lettre_email/Cargo.toml
@@ -23,7 +23,7 @@ lettre = { version = "^0.9", path = "../lettre", features = ["smtp-transport"] }
 glob = "0.3"
 
 [dependencies]
-email = "^0.0.20"
+email = ">=0.0.20, <0.0.22"
 mime = "^0.3"
 time = "^0.1"
 uuid = { version = "^0.7", features = ["v4"] }


### PR DESCRIPTION
Allow the use of `lettre 0.9` together with version `0.0.21` of the email crate.

fixes #506 