### PR TITLE
message: more body improvements

### DIFF
--- a/benches/transport_smtp.rs
+++ b/benches/transport_smtp.rs
@@ -13,7 +13,7 @@ fn bench_simple_send(c: &mut Criterion) {
                 .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
                 .to("Hei <hei@domain.tld>".parse().unwrap())
                 .subject("Happy new year")
-                .body("Be happy!")
+                .body(String::from("Be happy!"))
                 .unwrap();
             let result = black_box(sender.send(&email));
             assert!(result.is_ok());
@@ -32,7 +32,7 @@ fn bench_reuse_send(c: &mut Criterion) {
                 .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
                 .to("Hei <hei@domain.tld>".parse().unwrap())
                 .subject("Happy new year")
-                .body("Be happy!")
+                .body(String::from("Be happy!"))
                 .unwrap();
             let result = black_box(sender.send(&email));
             assert!(result.is_ok());

--- a/examples/smtp.rs
+++ b/examples/smtp.rs
@@ -8,7 +8,7 @@ fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new year")
-        .body("Be happy!")
+        .body(String::from("Be happy!"))
         .unwrap();
 
     // Open a local connection on port 25

--- a/examples/smtp_selfsigned.rs
+++ b/examples/smtp_selfsigned.rs
@@ -14,7 +14,7 @@ fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new year")
-        .body("Be happy!")
+        .body(String::from("Be happy!"))
         .unwrap();
 
     // Use a custom certificate stored on disk to securely verify the server's certificate

--- a/examples/smtp_starttls.rs
+++ b/examples/smtp_starttls.rs
@@ -8,7 +8,7 @@ fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new year")
-        .body("Be happy!")
+        .body(String::from("Be happy!"))
         .unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());

--- a/examples/smtp_tls.rs
+++ b/examples/smtp_tls.rs
@@ -8,7 +8,7 @@ fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new year")
-        .body("Be happy!")
+        .body(String::from("Be happy!"))
         .unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());

--- a/examples/tokio02_smtp_starttls.rs
+++ b/examples/tokio02_smtp_starttls.rs
@@ -17,7 +17,7 @@ async fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new async year")
-        .body("Be happy with async!")
+        .body(String::from("Be happy with async!"))
         .unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());

--- a/examples/tokio02_smtp_tls.rs
+++ b/examples/tokio02_smtp_tls.rs
@@ -17,7 +17,7 @@ async fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new async year")
-        .body("Be happy with async!")
+        .body(String::from("Be happy with async!"))
         .unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());

--- a/examples/tokio03_smtp_starttls.rs
+++ b/examples/tokio03_smtp_starttls.rs
@@ -17,7 +17,7 @@ async fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new async year")
-        .body("Be happy with async!")
+        .body(String::from("Be happy with async!"))
         .unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());

--- a/examples/tokio03_smtp_tls.rs
+++ b/examples/tokio03_smtp_tls.rs
@@ -17,7 +17,7 @@ async fn main() {
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
         .subject("Happy new async year")
-        .body("Be happy with async!")
+        .body(String::from("Be happy with async!"))
         .unwrap();
 
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -19,7 +19,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
@@ -51,7 +51,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let result = sender.send(&email);
 //! assert!(result.is_ok());
@@ -79,7 +79,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
@@ -104,7 +104,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -14,7 +14,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let sender = SendmailTransport::new();
 //! let result = sender.send(&email);
@@ -40,7 +40,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let sender = SendmailTransport::new();
 //! let result = sender.send(email).await;
@@ -63,7 +63,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let sender = SendmailTransport::new();
 //! let result = sender.send(email).await;

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -40,7 +40,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! // Create TLS transport on port 465
 //! let sender = SmtpTransport::relay("smtp.example.com")

--- a/src/transport/stub/mod.rs
+++ b/src/transport/stub/mod.rs
@@ -19,7 +19,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
-//!     .body("Be happy!")?;
+//!     .body(String::from("Be happy!"))?;
 //!
 //! let mut sender = StubTransport::new_ok();
 //! let result = sender.send(&email);

--- a/testdata/email_with_png.eml
+++ b/testdata/email_with_png.eml
@@ -7,15 +7,15 @@ MIME-Version: 1.0
 Content-Type: multipart/related; boundary="kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec"
 
 --kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec
-Content-Transfer-Encoding: 8bit
 Content-Type: text/html; charset=utf8
+Content-Transfer-Encoding: 7bit
 
 <p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>
 --kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec
-Content-Transfer-Encoding: base64
 Content-Type: image/png
 Content-Disposition: inline
 Content-ID: <123>
+Content-Transfer-Encoding: base64
 
 iVBORw0KGgoAAAANSUhEUgAAA+gAAAPoCAYAAABNo9TkAAAACXBIWXMAASdGAAEnRgHWSSfaAAAA
 GXRFWHRTb2Z0d2FyZQB3d3cuaW5rc2NhcGUub3Jnm+48GgAAIABJREFUeJzs3WmMlfXd//HvzLAO

--- a/tests/transport_file.rs
+++ b/tests/transport_file.rs
@@ -20,7 +20,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(&email);
@@ -31,7 +31,17 @@ mod test {
 
         assert_eq!(
             eml,
-            "From: NoBody <nobody@domain.tld>\r\nReply-To: Yuin <yuin@domain.tld>\r\nTo: Hei <hei@domain.tld>\r\nSubject: Happy new year\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\nBe happy!");
+            concat!(
+                "From: NoBody <nobody@domain.tld>\r\n",
+                "Reply-To: Yuin <yuin@domain.tld>\r\n",
+                "To: Hei <hei@domain.tld>\r\n",
+                "Subject: Happy new year\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n",
+                "Content-Transfer-Encoding: 7bit\r\n",
+                "\r\n",
+                "Be happy!"
+            )
+        );
         remove_file(eml_file).unwrap();
     }
 
