### PR TITLE
Executor refactor

### DIFF
--- a/examples/asyncstd1_smtp_starttls.rs
+++ b/examples/asyncstd1_smtp_starttls.rs
@@ -1,5 +1,5 @@
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, AsyncStd1Connector,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, AsyncStd1Executor,
     AsyncStd1Transport, Message,
 };
 
@@ -18,8 +18,8 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer: AsyncSmtpTransport<AsyncStd1Connector> =
-        AsyncSmtpTransport::<AsyncStd1Connector>::starttls_relay("smtp.gmail.com")
+    let mailer: AsyncSmtpTransport<AsyncStd1Executor> =
+        AsyncSmtpTransport::<AsyncStd1Executor>::starttls_relay("smtp.gmail.com")
             .unwrap()
             .credentials(creds)
             .build();

--- a/examples/asyncstd1_smtp_starttls.rs
+++ b/examples/asyncstd1_smtp_starttls.rs
@@ -18,10 +18,11 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer = AsyncSmtpTransport::<AsyncStd1Connector>::starttls_relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
+    let mailer: AsyncSmtpTransport<AsyncStd1Connector> =
+        AsyncSmtpTransport::<AsyncStd1Connector>::starttls_relay("smtp.gmail.com")
+            .unwrap()
+            .credentials(creds)
+            .build();
 
     // Send the email
     match mailer.send(email).await {

--- a/examples/asyncstd1_smtp_tls.rs
+++ b/examples/asyncstd1_smtp_tls.rs
@@ -18,10 +18,11 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer = AsyncSmtpTransport::<AsyncStd1Connector>::relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
+    let mailer: AsyncSmtpTransport<AsyncStd1Connector> =
+        AsyncSmtpTransport::<AsyncStd1Connector>::relay("smtp.gmail.com")
+            .unwrap()
+            .credentials(creds)
+            .build();
 
     // Send the email
     match mailer.send(email).await {

--- a/examples/asyncstd1_smtp_tls.rs
+++ b/examples/asyncstd1_smtp_tls.rs
@@ -1,5 +1,5 @@
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, AsyncStd1Connector,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, AsyncStd1Executor,
     AsyncStd1Transport, Message,
 };
 
@@ -18,8 +18,8 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer: AsyncSmtpTransport<AsyncStd1Connector> =
-        AsyncSmtpTransport::<AsyncStd1Connector>::relay("smtp.gmail.com")
+    let mailer: AsyncSmtpTransport<AsyncStd1Executor> =
+        AsyncSmtpTransport::<AsyncStd1Executor>::relay("smtp.gmail.com")
             .unwrap()
             .credentials(creds)
             .build();

--- a/examples/tokio02_smtp_starttls.rs
+++ b/examples/tokio02_smtp_starttls.rs
@@ -23,10 +23,11 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer = AsyncSmtpTransport::<Tokio02Connector>::starttls_relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
+    let mailer: AsyncSmtpTransport<Tokio02Connector> =
+        AsyncSmtpTransport::<Tokio02Connector>::starttls_relay("smtp.gmail.com")
+            .unwrap()
+            .credentials(creds)
+            .build();
 
     // Send the email
     match mailer.send(email).await {

--- a/examples/tokio02_smtp_starttls.rs
+++ b/examples/tokio02_smtp_starttls.rs
@@ -4,7 +4,7 @@
 use tokio02_crate as tokio;
 
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio02Connector,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio02Executor,
     Tokio02Transport,
 };
 
@@ -23,8 +23,8 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer: AsyncSmtpTransport<Tokio02Connector> =
-        AsyncSmtpTransport::<Tokio02Connector>::starttls_relay("smtp.gmail.com")
+    let mailer: AsyncSmtpTransport<Tokio02Executor> =
+        AsyncSmtpTransport::<Tokio02Executor>::starttls_relay("smtp.gmail.com")
             .unwrap()
             .credentials(creds)
             .build();

--- a/examples/tokio02_smtp_tls.rs
+++ b/examples/tokio02_smtp_tls.rs
@@ -4,7 +4,7 @@
 use tokio02_crate as tokio;
 
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio02Connector,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio02Executor,
     Tokio02Transport,
 };
 
@@ -23,8 +23,8 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer: AsyncSmtpTransport<Tokio02Connector> =
-        AsyncSmtpTransport::<Tokio02Connector>::relay("smtp.gmail.com")
+    let mailer: AsyncSmtpTransport<Tokio02Executor> =
+        AsyncSmtpTransport::<Tokio02Executor>::relay("smtp.gmail.com")
             .unwrap()
             .credentials(creds)
             .build();

--- a/examples/tokio02_smtp_tls.rs
+++ b/examples/tokio02_smtp_tls.rs
@@ -23,10 +23,11 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer = AsyncSmtpTransport::<Tokio02Connector>::relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
+    let mailer: AsyncSmtpTransport<Tokio02Connector> =
+        AsyncSmtpTransport::<Tokio02Connector>::relay("smtp.gmail.com")
+            .unwrap()
+            .credentials(creds)
+            .build();
 
     // Send the email
     match mailer.send(email).await {

--- a/examples/tokio1_smtp_starttls.rs
+++ b/examples/tokio1_smtp_starttls.rs
@@ -4,7 +4,7 @@
 use tokio1_crate as tokio;
 
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio1Connector,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio1Executor,
     Tokio1Transport,
 };
 
@@ -23,8 +23,8 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer: AsyncSmtpTransport<Tokio1Connector> =
-        AsyncSmtpTransport::<Tokio1Connector>::starttls_relay("smtp.gmail.com")
+    let mailer: AsyncSmtpTransport<Tokio1Executor> =
+        AsyncSmtpTransport::<Tokio1Executor>::starttls_relay("smtp.gmail.com")
             .unwrap()
             .credentials(creds)
             .build();

