### PR TITLE
Update to tokio 1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ Several breaking changes were made between 0.9 and 0.10, but changes should be s
 
 #### Features
 
-* Add `tokio` 0.2 and 0.3 support
+* Add `tokio` 0.2 and 1.0 support
 * Add `rustls` support
 * Add `async-std` support
 * Allow enabling multiple SMTP authentication mechanisms

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,9 +59,9 @@ async-trait = { version = "0.1", optional = true }
 tokio02_crate = { package = "tokio", version = "0.2.7", features = ["fs", "process", "tcp", "dns", "io-util"], optional = true }
 tokio02_native_tls_crate = { package = "tokio-native-tls", version = "0.1", optional = true }
 tokio02_rustls = { package = "tokio-rustls", version = "0.15", optional = true }
-tokio03_crate = { package = "tokio", version = "0.3", features = ["fs", "process", "net", "io-util"], optional = true }
-tokio03_native_tls_crate = { package = "tokio-native-tls", version = "0.2", optional = true }
-tokio03_rustls = { package = "tokio-rustls", version = "0.21", optional = true }
+tokio1_crate = { package = "tokio", version = "1", features = ["fs", "process", "net", "io-util"], optional = true }
+tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optional = true }
+tokio1_rustls = { package = "tokio-rustls", version = "0.22", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -69,7 +69,7 @@ tracing-subscriber = "0.2.10"
 glob = "0.3"
 walkdir = "2"
 tokio02_crate = { package = "tokio", version = "0.2.7", features = ["macros", "rt-threaded"] }
-tokio03_crate = { package = "tokio", version = "0.3", features = ["macros", "rt-multi-thread"] }
+tokio1_crate = { package = "tokio", version = "1", features = ["macros", "rt-multi-thread"] }
 serde_json = "1"
 maud = "0.22.1"
 
@@ -94,9 +94,9 @@ async-std1 = ["async-std", "async-trait", "async-attributes"]
 tokio02 = ["tokio02_crate", "async-trait", "futures-io", "futures-util"]
 tokio02-native-tls = ["tokio02", "native-tls", "tokio02_native_tls_crate"]
 tokio02-rustls-tls = ["tokio02", "rustls-tls", "tokio02_rustls"]
-tokio03 = ["tokio03_crate", "async-trait", "futures-io", "futures-util"]
-tokio03-native-tls = ["tokio03", "native-tls", "tokio03_native_tls_crate"]
-tokio03-rustls-tls = ["tokio03", "rustls-tls", "tokio03_rustls"]
+tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
+tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
+tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
 [package.metadata.docs.rs]
 all-features = true
@@ -135,10 +135,10 @@ name = "tokio02_smtp_starttls"
 required-features = ["smtp-transport", "tokio02", "tokio02-native-tls", "builder"]
 
 [[example]]
-name = "tokio03_smtp_tls"
-required-features = ["smtp-transport", "tokio03", "tokio03-native-tls", "builder"]
+name = "tokio1_smtp_tls"
+required-features = ["smtp-transport", "tokio1", "tokio1-native-tls", "builder"]
 
 [[example]]
-name = "tokio03_smtp_starttls"
-required-features = ["smtp-transport", "tokio03", "tokio03-native-tls", "builder"]
+name = "tokio1_smtp_starttls"
+required-features = ["smtp-transport", "tokio1", "tokio1-native-tls", "builder"]
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -14,7 +14,7 @@ This folder contains examples showing how to use lettre in your own projects.
 - [smtp_starttls.rs] - Send an email over SMTP with STARTTLS and authenticating with username and password.
 - [smtp_selfsigned.rs] - Send an email over SMTP encrypted with TLS using a self-signed certificate and authenticating with username and password.
 - The [smtp_tls.rs] and [smtp_starttls.rs] examples also feature `async`hronous implementations powered by [Tokio](https://tokio.rs/).
-  These files are prefixed with `tokio02_` or `tokio03_`.
+  These files are prefixed with `tokio02_` or `tokio1_`.
 
 [basic_html.rs]: ./basic_html.rs
 [maud_html.rs]: ./maud_html.rs

--- a/examples/tokio1_smtp_starttls.rs
+++ b/examples/tokio1_smtp_starttls.rs
@@ -1,11 +1,11 @@
 // This line is only to make it compile from lettre's examples folder,
 // since it uses Rust 2018 crate renaming to import tokio.
 // Won't be needed in user's code.
-use tokio03_crate as tokio;
+use tokio1_crate as tokio;
 
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio03Connector,
-    Tokio03Transport,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio1Connector,
+    Tokio1Transport,
 };
 
 #[tokio::main]
@@ -23,7 +23,7 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer = AsyncSmtpTransport::<Tokio03Connector>::starttls_relay("smtp.gmail.com")
+    let mailer = AsyncSmtpTransport::<Tokio1Connector>::starttls_relay("smtp.gmail.com")
         .unwrap()
         .credentials(creds)
         .build();

--- a/examples/tokio1_smtp_tls.rs
+++ b/examples/tokio1_smtp_tls.rs
@@ -1,11 +1,11 @@
 // This line is only to make it compile from lettre's examples folder,
 // since it uses Rust 2018 crate renaming to import tokio.
 // Won't be needed in user's code.
-use tokio03_crate as tokio;
+use tokio1_crate as tokio;
 
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio03Connector,
-    Tokio03Transport,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio1Connector,
+    Tokio1Transport,
 };
 
 #[tokio::main]
