### PR TITLE
Remove file and sendmail transport by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,7 +80,7 @@ harness = false
 name = "transport_smtp"
 
 [features]
-default = ["file-transport", "file-transport-envelope", "smtp-transport", "native-tls", "hostname", "r2d2", "sendmail-transport", "builder"]
+default = ["smtp-transport", "native-tls", "hostname", "r2d2", "builder"]
 builder = ["mime", "base64", "hyperx", "rand", "quoted_printable"]
 
 # transports


### PR DESCRIPTION
We can probably consider SMTP as the main and recommended transport. Also keep TLS through native-tls and connection pooling for fast and secure default feature set that should fir most needs.