--- a/examples/tokio1_smtp_starttls.rs
+++ b/examples/tokio1_smtp_starttls.rs
@@ -23,10 +23,11 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer = AsyncSmtpTransport::<Tokio1Connector>::starttls_relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
+    let mailer: AsyncSmtpTransport<Tokio1Connector> =
+        AsyncSmtpTransport::<Tokio1Connector>::starttls_relay("smtp.gmail.com")
+            .unwrap()
+            .credentials(creds)
+            .build();
 
     // Send the email
     match mailer.send(email).await {

--- a/examples/tokio1_smtp_tls.rs
+++ b/examples/tokio1_smtp_tls.rs
@@ -23,10 +23,11 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer = AsyncSmtpTransport::<Tokio1Connector>::relay("smtp.gmail.com")
-        .unwrap()
-        .credentials(creds)
-        .build();
+    let mailer: AsyncSmtpTransport<Tokio1Connector> =
+        AsyncSmtpTransport::<Tokio1Connector>::relay("smtp.gmail.com")
+            .unwrap()
+            .credentials(creds)
+            .build();
 
     // Send the email
     match mailer.send(email).await {

--- a/examples/tokio1_smtp_tls.rs
+++ b/examples/tokio1_smtp_tls.rs
@@ -4,7 +4,7 @@
 use tokio1_crate as tokio;
 
 use lettre::{
-    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio1Connector,
+    transport::smtp::authentication::Credentials, AsyncSmtpTransport, Message, Tokio1Executor,
     Tokio1Transport,
 };
 
@@ -23,8 +23,8 @@ async fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer: AsyncSmtpTransport<Tokio1Connector> =
-        AsyncSmtpTransport::<Tokio1Connector>::relay("smtp.gmail.com")
+    let mailer: AsyncSmtpTransport<Tokio1Executor> =
+        AsyncSmtpTransport::<Tokio1Executor>::relay("smtp.gmail.com")
             .unwrap()
             .credentials(creds)
             .build();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,6 +1,6 @@
 use async_trait::async_trait;
 
-#[cfg(feature = "file-transport-envelope")]
+#[cfg(feature = "file-transport")]
 use std::io::Result as IoResult;
 #[cfg(feature = "file-transport")]
 use std::path::Path;

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,10 +1,24 @@
 use async_trait::async_trait;
 
+#[cfg(all(
+    feature = "smtp-transport",
+    any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
+))]
 use crate::transport::smtp::client::AsyncSmtpConnection;
-#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+#[cfg(all(
+    feature = "smtp-transport",
+    any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
+))]
 use crate::transport::smtp::client::Tls;
-#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+#[cfg(all(
+    feature = "smtp-transport",
+    any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
+))]
 use crate::transport::smtp::extension::ClientId;
+#[cfg(all(
+    feature = "smtp-transport",
+    any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
+))]
 use crate::transport::smtp::Error;
 
 #[async_trait]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 
 #[cfg(feature = "file-transport-envelope")]
 use std::io::Result as IoResult;
-#[cfg(feature = "file-transport-envelope")]
+#[cfg(feature = "file-transport")]
 use std::path::Path;
 
 #[cfg(all(

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,5 +1,10 @@
 use async_trait::async_trait;
 
+#[cfg(feature = "file-transport-envelope")]
+use std::io::Result as IoResult;
+#[cfg(feature = "file-transport-envelope")]
+use std::path::Path;
+
 #[cfg(all(
     feature = "smtp-transport",
     any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
@@ -31,6 +36,10 @@ pub trait Executor: private::Sealed {
         hello_name: &ClientId,
         tls: &Tls,
     ) -> Result<AsyncSmtpConnection, Error>;
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport-envelope")]
+    async fn fs_read(path: &Path) -> IoResult<Vec<u8>>;
 }
 
 #[allow(missing_copy_implementations)]
@@ -76,6 +85,12 @@ impl Executor for Tokio02Executor {
 
         Ok(conn)
     }
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport-envelope")]
+    async fn fs_read(path: &Path) -> IoResult<Vec<u8>> {
+        tokio02_crate::fs::read(path).await
+    }
 }
 
 #[allow(missing_copy_implementations)]
@@ -119,6 +134,12 @@ impl Executor for Tokio1Executor {
         }
 
         Ok(conn)
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport-envelope")]
+    async fn fs_read(path: &Path) -> IoResult<Vec<u8>> {
+        tokio1_crate::fs::read(path).await
     }
 }
 
