### PR TITLE
fix: re-enable unicode-case feature on regex

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ rand = { version = "0.8", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
 once_cell = "1"
-regex = { version = "1", default-features = false, features = ["std"] }
+regex = { version = "1", default-features = false, features = ["std", "unicode-case"] }
 
 # file transport
 serde = { version = "1", optional = true, features = ["derive"] }


### PR DESCRIPTION
Originally I was going to file an issue for this, but I figured I can just quickly PR the fix. Below is the bug report that this pre-emptively fixes. This broke due to #526.

---

**Describe the bug**
When compiling against master, lettre now panics when parsing addresses.

**To Reproduce**
```rust
use std::str::FromStr;

fn main() {
    lettre::message::Mailbox::from_str("Example <example@example.com>").unwrap();
}
```

**Expected behavior**
Addresses parse without panicking.

**Environment (please complete the following information):**
- Lettre version: 7f384bc
- OS: any

**Additional context**
```
thread 'async-std/runtime' panicked at 'called `Result::unwrap()` on an `Err` value: Syntax(
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
regex parse error:
    ^(?i)[a-z0-9.!#$%&'*+/=?^_`{|}~-]+\z
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: Unicode-aware case insensitivity matching is not available (make sure the unicode-case feature is enabled)~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
)', /home/build/.cargo/git/checkouts/lettre-53652803723a9045/7f384bc/src/address/types.rs:79:70
```

Looks to me like `unicode-case` needs to be enabled.