@@ -23,7 +23,7 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer = AsyncSmtpTransport::<Tokio03Connector>::relay("smtp.gmail.com")
+    let mailer = AsyncSmtpTransport::<Tokio1Connector>::relay("smtp.gmail.com")
         .unwrap()
         .credentials(creds)
         .build();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,9 +19,9 @@
 //! * **tokio02**: Allow to asyncronously send emails using tokio 0.2.x
 //! * **tokio02-rustls-tls**: Async TLS support with the `rustls` crate using tokio 0.2
 //! * **tokio02-native-tls**: Async TLS support with the `native-tls` crate using tokio 0.2
-//! * **tokio03**: Allow to asyncronously send emails using tokio 0.3.x
-//! * **tokio03-rustls-tls**: Async TLS support with the `rustls` crate using tokio 0.3
-//! * **tokio03-native-tls**: Async TLS support with the `native-tls` crate using tokio 0.3
+//! * **tokio1**: Allow to asyncronously send emails using tokio 1.x
+//! * **tokio1-rustls-tls**: Async TLS support with the `rustls` crate using tokio 1.x
+//! * **tokio1-native-tls**: Async TLS support with the `native-tls` crate using tokio 1.x
 //! * **async-std1**: Allow to asynchronously send emails using async-std 1.x (SMTP isn't supported yet)
 //! * **r2d2**: Connection pool for SMTP transport
 //! * **tracing**: Logging using the `tracing` crate
@@ -64,16 +64,16 @@ pub use crate::transport::file::FileTransport;
 pub use crate::transport::sendmail::SendmailTransport;
 #[cfg(all(
     feature = "smtp-transport",
-    any(feature = "tokio02", feature = "tokio03")
+    any(feature = "tokio02", feature = "tokio1")
 ))]
 pub use crate::transport::smtp::AsyncSmtpTransport;
 #[cfg(feature = "smtp-transport")]
 pub use crate::transport::smtp::SmtpTransport;
 #[cfg(all(feature = "smtp-transport", feature = "tokio02"))]
 pub use crate::transport::smtp::Tokio02Connector;
-#[cfg(all(feature = "smtp-transport", feature = "tokio03"))]
-pub use crate::transport::smtp::Tokio03Connector;
-#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio03"))]
+#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+pub use crate::transport::smtp::Tokio1Connector;
+#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 use async_trait::async_trait;
 
 /// Blocking Transport method for emails
@@ -140,11 +140,11 @@ pub trait Tokio02Transport {
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
 }
 
-/// tokio 0.3.x based Transport method for emails
-#[cfg(feature = "tokio03")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio03")))]
+/// tokio 1.x based Transport method for emails
+#[cfg(feature = "tokio1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
 #[async_trait]