@@ -164,6 +185,12 @@ impl Executor for AsyncStd1Executor {
         }
 
         Ok(conn)
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport-envelope")]
+    async fn fs_read(path: &Path) -> IoResult<Vec<u8>> {
+        async_std::fs::read(path).await
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -27,7 +27,7 @@ use crate::transport::smtp::extension::ClientId;
 use crate::transport::smtp::Error;
 
 #[async_trait]
-pub trait Executor: private::Sealed {
+pub trait Executor: Send + Sync + private::Sealed {
     #[doc(hidden)]
     #[cfg(feature = "smtp-transport")]
     async fn connect(
@@ -40,6 +40,10 @@ pub trait Executor: private::Sealed {
     #[doc(hidden)]
     #[cfg(feature = "file-transport-envelope")]
     async fn fs_read(path: &Path) -> IoResult<Vec<u8>>;
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport")]
+    async fn fs_write(path: &Path, contents: &[u8]) -> IoResult<()>;
 }
 
 #[allow(missing_copy_implementations)]
@@ -91,6 +95,12 @@ impl Executor for Tokio02Executor {
     async fn fs_read(path: &Path) -> IoResult<Vec<u8>> {
         tokio02_crate::fs::read(path).await
     }
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport")]
+    async fn fs_write(path: &Path, contents: &[u8]) -> IoResult<()> {
+        tokio02_crate::fs::write(path, contents).await
+    }
 }
 
 #[allow(missing_copy_implementations)]
@@ -140,6 +150,12 @@ impl Executor for Tokio1Executor {
     #[cfg(feature = "file-transport-envelope")]
     async fn fs_read(path: &Path) -> IoResult<Vec<u8>> {
         tokio1_crate::fs::read(path).await
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport")]
+    async fn fs_write(path: &Path, contents: &[u8]) -> IoResult<()> {
+        tokio1_crate::fs::write(path, contents).await
     }
 }
 
@@ -191,6 +207,12 @@ impl Executor for AsyncStd1Executor {
     #[cfg(feature = "file-transport-envelope")]
     async fn fs_read(path: &Path) -> IoResult<Vec<u8>> {
         async_std::fs::read(path).await
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "file-transport")]
+    async fn fs_write(path: &Path, contents: &[u8]) -> IoResult<()> {
+        async_std::fs::write(path, contents).await
     }
 }
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,0 +1,169 @@
+use async_trait::async_trait;
+
+use crate::transport::smtp::client::AsyncSmtpConnection;
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+use crate::transport::smtp::client::Tls;
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+use crate::transport::smtp::extension::ClientId;
+use crate::transport::smtp::Error;
+
+#[async_trait]
+pub trait Executor: private::Sealed {
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    async fn connect(
+        hostname: &str,
+        port: u16,
+        hello_name: &ClientId,
+        tls: &Tls,
+    ) -> Result<AsyncSmtpConnection, Error>;
+}
+
+#[allow(missing_copy_implementations)]
+#[non_exhaustive]
+#[cfg(feature = "tokio02")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
+pub struct Tokio02Executor;
+
+#[async_trait]
+#[cfg(feature = "tokio02")]
+impl Executor for Tokio02Executor {
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    async fn connect(
+        hostname: &str,
+        port: u16,
+        hello_name: &ClientId,
+        tls: &Tls,
+    ) -> Result<AsyncSmtpConnection, Error> {
+        #[allow(clippy::match_single_binding)]
+        let tls_parameters = match tls {
+            #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
+            Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
+            _ => None,
+        };
+        #[allow(unused_mut)]
+        let mut conn =
+            AsyncSmtpConnection::connect_tokio02(hostname, port, hello_name, tls_parameters)
+                .await?;
+
+        #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
+        match tls {
+            Tls::Opportunistic(ref tls_parameters) => {
+                if conn.can_starttls() {
+                    conn.starttls(tls_parameters.clone(), hello_name).await?;
+                }
+            }
+            Tls::Required(ref tls_parameters) => {
+                conn.starttls(tls_parameters.clone(), hello_name).await?;
+            }
+            _ => (),
+        }
+
+        Ok(conn)
+    }
+}
+
+#[allow(missing_copy_implementations)]
+#[non_exhaustive]
+#[cfg(feature = "tokio1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
+pub struct Tokio1Executor;
+
+#[async_trait]
+#[cfg(feature = "tokio1")]
+impl Executor for Tokio1Executor {
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    async fn connect(
+        hostname: &str,
+        port: u16,
+        hello_name: &ClientId,
+        tls: &Tls,
+    ) -> Result<AsyncSmtpConnection, Error> {
+        #[allow(clippy::match_single_binding)]
+        let tls_parameters = match tls {
+            #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
+            Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
+            _ => None,
+        };
+        #[allow(unused_mut)]
+        let mut conn =
+            AsyncSmtpConnection::connect_tokio1(hostname, port, hello_name, tls_parameters).await?;
+
+        #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
+        match tls {
+            Tls::Opportunistic(ref tls_parameters) => {
+                if conn.can_starttls() {
+                    conn.starttls(tls_parameters.clone(), hello_name).await?;
+                }
+            }
+            Tls::Required(ref tls_parameters) => {
+                conn.starttls(tls_parameters.clone(), hello_name).await?;
+            }
+            _ => (),
+        }
+
+        Ok(conn)
+    }
+}
+
+#[allow(missing_copy_implementations)]
+#[non_exhaustive]
+#[cfg(feature = "async-std1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
+pub struct AsyncStd1Executor;
+
+#[async_trait]
+#[cfg(feature = "async-std1")]
+impl Executor for AsyncStd1Executor {
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    async fn connect(
+        hostname: &str,
+        port: u16,
+        hello_name: &ClientId,
+        tls: &Tls,
+    ) -> Result<AsyncSmtpConnection, Error> {
+        #[allow(clippy::match_single_binding)]
+        let tls_parameters = match tls {
+            #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]
+            Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
+            _ => None,
+        };
+        #[allow(unused_mut)]
+        let mut conn =
+            AsyncSmtpConnection::connect_asyncstd1(hostname, port, hello_name, tls_parameters)
+                .await?;
+
+        #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]
+        match tls {
+            Tls::Opportunistic(ref tls_parameters) => {
+                if conn.can_starttls() {
+                    conn.starttls(tls_parameters.clone(), hello_name).await?;
+                }
+            }
+            Tls::Required(ref tls_parameters) => {
+                conn.starttls(tls_parameters.clone(), hello_name).await?;
+            }
+            _ => (),
+        }
+
+        Ok(conn)
+    }
+}
+
+mod private {
+    use super::*;
+
+    pub trait Sealed {}
+
+    #[cfg(feature = "tokio02")]
+    impl Sealed for Tokio02Executor {}
+
+    #[cfg(feature = "tokio1")]
+    impl Sealed for Tokio1Executor {}
+
+    #[cfg(feature = "async-std1")]
+    impl Sealed for AsyncStd1Executor {}
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,10 +103,13 @@ pub use crate::transport::smtp::Tokio02Connector;
 #[allow(deprecated)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
 pub use crate::transport::smtp::Tokio1Connector;
+#[doc(hidden)]
 #[cfg(feature = "async-std1")]
 pub use crate::transport::AsyncStd1Transport;
+#[doc(hidden)]
 #[cfg(feature = "tokio02")]
 pub use crate::transport::Tokio02Transport;
+#[doc(hidden)]
 #[cfg(feature = "tokio1")]
 pub use crate::transport::Tokio1Transport;
 pub use crate::transport::Transport;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -103,13 +103,12 @@ pub use crate::transport::smtp::Tokio02Connector;
 #[allow(deprecated)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
 pub use crate::transport::smtp::Tokio1Connector;
-#[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
+#[cfg(feature = "async-std1")]
 pub use crate::transport::AsyncStd1Transport;
-#[cfg(all(feature = "smtp-transport", feature = "tokio02"))]
+#[cfg(feature = "tokio02")]
 pub use crate::transport::Tokio02Transport;
-#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+#[cfg(feature = "tokio1")]
 pub use crate::transport::Tokio1Transport;
-#[cfg(feature = "smtp-transport")]
 pub use crate::transport::Transport;
 use crate::{address::Envelope, error::Error};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,11 +65,23 @@ pub use self::executor::Executor;
 pub use self::executor::Tokio02Executor;
 #[cfg(feature = "tokio1")]
 pub use self::executor::Tokio1Executor;
+#[cfg(all(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))]
+pub use self::transport::AsyncTransport;
 pub use crate::address::Address;
 #[cfg(feature = "builder")]
 pub use crate::message::Message;
+#[cfg(all(
+    feature = "file-transport",
+    any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
+))]
+pub use crate::transport::file::AsyncFileTransport;
 #[cfg(feature = "file-transport")]
 pub use crate::transport::file::FileTransport;
+#[cfg(all(
+    feature = "sendmail-transport",
+    any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
+))]
+pub use crate::transport::sendmail::AsyncSendmailTransport;
 #[cfg(feature = "sendmail-transport")]
 pub use crate::transport::sendmail::SendmailTransport;
 #[cfg(all(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,14 +89,18 @@ pub use crate::transport::sendmail::SendmailTransport;
     any(feature = "tokio02", feature = "tokio1")
 ))]
 pub use crate::transport::smtp::AsyncSmtpTransport;
