### PR TITLE
Update rand to 0.8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1.16", default-features = false, features = ["std"], op
 hyperx = { version = "1", optional = true, features = ["headers"] }
 mime = { version = "0.3", optional = true }
 uuid = { version = "0.8", features = ["v4"] }
-rand = { version = "0.7", optional = true }
+rand = { version = "0.8", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
 once_cell = "1"

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -198,8 +198,9 @@ pub enum MultiPartKind {
 /// Create a random MIME boundary.
 fn make_boundary() -> String {
     rand::thread_rng()
-        .sample_iter(&rand::distributions::Alphanumeric)
+        .sample_iter(rand::distributions::Alphanumeric)
         .take(40)
+        .map(char::from)
         .collect()
 }
 


### PR DESCRIPTION
Prepares for rand 0.8 upgrade.

We should probably wait for a few other crates to depend on an updated version before merging.

Crates using `rand` (ignore the ones using it as a dev dependency): https://lib.rs/crates/rand/rev