-pub trait Tokio03Transport {
+pub trait Tokio1Transport {
     /// Response produced by the Transport
     type Ok;
     /// Error produced by the Transport

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -62,15 +62,15 @@
 //! # fn main() {}
 //! ```
 //!
-//! ## Async tokio 0.2
+//! ## Async tokio 1.x
 //!
 //! ```rust,no_run
 //! # use std::error::Error;
 //!
-//! # #[cfg(all(feature = "tokio02", feature = "file-transport", feature = "builder"))]
+//! # #[cfg(all(feature = "tokio1", feature = "file-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
-//! use lettre::{Tokio02Transport, Message, FileTransport};
+//! use lettre::{Tokio1Transport, Message, FileTransport};
 //!
 //! // Write to the local temp directory
 //! let sender = FileTransport::new(temp_dir());
@@ -138,10 +138,10 @@ use crate::address::Envelope;
 use crate::AsyncStd1Transport;
 #[cfg(feature = "tokio02")]
 use crate::Tokio02Transport;
-#[cfg(feature = "tokio03")]
-use crate::Tokio03Transport;
+#[cfg(feature = "tokio1")]
+use crate::Tokio1Transport;
 use crate::Transport;
-#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 use async_trait::async_trait;
 use std::{
     path::{Path, PathBuf},
@@ -273,14 +273,14 @@ impl Tokio02Transport for FileTransport {
     }
 }
 
-#[cfg(feature = "tokio03")]
+#[cfg(feature = "tokio1")]
 #[async_trait]
-impl Tokio03Transport for FileTransport {
+impl Tokio1Transport for FileTransport {
     type Ok = Id;
     type Error = Error;
 
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
-        use tokio03_crate::fs;
+        use tokio1_crate::fs;
 
         let email_id = Uuid::new_v4();
 

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -49,6 +49,29 @@
 //! # }
 //! ```
 //!
+//! ## Async tokio 1.x example
+//!
+//! ```rust,no_run
+//! # use std::error::Error;
+//!
+//! # #[cfg(all(feature = "tokio1", feature = "sendmail-transport", feature = "builder"))]
+//! # async fn run() -> Result<(), Box<dyn Error>> {
+//! use lettre::{Message, Tokio1Transport, SendmailTransport};
+//!
+//! let email = Message::builder()
+//!     .from("NoBody <nobody@domain.tld>".parse()?)
+//!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
+//!     .to("Hei <hei@domain.tld>".parse()?)
+//!     .subject("Happy new year")
+//!     .body(String::from("Be happy!"))?;
+//!
+//! let sender = SendmailTransport::new();
+//! let result = sender.send(email).await;
+//! assert!(result.is_ok());
+//! # Ok(())
+//! # }
+//! ```
+//!
 //! ## Async async-std 1.x example
 //!
 //!```rust,no_run
@@ -78,10 +101,10 @@ use crate::address::Envelope;
 use crate::AsyncStd1Transport;
 #[cfg(feature = "tokio02")]
 use crate::Tokio02Transport;
-#[cfg(feature = "tokio03")]
-use crate::Tokio03Transport;
+#[cfg(feature = "tokio1")]
+use crate::Tokio1Transport;
 use crate::Transport;
-#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 use async_trait::async_trait;
 use std::{
     ffi::OsString,
@@ -147,9 +170,9 @@ impl SendmailTransport {
         c
     }
 
-    #[cfg(feature = "tokio03")]
-    fn tokio03_command(&self, envelope: &Envelope) -> tokio03_crate::process::Command {
-        use tokio03_crate::process::Command;
+    #[cfg(feature = "tokio1")]
+    fn tokio1_command(&self, envelope: &Envelope) -> tokio1_crate::process::Command {
+        use tokio1_crate::process::Command;
 
         let mut c = Command::new(&self.command);
         c.kill_on_drop(true);
@@ -260,16 +283,16 @@ impl Tokio02Transport for SendmailTransport {
     }
 }
 
-#[cfg(feature = "tokio03")]
+#[cfg(feature = "tokio1")]
 #[async_trait]
-impl Tokio03Transport for SendmailTransport {
+impl Tokio1Transport for SendmailTransport {
     type Ok = ();
     type Error = Error;
 
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
-        use tokio03_crate::io::AsyncWriteExt;
+        use tokio1_crate::io::AsyncWriteExt;
 
-        let mut command = self.tokio03_command(envelope);
+        let mut command = self.tokio1_command(envelope);
 
         // Spawn the sendmail command
         let mut process = command.spawn()?;

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 use super::Tls;
 use super::{
     client::AsyncSmtpConnection, ClientId, Credentials, Error, Mechanism, Response, SmtpInfo,
@@ -8,8 +8,8 @@ use super::{
 use crate::Envelope;
 #[cfg(feature = "tokio02")]
 use crate::Tokio02Transport;
-#[cfg(feature = "tokio03")]
-use crate::Tokio03Transport;
+#[cfg(feature = "tokio1")]
+use crate::Tokio1Transport;
 
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
@@ -36,9 +36,9 @@ impl Tokio02Transport for AsyncSmtpTransport<Tokio02Connector> {
     }
 }
 
-#[cfg(feature = "tokio03")]
+#[cfg(feature = "tokio1")]
 #[async_trait]
-impl Tokio03Transport for AsyncSmtpTransport<Tokio03Connector> {
+impl Tokio1Transport for AsyncSmtpTransport<Tokio1Connector> {
     type Ok = Response;
     type Error = Error;
 
@@ -67,8 +67,8 @@ where
     #[cfg(any(
         feature = "tokio02-native-tls",
         feature = "tokio02-rustls-tls",
-        feature = "tokio03-native-tls",
-        feature = "tokio03-rustls-tls"
+        feature = "tokio1-native-tls",
+        feature = "tokio1-rustls-tls"
     ))]
     pub fn relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         use super::{TlsParameters, SUBMISSIONS_PORT};
@@ -94,8 +94,8 @@ where
     #[cfg(any(
         feature = "tokio02-native-tls",
         feature = "tokio02-rustls-tls",
-        feature = "tokio03-native-tls",
-        feature = "tokio03-rustls-tls"
+        feature = "tokio1-native-tls",
+        feature = "tokio1-rustls-tls"
     ))]
     pub fn starttls_relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         use super::{TlsParameters, SUBMISSION_PORT};
@@ -170,8 +170,8 @@ impl AsyncSmtpTransportBuilder {
     #[cfg(any(
         feature = "tokio02-native-tls",
         feature = "tokio02-rustls-tls",
-        feature = "tokio03-native-tls",
-        feature = "tokio03-rustls-tls"
+        feature = "tokio1-native-tls",
+        feature = "tokio1-rustls-tls"
     ))]
     pub fn tls(mut self, tls: Tls) -> Self {
         self.info.tls = tls;
@@ -275,13 +275,13 @@ impl AsyncSmtpConnector for Tokio02Connector {
 }
 
 #[derive(Debug, Copy, Clone, Default)]
-#[cfg(feature = "tokio03")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio03")))]
-pub struct Tokio03Connector;
+#[cfg(feature = "tokio1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
+pub struct Tokio1Connector;
 
 #[async_trait]
-#[cfg(feature = "tokio03")]
-impl AsyncSmtpConnector for Tokio03Connector {
+#[cfg(feature = "tokio1")]
+impl AsyncSmtpConnector for Tokio1Connector {
     async fn connect(
         hostname: &str,
         port: u16,
@@ -290,16 +290,15 @@ impl AsyncSmtpConnector for Tokio03Connector {
     ) -> Result<AsyncSmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match tls {
-            #[cfg(any(feature = "tokio03-native-tls", feature = "tokio03-rustls-tls"))]
+            #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
             Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
             _ => None,
         };
         #[allow(unused_mut)]
         let mut conn =
-            AsyncSmtpConnection::connect_tokio03(hostname, port, hello_name, tls_parameters)
-                .await?;
+            AsyncSmtpConnection::connect_tokio1(hostname, port, hello_name, tls_parameters).await?;
 
-        #[cfg(any(feature = "tokio03-native-tls", feature = "tokio03-rustls-tls"))]
+        #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
         match tls {
             Tls::Opportunistic(ref tls_parameters) => {
                 if conn.can_starttls() {
@@ -324,6 +323,6 @@ mod private {
     #[cfg(feature = "tokio02")]
     impl Sealed for Tokio02Connector {}
 
-    #[cfg(feature = "tokio03")]
-    impl Sealed for Tokio03Connector {}
+    #[cfg(feature = "tokio1")]
+    impl Sealed for Tokio1Connector {}
 }

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -62,14 +62,14 @@ impl AsyncSmtpConnection {
     /// Connects to the configured server
     ///
     /// Sends EHLO and parses server information
-    #[cfg(feature = "tokio03")]
-    pub async fn connect_tokio03(
+    #[cfg(feature = "tokio1")]
+    pub async fn connect_tokio1(
         hostname: &str,
         port: u16,
         hello_name: &ClientId,
         tls_parameters: Option<TlsParameters>,
     ) -> Result<AsyncSmtpConnection, Error> {
-        let stream = AsyncNetworkStream::connect_tokio03(hostname, port, tls_parameters).await?;
+        let stream = AsyncNetworkStream::connect_tokio1(hostname, port, tls_parameters).await?;
         Self::connect_impl(stream, hello_name).await
     }
 

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -27,9 +27,9 @@
 #[cfg(feature = "serde")]
 use std::fmt::Debug;
 
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 pub(crate) use self::async_connection::AsyncSmtpConnection;
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 pub(crate) use self::async_net::AsyncNetworkStream;
 use self::net::NetworkStream;
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
@@ -40,9 +40,9 @@ pub use self::{
     tls::{Certificate, Tls, TlsParameters, TlsParametersBuilder},
 };
 
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 mod async_connection;
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 mod async_net;
 mod connection;
 mod mock;

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -156,9 +156,9 @@
 
 #[cfg(feature = "tokio02")]
 pub use self::async_transport::Tokio02Connector;
-#[cfg(feature = "tokio03")]
-pub use self::async_transport::Tokio03Connector;
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(feature = "tokio1")]
+pub use self::async_transport::Tokio1Connector;
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 pub use self::async_transport::{
     AsyncSmtpConnector, AsyncSmtpTransport, AsyncSmtpTransportBuilder,
 };
@@ -181,7 +181,7 @@ use crate::transport::smtp::{
 use client::Tls;
 use std::time::Duration;
 
-#[cfg(any(feature = "tokio02", feature = "tokio03"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1"))]
 mod async_transport;
 pub mod authentication;
 pub mod client;


### PR DESCRIPTION
Since everybody, especially projects depending on tokio 0.3, are upgrading to tokio 1.0, this replaces tokio 0.3 support with tokio 1.0.
Tokio 0.2 support is kept.

Closes #525