+#[doc(hidden)]
+#[allow(deprecated)]
 #[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
 pub use crate::transport::smtp::AsyncStd1Connector;
 #[cfg(feature = "smtp-transport")]
 pub use crate::transport::smtp::SmtpTransport;
 #[doc(hidden)]
+#[allow(deprecated)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio02"))]
 pub use crate::transport::smtp::Tokio02Connector;
 #[doc(hidden)]
+#[allow(deprecated)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
 pub use crate::transport::smtp::Tokio1Connector;
 #[cfg(all(feature = "smtp-transport", feature = "async-std1"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,8 @@
 
 pub mod address;
 pub mod error;
+#[cfg(all(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))]
+mod executor;
 #[cfg(feature = "builder")]
 #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
 pub mod message;
@@ -55,6 +57,14 @@ pub mod transport;
 #[macro_use]
 extern crate hyperx;
 
+#[cfg(feature = "async-std1")]
+pub use self::executor::AsyncStd1Executor;
+#[cfg(all(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))]
+pub use self::executor::Executor;
+#[cfg(feature = "tokio02")]
+pub use self::executor::Tokio02Executor;
+#[cfg(feature = "tokio1")]
+pub use self::executor::Tokio1Executor;
 pub use crate::address::Address;
 #[cfg(feature = "builder")]
 pub use crate::message::Message;
@@ -71,11 +81,14 @@ pub use crate::transport::smtp::AsyncSmtpTransport;
 pub use crate::transport::smtp::AsyncStd1Connector;
 #[cfg(feature = "smtp-transport")]
 pub use crate::transport::smtp::SmtpTransport;
+#[doc(hidden)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio02"))]
 pub use crate::transport::smtp::Tokio02Connector;
+#[doc(hidden)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
 pub use crate::transport::smtp::Tokio1Connector;
 use crate::{address::Envelope, error::Error};
+
 #[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 use async_trait::async_trait;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,6 +89,9 @@ pub use crate::transport::sendmail::SendmailTransport;
     any(feature = "tokio02", feature = "tokio1")
 ))]
 pub use crate::transport::smtp::AsyncSmtpTransport;
+pub use crate::transport::Transport;
+use crate::{address::Envelope, error::Error};
+
 #[doc(hidden)]
 #[allow(deprecated)]
 #[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
@@ -112,8 +115,6 @@ pub use crate::transport::Tokio02Transport;
 #[doc(hidden)]
 #[cfg(feature = "tokio1")]
 pub use crate::transport::Tokio1Transport;
-pub use crate::transport::Transport;
-use crate::{address::Envelope, error::Error};
 
 #[cfg(test)]
 #[cfg(feature = "builder")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,97 +87,15 @@ pub use crate::transport::smtp::Tokio02Connector;
 #[doc(hidden)]
 #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
 pub use crate::transport::smtp::Tokio1Connector;
+#[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
+pub use crate::transport::AsyncStd1Transport;
+#[cfg(all(feature = "smtp-transport", feature = "tokio02"))]
+pub use crate::transport::Tokio02Transport;
+#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+pub use crate::transport::Tokio1Transport;
+#[cfg(feature = "smtp-transport")]
+pub use crate::transport::Transport;
 use crate::{address::Envelope, error::Error};
-
-#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
-use async_trait::async_trait;
-
-/// Blocking Transport method for emails
-pub trait Transport {
-    /// Response produced by the Transport
-    type Ok;
-    /// Error produced by the Transport
-    type Error;
-
-    /// Sends the email
-    #[cfg(feature = "builder")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
-    fn send(&self, message: &Message) -> Result<Self::Ok, Self::Error> {
-        let raw = message.formatted();
-        self.send_raw(message.envelope(), &raw)
-    }
-
-    fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
-}
-
-/// async-std 1.x based Transport method for emails
-#[cfg(feature = "async-std1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
-#[async_trait]
-pub trait AsyncStd1Transport {
-    /// Response produced by the Transport
-    type Ok;
-    /// Error produced by the Transport
-    type Error;
-
-    /// Sends the email
-    #[cfg(feature = "builder")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
-    // TODO take &Message
-    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
-        let raw = message.formatted();
-        let envelope = message.envelope();
-        self.send_raw(&envelope, &raw).await
-    }
-
-    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
-}
-
-/// tokio 0.2.x based Transport method for emails
-#[cfg(feature = "tokio02")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
-#[async_trait]
-pub trait Tokio02Transport {
-    /// Response produced by the Transport
-    type Ok;
-    /// Error produced by the Transport
-    type Error;
-
-    /// Sends the email
-    #[cfg(feature = "builder")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
-    // TODO take &Message
-    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
-        let raw = message.formatted();
-        let envelope = message.envelope();
-        self.send_raw(&envelope, &raw).await
-    }
-
-    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
-}
-
-/// tokio 1.x based Transport method for emails
-#[cfg(feature = "tokio1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
-#[async_trait]
-pub trait Tokio1Transport {
-    /// Response produced by the Transport
-    type Ok;
-    /// Error produced by the Transport
-    type Error;
-
-    /// Sends the email
-    #[cfg(feature = "builder")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
-    // TODO take &Message
-    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
-        let raw = message.formatted();
-        let envelope = message.envelope();
-        self.send_raw(&envelope, &raw).await
-    }
-
-    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
-}
 
 #[cfg(test)]
 #[cfg(feature = "builder")]

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -246,6 +246,21 @@ where
             marker_: PhantomData,
         }
     }