@@ -46,7 +56,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(&email);
@@ -60,7 +70,17 @@ mod test {
 
         assert_eq!(
             eml,
-            "From: NoBody <nobody@domain.tld>\r\nReply-To: Yuin <yuin@domain.tld>\r\nTo: Hei <hei@domain.tld>\r\nSubject: Happy new year\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\nBe happy!");
+            concat!(
+                "From: NoBody <nobody@domain.tld>\r\n",
+                "Reply-To: Yuin <yuin@domain.tld>\r\n",
+                "To: Hei <hei@domain.tld>\r\n",
+                "Subject: Happy new year\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n",
+                "Content-Transfer-Encoding: 7bit\r\n",
+                "\r\n",
+                "Be happy!"
+            )
+        );
         remove_file(eml_file).unwrap();
 
         assert_eq!(
@@ -82,7 +102,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(email).await;
@@ -93,7 +113,17 @@ mod test {
 
         assert_eq!(
             eml,
-            "From: NoBody <nobody@domain.tld>\r\nReply-To: Yuin <yuin@domain.tld>\r\nTo: Hei <hei@domain.tld>\r\nSubject: Happy new year\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\nBe happy!");
+            concat!(
+                "From: NoBody <nobody@domain.tld>\r\n",
+                "Reply-To: Yuin <yuin@domain.tld>\r\n",
+                "To: Hei <hei@domain.tld>\r\n",
+                "Subject: Happy new year\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n",
+                "Content-Transfer-Encoding: 7bit\r\n",
+                "\r\n",
+                "Be happy!"
+            )
+        );
         remove_file(eml_file).unwrap();
     }
 
@@ -109,7 +139,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(email).await;
@@ -120,7 +150,17 @@ mod test {
 
         assert_eq!(
             eml,
-            "From: NoBody <nobody@domain.tld>\r\nReply-To: Yuin <yuin@domain.tld>\r\nTo: Hei <hei@domain.tld>\r\nSubject: Happy new year\r\nDate: Tue, 15 Nov 1994 08:12:31 GMT\r\n\r\nBe happy!");
+            concat!(
+                "From: NoBody <nobody@domain.tld>\r\n",
+                "Reply-To: Yuin <yuin@domain.tld>\r\n",
+                "To: Hei <hei@domain.tld>\r\n",
+                "Subject: Happy new year\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 GMT\r\n",
+                "Content-Transfer-Encoding: 7bit\r\n",
+                "\r\n",
+                "Be happy!"
+            )
+        );
         remove_file(eml_file).unwrap();
     }
 }

--- a/tests/transport_sendmail.rs
+++ b/tests/transport_sendmail.rs
@@ -15,7 +15,7 @@ mod test {
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(&email);
@@ -35,7 +35,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(email).await;
@@ -54,7 +54,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         let result = sender.send(email).await;

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -10,7 +10,7 @@ mod test {
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
         SmtpTransport::builder_dangerous("127.0.0.1")
             .port(2525)

--- a/tests/transport_stub.rs
+++ b/tests/transport_stub.rs
@@ -16,7 +16,7 @@ mod test {
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         sender_ok.send(&email).unwrap();
@@ -36,7 +36,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         sender_ok.send(email.clone()).await.unwrap();
@@ -56,7 +56,7 @@ mod test {
             .to("Hei <hei@domain.tld>".parse().unwrap())
             .subject("Happy new year")
             .date("Tue, 15 Nov 1994 08:12:31 GMT".parse().unwrap())
-            .body("Be happy!")
+            .body(String::from("Be happy!"))
             .unwrap();
 
         sender_ok.send(email.clone()).await.unwrap();


### PR DESCRIPTION
Makes the `MessageBuilder::body` more useful.

Also improves `Body` to be more efficient, by allowing an already encoded `Body` to be reused, instead of encoding it when the email actually gets encoded.

Deprecates `SinglePart::seven_bit`, `SinglePart::quoted_printable`, `SinglePart::base64` and `SinglePart::eight_bit`, since most users shouldn't probably care about which `Content-Transfer-Encoding` gets used.