### PR TITLE
PoolConfig max_size setter fix

### DIFF
--- a/src/transport/smtp/pool.rs
+++ b/src/transport/smtp/pool.rs
@@ -33,7 +33,7 @@ impl PoolConfig {
     ///
     /// Defaults to `10`
     pub fn max_size(mut self, max_size: u32) -> Self {
-        self.min_idle = max_size;
+        self.max_size = max_size;
         self
     }
 


### PR DESCRIPTION
Currently the `max_size` setter method incorrectly assigns the new value to `self.min_idle` instead of `self.max_size`. This
change fixes the issue.