+
+    /// Read a message that was written using the file transport.
+    ///
+    /// Reads the envelope and the raw message content.
+    #[cfg(feature = "file-transport-envelope")]
+    pub async fn read(&self, email_id: &str) -> Result<(Envelope, Vec<u8>), Error> {
+        let eml_file = self.inner.path.join(format!("{}.eml", email_id));
+        let eml = E::fs_read(&eml_file).await?;
+
+        let json_file = self.inner.path.join(format!("{}.json", email_id));
+        let json = E::fs_read(&json_file).await?;
+        let envelope = serde_json::from_slice(&json)?;
+
+        Ok((envelope, eml))
+    }
 }
 
 impl Transport for FileTransport {

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -70,10 +70,10 @@
 //! # #[cfg(all(feature = "tokio1", feature = "file-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
-//! use lettre::{Tokio1Transport, Message, FileTransport};
+//! use lettre::{AsyncTransport, Tokio1Executor, Message, AsyncFileTransport};
 //!
 //! // Write to the local temp directory
-//! let sender = FileTransport::new(temp_dir());
+//! let sender = AsyncFileTransport::<Tokio1Executor>::new(temp_dir());
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
@@ -95,10 +95,10 @@
 //! # #[cfg(all(feature = "async-std1", feature = "file-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
-//! use lettre::{AsyncStd1Transport, Message, FileTransport};
+//! use lettre::{AsyncTransport, AsyncStd1Executor, Message, AsyncFileTransport};
 //!
 //! // Write to the local temp directory
-//! let sender = FileTransport::new(temp_dir());
+//! let sender = AsyncFileTransport::<AsyncStd1Executor>::new(temp_dir());
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -19,6 +19,19 @@
 #[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 use async_trait::async_trait;
 
+#[doc(hidden)]
+#[deprecated(note = "use lettre::AsyncStd1Transport")]
+#[cfg(feature = "async-std1")]
+pub use self::AsyncTransport as AsyncStd1Transport;
+#[doc(hidden)]
+#[deprecated(note = "use lettre::Tokio1Transport")]
+#[cfg(feature = "tokio1")]
+pub use self::AsyncTransport as Tokio1Transport;
+#[doc(hidden)]
+#[deprecated(note = "use lettre::Tokio02Transport")]
+#[cfg(feature = "tokio02")]
+pub use self::AsyncTransport as Tokio02Transport;
+
 use crate::{Envelope, Message};
 
 #[cfg(feature = "file-transport")]
@@ -50,57 +63,14 @@ pub trait Transport {
     fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
 }
 
-/// async-std 1.x based Transport method for emails
-#[cfg(feature = "async-std1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
+/// Async Transport method for emails
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
+)]
 #[async_trait]
-pub trait AsyncStd1Transport {
-    /// Response produced by the Transport
-    type Ok;
-    /// Error produced by the Transport
-    type Error;
-
-    /// Sends the email
-    #[cfg(feature = "builder")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
-    // TODO take &Message
-    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
-        let raw = message.formatted();
-        let envelope = message.envelope();
-        self.send_raw(&envelope, &raw).await
-    }
-
-    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
-}
-
-/// tokio 0.2.x based Transport method for emails
-#[cfg(feature = "tokio02")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
-#[async_trait]
-pub trait Tokio02Transport {
-    /// Response produced by the Transport
-    type Ok;
-    /// Error produced by the Transport
-    type Error;
-
-    /// Sends the email
-    #[cfg(feature = "builder")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
-    // TODO take &Message
-    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
-        let raw = message.formatted();
-        let envelope = message.envelope();
-        self.send_raw(&envelope, &raw).await
-    }
-
-    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
-}
-
-/// tokio 1.x based Transport method for emails
-#[cfg(feature = "tokio1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
-#[async_trait]
-pub trait Tokio1Transport {
+pub trait AsyncTransport {
     /// Response produced by the Transport
     type Ok;
     /// Error produced by the Transport

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -16,6 +16,11 @@
 //! * The `StubTransport` is useful for debugging, and only prints the content of the email in the
 //!   logs.
 
+#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
+use async_trait::async_trait;
+
+use crate::{Envelope, Message};
+
 #[cfg(feature = "file-transport")]
 #[cfg_attr(docsrs, doc(cfg(feature = "file-transport")))]
 pub mod file;
@@ -26,3 +31,90 @@ pub mod sendmail;
 #[cfg_attr(docsrs, doc(cfg(feature = "smtp-transport")))]
 pub mod smtp;
 pub mod stub;
+
+/// Blocking Transport method for emails
+pub trait Transport {
+    /// Response produced by the Transport
+    type Ok;
+    /// Error produced by the Transport
+    type Error;
+
+    /// Sends the email
+    #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
+    fn send(&self, message: &Message) -> Result<Self::Ok, Self::Error> {
+        let raw = message.formatted();
+        self.send_raw(message.envelope(), &raw)
+    }
+
+    fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
+}
+
+/// async-std 1.x based Transport method for emails
+#[cfg(feature = "async-std1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
+#[async_trait]
+pub trait AsyncStd1Transport {
+    /// Response produced by the Transport
+    type Ok;
+    /// Error produced by the Transport
+    type Error;
+
+    /// Sends the email
+    #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
+    // TODO take &Message
+    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
+        let raw = message.formatted();
+        let envelope = message.envelope();
+        self.send_raw(&envelope, &raw).await
+    }
+
+    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
+}
+
+/// tokio 0.2.x based Transport method for emails
+#[cfg(feature = "tokio02")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
+#[async_trait]
+pub trait Tokio02Transport {
+    /// Response produced by the Transport
+    type Ok;
+    /// Error produced by the Transport
+    type Error;
+
+    /// Sends the email
+    #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
+    // TODO take &Message
+    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
+        let raw = message.formatted();
+        let envelope = message.envelope();
+        self.send_raw(&envelope, &raw).await
+    }
+
+    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
+}
+
+/// tokio 1.x based Transport method for emails
+#[cfg(feature = "tokio1")]
+#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
+#[async_trait]
+pub trait Tokio1Transport {
+    /// Response produced by the Transport
+    type Ok;
+    /// Error produced by the Transport
+    type Error;
+
+    /// Sends the email
+    #[cfg(feature = "builder")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
+    // TODO take &Message
+    async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
+        let raw = message.formatted();
+        let envelope = message.envelope();
+        self.send_raw(&envelope, &raw).await
+    }
+
+    async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
+}

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,7 +32,9 @@ pub use self::AsyncTransport as Tokio1Transport;
 #[cfg(feature = "tokio02")]
 pub use self::AsyncTransport as Tokio02Transport;
 
