### PR TITLE
Reduce regex features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand = { version = "0.7", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
 once_cell = "1"
-regex = "1"
+regex = { version = "1", default-features = false, features = ["std"] }
 
 # file transport
 serde = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
We only need it for `Address::from_str`

I did a quick benchmark, making it parse my email address. The speed regressed by ~2000%, but ~4 us (vs ~150 ns with default features) is still very fast so I think the reduced number of dependencies and faster compile time justifies it.

Benchmark code:

```rust
use criterion::{black_box, criterion_group, criterion_main, Criterion};
use lettre::Address;

fn bench_parse(c: &mut Criterion) {
    let email = String::from("paolo@paolo565.org");

    c.bench_function("address", move |b| {
        b.iter(|| {
            let email = black_box(email.as_str());
            let address: Address = email.parse().unwrap();
            assert_eq!(address.user(), "paolo");
            assert_eq!(address.domain(), "paolo565.org");
        })
    });
}

criterion_group!(benches, bench_parse);
criterion_main!(benches);
```