### PR TITLE
message: generate a shorter multipart boundary

### DIFF
--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -199,7 +199,7 @@ pub enum MultiPartKind {
 fn make_boundary() -> String {
     rand::thread_rng()
         .sample_iter(&rand::distributions::Alphanumeric)
-        .take(68)
+        .take(40)
         .collect()
 }
 
@@ -772,7 +772,7 @@ mod test {
 
         // Ensure correct length
         for boundary in boundaries {
-            assert_eq!(68, boundary.len());
+            assert_eq!(40, boundary.len());
         }
     }
 }

--- a/testdata/email_with_png.eml
+++ b/testdata/email_with_png.eml
@@ -4,14 +4,14 @@ Reply-To: Yuin <yuin@domain.tld>
 To: Hei <hei@domain.tld>
 Subject: Happy new year
 MIME-Version: 1.0
-Content-Type: multipart/related; boundary="kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec"
+Content-Type: multipart/related; boundary="0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1"
 
---kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec
+--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1
 Content-Type: text/html; charset=utf8
 Content-Transfer-Encoding: 7bit
 
 <p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>
---kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec
+--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1
 Content-Type: image/png
 Content-Disposition: inline
 Content-ID: <123>
@@ -230,4 +230,4 @@ AAAACQh0AAAASECgAwAAQAICHQAAABIQ6AAAAJCAQAcAAIAEBDoAAAAkINABAAAgAYEOAAAACQh0
 AAAASECgAwAAQAICHQAAABIQ6AAAAJCAQAcAAIAEBDoAAAAkINABAAAgAYEOAAAACQh0AAAASECg
 AwAAQAICHQAAABIQ6AAAAJCAQAcAAIAEBDoAAAAkINABAAAgAYEOAAAACQh0AAAASECgAwAAQAIC
 HQAAABIQ6AAAAJDAfwHNjj3TR6+CggAAAABJRU5ErkJggg==
---kve7WTqtIDDNFzED8Dccv2dHCJYXcEwETTAaIYCAcfn6lxvHldUc21nczexPKCfoDVec--
+--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1--


### PR DESCRIPTION
Fixes https://tools.ietf.org/tools/msglint/ warning about the Content-Type header being too long.

I looked at many emails I received over time and I couldn't find any with a boundary as long as ours, so this isn't only justified by making some tool happy.