-use crate::{Envelope, Message};
+use crate::Envelope;
+#[cfg(feature = "builder")]
+use crate::Message;
 
 #[cfg(feature = "file-transport")]
 #[cfg_attr(docsrs, doc(cfg(feature = "file-transport")))]

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -247,6 +247,16 @@ impl Default for SendmailTransport {
     }
 }
 
+#[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
+impl<E> Default for AsyncSendmailTransport<E>
+where
+    E: Executor,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl Transport for SendmailTransport {
     type Ok = ();
     type Error = Error;

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -33,7 +33,7 @@
 //!
 //! # #[cfg(all(feature = "tokio02", feature = "sendmail-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
-//! use lettre::{Message, Tokio02Transport, SendmailTransport};
+//! use lettre::{Message, AsyncTransport, Tokio02Executor, AsyncSendmailTransport, SendmailTransport};
 //!
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
@@ -42,7 +42,7 @@
 //!     .subject("Happy new year")
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let sender = SendmailTransport::new();
+//! let sender = AsyncSendmailTransport::<Tokio02Executor>::new();
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
 //! # Ok(())
@@ -56,7 +56,7 @@
 //!
 //! # #[cfg(all(feature = "tokio1", feature = "sendmail-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
-//! use lettre::{Message, Tokio1Transport, SendmailTransport};
+//! use lettre::{Message, AsyncTransport, Tokio1Executor, AsyncSendmailTransport, SendmailTransport};
 //!
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
@@ -65,7 +65,7 @@
 //!     .subject("Happy new year")
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let sender = SendmailTransport::new();
+//! let sender = AsyncSendmailTransport::<Tokio1Executor>::new();
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
 //! # Ok(())
@@ -79,7 +79,7 @@
 //!
 //! # #[cfg(all(feature = "async-std1", feature = "sendmail-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
-//! use lettre::{Message, AsyncStd1Transport, SendmailTransport};
+//! use lettre::{Message, AsyncTransport, AsyncStd1Executor, AsyncSendmailTransport};
 //!
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
@@ -88,7 +88,7 @@
 //!     .subject("Happy new year")
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let sender = SendmailTransport::new();
+//! let sender = AsyncSendmailTransport::<AsyncStd1Executor>::new();
 //! let result = sender.send(email).await;
 //! assert!(result.is_ok());
 //! # Ok(())

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -272,159 +272,21 @@ where
     }
 }
 
