### PR TITLE
[Do not merge yet] Prepare 0.10.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,9 +29,9 @@ Several breaking changes were made between 0.9 and 0.10, but changes should be s
 * Refactor `TlsParameters` implementation to not expose the internal TLS library
 * `FileTransport` writes emails into `.eml` instead of `.json`
 * When the hostname feature is disabled or hostname cannot be fetched, `127.0.0.1` is used instead of `localhost` as EHLO parameter (for better RFC compliance and mail server compatibility)
+* The `sendmail` and `file` transports aren't enabled by default anymore.
 * The `new` method of `ClientId` is deprecated
 * Rename `serde-impls` feature to `serde`
-
 
 #### Bug Fixes
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.10.0-alpha.5"
+version = "0.10.0"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,19 +28,11 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.10.0-alpha.4">
-    <img src="https://deps.rs/crate/lettre/0.10.0-alpha.4/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.10.0">
+    <img src="https://deps.rs/crate/lettre/0.10.0/status.svg"
       alt="dependency status" />
   </a>
 </div>
-
----
-
-**NOTE**: this readme refers to the 0.10 version of lettre, which is
-still being worked on. The master branch and the alpha releases will see
-API breaking changes and some features may be missing or incomplete until
-the stable 0.10.0 release is out.
-Use the [`v0.9.x`](https://github.com/lettre/lettre/tree/v0.9.x) branch for stable releases.
 
 ---
 
@@ -66,7 +58,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lettre = "0.10.0-alpha.4"
+lettre = "0.10"
 ```
 
 ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,7 +30,7 @@
 //! * **serde**: Serialization/Deserialization of entities
 //! * **hostname**: Ability to try to use actual hostname in SMTP transaction
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-alpha.5")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
PR for the 0.10.0 release.

There are still a few changes I want to get in, so at the moment this is a draft:

* [ ] Part 2 of 2 of the `AsyncSmtpConnector` refactor.
* [ ] Seal [`lettre::transport::smtp::Error`](https://docs.rs/lettre/0.10.0-alpha.5/lettre/transport/smtp/enum.Error.html) so that we don't expose libraries like `r2d2`, `webpki` ecc. since they aren't stable yet. The idea is to make it like [`reqwest::Error`](https://docs.rs/reqwest/0.11.0/reqwest/struct.Error.html).
* [ ] Remove [`lettre::transport::stub`](https://docs.rs/lettre/0.10.0-alpha.5/lettre/transport/stub/index.html), we can always add it back later if people need it.
* [ ] Add integration tests for the async versions of the transports (we can probably copy them from the sync version)
* [ ] Go through the docs again and see if we forgot anything
* [ ] Anything else I might be forgetting?

Issues for a future 0.10.x release:

* #511 #495 

Issues for a future 0.11.0 release:

* #474 (a workaround is explained in the comments)
* #458

In the meantime we can use this PR to evaluate what else should go in the changelog.