-#[async_trait]
-pub trait AsyncSmtpConnector: private::Sealed {
-    #[doc(hidden)]
-    async fn connect(
-        hostname: &str,
-        port: u16,
-        hello_name: &ClientId,
-        tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error>;
-}
+#[doc(hidden)]
+#[deprecated(note = "use lettre::Executor instead")]
+pub use crate::Executor as AsyncSmtpConnector;
 
-#[allow(missing_copy_implementations)]
-#[non_exhaustive]
+#[doc(hidden)]
+#[deprecated(note = "use lettre::Tokio02Executor instead")]
 #[cfg(feature = "tokio02")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
-pub struct Tokio02Connector;
+pub type Tokio02Connector = crate::Tokio02Executor;
 
-#[async_trait]
-#[cfg(feature = "tokio02")]
-impl AsyncSmtpConnector for Tokio02Connector {
-    #[doc(hidden)]
-    async fn connect(
-        hostname: &str,
-        port: u16,
-        hello_name: &ClientId,
-        tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error> {
-        #[allow(clippy::match_single_binding)]
-        let tls_parameters = match tls {
-            #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
-            Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
-            _ => None,
-        };
-        #[allow(unused_mut)]
-        let mut conn =
-            AsyncSmtpConnection::connect_tokio02(hostname, port, hello_name, tls_parameters)
-                .await?;
-
-        #[cfg(any(feature = "tokio02-native-tls", feature = "tokio02-rustls-tls"))]
-        match tls {
-            Tls::Opportunistic(ref tls_parameters) => {
-                if conn.can_starttls() {
-                    conn.starttls(tls_parameters.clone(), hello_name).await?;
-                }
-            }
-            Tls::Required(ref tls_parameters) => {
-                conn.starttls(tls_parameters.clone(), hello_name).await?;
-            }
-            _ => (),
-        }
-
-        Ok(conn)
-    }
-}
-
-#[allow(missing_copy_implementations)]
-#[non_exhaustive]
+#[doc(hidden)]
+#[deprecated(note = "use lettre::Tokio1Executor instead")]
 #[cfg(feature = "tokio1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
-pub struct Tokio1Connector;
+pub type Tokio1Connector = crate::Tokio1Executor;
 
-#[async_trait]
-#[cfg(feature = "tokio1")]
-impl AsyncSmtpConnector for Tokio1Connector {
-    #[doc(hidden)]
-    async fn connect(
-        hostname: &str,
-        port: u16,
-        hello_name: &ClientId,
-        tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error> {
-        #[allow(clippy::match_single_binding)]
-        let tls_parameters = match tls {
-            #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
-            Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
-            _ => None,
-        };
-        #[allow(unused_mut)]
-        let mut conn =
-            AsyncSmtpConnection::connect_tokio1(hostname, port, hello_name, tls_parameters).await?;
-
-        #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
-        match tls {
-            Tls::Opportunistic(ref tls_parameters) => {
-                if conn.can_starttls() {
-                    conn.starttls(tls_parameters.clone(), hello_name).await?;
-                }
-            }
-            Tls::Required(ref tls_parameters) => {
-                conn.starttls(tls_parameters.clone(), hello_name).await?;
-            }
-            _ => (),
-        }
-
-        Ok(conn)
-    }
-}
-
-#[allow(missing_copy_implementations)]
-#[non_exhaustive]
+#[doc(hidden)]
+#[deprecated(note = "use lettre::AsyncStd1Executor instead")]
 #[cfg(feature = "async-std1")]
-#[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
-pub struct AsyncStd1Connector;
-
-#[async_trait]
-#[cfg(feature = "async-std1")]
-impl AsyncSmtpConnector for AsyncStd1Connector {
-    #[doc(hidden)]
-    async fn connect(
-        hostname: &str,
-        port: u16,
-        hello_name: &ClientId,
-        tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error> {
-        #[allow(clippy::match_single_binding)]
-        let tls_parameters = match tls {
-            #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]
-            Tls::Wrapper(ref tls_parameters) => Some(tls_parameters.clone()),
-            _ => None,
-        };
-        #[allow(unused_mut)]
-        let mut conn =
-            AsyncSmtpConnection::connect_asyncstd1(hostname, port, hello_name, tls_parameters)
-                .await?;
-
-        #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]
-        match tls {
-            Tls::Opportunistic(ref tls_parameters) => {
-                if conn.can_starttls() {
-                    conn.starttls(tls_parameters.clone(), hello_name).await?;
-                }
-            }
-            Tls::Required(ref tls_parameters) => {
-                conn.starttls(tls_parameters.clone(), hello_name).await?;
-            }
-            _ => (),
-        }
-
-        Ok(conn)
-    }
-}
-
-mod private {
-    use super::*;
-
-    pub trait Sealed {}
-
-    #[cfg(feature = "tokio02")]
-    impl Sealed for Tokio02Connector {}
-
-    #[cfg(feature = "tokio1")]
-    impl Sealed for Tokio1Connector {}
-
-    #[cfg(feature = "async-std1")]
-    impl Sealed for AsyncStd1Connector {}
-}
+pub type AsyncStd1Connector = crate::AsyncStd1Executor;

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -8,22 +8,24 @@ use super::{
     client::AsyncSmtpConnection, ClientId, Credentials, Error, Mechanism, Response, SmtpInfo,
 };
 #[cfg(feature = "async-std1")]
-use crate::AsyncStd1Transport;
+use crate::AsyncStd1Executor;
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+use crate::AsyncTransport;
 use crate::Envelope;
 #[cfg(feature = "tokio02")]
-use crate::Tokio02Transport;
+use crate::Tokio02Executor;
 #[cfg(feature = "tokio1")]
-use crate::Tokio1Transport;
+use crate::Tokio1Executor;
 
 #[allow(missing_debug_implementations)]
-pub struct AsyncSmtpTransport<C> {
+pub struct AsyncSmtpTransport<E> {
     // TODO: pool
-    inner: AsyncSmtpClient<C>,
+    inner: AsyncSmtpClient<E>,
 }
 
 #[cfg(feature = "tokio02")]
 #[async_trait]
-impl Tokio02Transport for AsyncSmtpTransport<Tokio02Connector> {
+impl AsyncTransport for AsyncSmtpTransport<Tokio02Executor> {
     type Ok = Response;
     type Error = Error;
 
@@ -41,7 +43,7 @@ impl Tokio02Transport for AsyncSmtpTransport<Tokio02Connector> {
 
 #[cfg(feature = "tokio1")]
 #[async_trait]
-impl Tokio1Transport for AsyncSmtpTransport<Tokio1Connector> {
+impl AsyncTransport for AsyncSmtpTransport<Tokio1Executor> {
     type Ok = Response;
     type Error = Error;
 
@@ -59,7 +61,7 @@ impl Tokio1Transport for AsyncSmtpTransport<Tokio1Connector> {
 
 #[cfg(feature = "async-std1")]
 #[async_trait]
-impl AsyncStd1Transport for AsyncSmtpTransport<AsyncStd1Connector> {
+impl AsyncTransport for AsyncSmtpTransport<AsyncStd1Executor> {
     type Ok = Response;
     type Error = Error;
 

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -2,8 +2,6 @@ use std::marker::PhantomData;
 
 use async_trait::async_trait;
 
-#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
-use super::Tls;
 use super::{
     client::AsyncSmtpConnection, ClientId, Credentials, Error, Mechanism, Response, SmtpInfo,
 };
@@ -96,7 +94,7 @@ where
         feature = "async-std1-rustls-tls"
     ))]
     pub fn relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
-        use super::{TlsParameters, SUBMISSIONS_PORT};
+        use super::{Tls, TlsParameters, SUBMISSIONS_PORT};
 
         let tls_parameters = TlsParameters::new(relay.into())?;
 
@@ -125,7 +123,7 @@ where
         feature = "async-std1-rustls-tls"
     ))]
     pub fn starttls_relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
-        use super::{TlsParameters, SUBMISSION_PORT};
+        use super::{Tls, TlsParameters, SUBMISSION_PORT};
 
         let tls_parameters = TlsParameters::new(relay.into())?;
 
@@ -215,7 +213,7 @@ impl AsyncSmtpTransportBuilder {
         feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
-    pub fn tls(mut self, tls: Tls) -> Self {
+    pub fn tls(mut self, tls: super::Tls) -> Self {
         self.info.tls = tls;
         self
     }

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -117,12 +117,15 @@
 //! ```
 
 #[doc(hidden)]
+#[allow(deprecated)]
 #[cfg(feature = "async-std1")]
 pub use self::async_transport::AsyncStd1Connector;
 #[doc(hidden)]
+#[allow(deprecated)]
 #[cfg(feature = "tokio02")]
 pub use self::async_transport::Tokio02Connector;
 #[doc(hidden)]
+#[allow(deprecated)]
 #[cfg(feature = "tokio1")]
 pub use self::async_transport::Tokio1Connector;
 #[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -116,18 +116,6 @@
 //! # }
 //! ```
 
-#[doc(hidden)]
-#[allow(deprecated)]
-#[cfg(feature = "async-std1")]
-pub use self::async_transport::AsyncStd1Connector;
-#[doc(hidden)]
-#[allow(deprecated)]
-#[cfg(feature = "tokio02")]
-pub use self::async_transport::Tokio02Connector;
-#[doc(hidden)]
-#[allow(deprecated)]
-#[cfg(feature = "tokio1")]
-pub use self::async_transport::Tokio1Connector;
 #[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
 pub use self::async_transport::{
     AsyncSmtpConnector, AsyncSmtpTransport, AsyncSmtpTransportBuilder,
@@ -150,6 +138,19 @@ use crate::transport::smtp::{
 };
 use client::Tls;
 use std::time::Duration;
+
+#[doc(hidden)]
+#[allow(deprecated)]
+#[cfg(feature = "async-std1")]
+pub use self::async_transport::AsyncStd1Connector;
+#[doc(hidden)]
+#[allow(deprecated)]
+#[cfg(feature = "tokio02")]
+pub use self::async_transport::Tokio02Connector;
+#[doc(hidden)]
+#[allow(deprecated)]
+#[cfg(feature = "tokio1")]
+pub use self::async_transport::Tokio1Connector;
 
 #[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
 mod async_transport;

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -116,10 +116,13 @@
 //! # }
 //! ```
 
+#[doc(hidden)]
 #[cfg(feature = "async-std1")]
 pub use self::async_transport::AsyncStd1Connector;
+#[doc(hidden)]
 #[cfg(feature = "tokio02")]
 pub use self::async_transport::Tokio02Connector;
+#[doc(hidden)]
 #[cfg(feature = "tokio1")]
 pub use self::async_transport::Tokio1Connector;
 #[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]

--- a/src/transport/stub/mod.rs
+++ b/src/transport/stub/mod.rs
@@ -31,7 +31,7 @@
 #[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
 use crate::AsyncTransport;
 use crate::{address::Envelope, Transport};
-#[cfg(any(feature = "async-std1", feature = "tokio02"))]
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
 use async_trait::async_trait;
 use std::{error::Error as StdError, fmt};
 
@@ -80,7 +80,7 @@ impl Transport for StubTransport {
     }
 }
 
-#[cfg(feature = "tokio02")]
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
 #[async_trait]
 impl AsyncTransport for StubTransport {
     type Ok = ();

--- a/src/transport/stub/mod.rs
+++ b/src/transport/stub/mod.rs
@@ -28,10 +28,8 @@
 //! # }
 //! ```
 
-#[cfg(feature = "async-std1")]
-use crate::AsyncStd1Transport;
-#[cfg(feature = "tokio02")]
-use crate::Tokio02Transport;
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
+use crate::AsyncTransport;
 use crate::{address::Envelope, Transport};
 #[cfg(any(feature = "async-std1", feature = "tokio02"))]
 use async_trait::async_trait;
@@ -82,20 +80,9 @@ impl Transport for StubTransport {
     }
 }
 
-#[cfg(feature = "async-std1")]
-#[async_trait]
-impl AsyncStd1Transport for StubTransport {
-    type Ok = ();
-    type Error = Error;
-
-    async fn send_raw(&self, _envelope: &Envelope, _email: &[u8]) -> Result<Self::Ok, Self::Error> {
-        self.response
-    }
-}
-
 #[cfg(feature = "tokio02")]
 #[async_trait]
-impl Tokio02Transport for StubTransport {
+impl AsyncTransport for StubTransport {
     type Ok = ();
     type Error = Error;
 

--- a/tests/transport_file.rs
+++ b/tests/transport_file.rs
@@ -99,9 +99,9 @@ mod test {
     #[cfg(feature = "async-std1")]
     #[async_std::test]
     async fn file_transport_asyncstd1() {
-        use lettre::AsyncStd1Transport;
+        use lettre::{AsyncFileTransport, AsyncStd1Executor, AsyncTransport};
 
-        let sender = FileTransport::new(temp_dir());
+        let sender = AsyncFileTransport::<AsyncStd1Executor>::new(temp_dir());
         let email = Message::builder()
             .from("NoBody <nobody@domain.tld>".parse().unwrap())
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
@@ -136,9 +136,9 @@ mod test {
     #[cfg(feature = "tokio02")]
     #[tokio::test]
     async fn file_transport_tokio02() {
-        use lettre::Tokio02Transport;
+        use lettre::{AsyncFileTransport, AsyncTransport, Tokio02Executor};
 
-        let sender = FileTransport::new(temp_dir());
+        let sender = AsyncFileTransport::<Tokio02Executor>::new(temp_dir());
         let email = Message::builder()
             .from("NoBody <nobody@domain.tld>".parse().unwrap())
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())

--- a/tests/transport_sendmail.rs
+++ b/tests/transport_sendmail.rs
@@ -26,9 +26,9 @@ mod test {
     #[cfg(feature = "async-std1")]
     #[async_std::test]
     async fn sendmail_transport_asyncstd1() {
-        use lettre::AsyncStd1Transport;
+        use lettre::{AsyncSendmailTransport, AsyncStd1Executor, AsyncTransport};
 
-        let sender = SendmailTransport::new();
+        let sender = AsyncSendmailTransport::<AsyncStd1Executor>::new();
         let email = Message::builder()
             .from("NoBody <nobody@domain.tld>".parse().unwrap())
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
@@ -46,9 +46,9 @@ mod test {
     #[cfg(feature = "tokio02")]
     #[tokio::test]
     async fn sendmail_transport_tokio02() {
-        use lettre::Tokio02Transport;
+        use lettre::{AsyncSendmailTransport, Tokio02Executor, Tokio02Transport};
 
-        let sender = SendmailTransport::new();
+        let sender = AsyncSendmailTransport::<Tokio02Executor>::new();
         let email = Message::builder()
             .from("NoBody <nobody@domain.tld>".parse().unwrap())
             .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())


### PR DESCRIPTION
Part 2 of 2 of the `AsyncSmtpConnector` refactor.

Changes:

* `AsyncStd1Transport` -> `AsyncTransport`
* `Tokio02Transport` -> `AsyncTransport`
* `Tokio1Transport` -> `AsyncTransport`
* `AsyncStd1Connector` -> `AsyncStd1Executor`
* `Tokio02Connector` -> `Tokio02Executor`
* `Tokio1Connector` -> `Tokio1Executor`
* `FileTransport` is sync only, use `AsyncFileTransport<AsyncStd1Executor>`, `AsyncFileTransport<Tokio02Executor>`, `AsyncFileTransport<Tokio1Executor>` for the async version
* `SendmailTransport` is sync only, use `AsyncSendmailTransport<AsyncStd1Executor>`, `AsyncSendmailTransport<Tokio02Executor>`, `AsyncSendmailTransport<Tokio1Executor>` for the async version

Basically we now have a trait for sync transports and another one for async transports, instead of having a different trait for every executor, which didn't make much sense.


The old names have been kept, but are deprecated. This should allow for an easier migration.