### PR TITLE
Fix various parts of the docs

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -26,6 +26,18 @@ use crate::transport::smtp::extension::ClientId;
 ))]
 use crate::transport::smtp::Error;
 
+/// Async executor abstraction trait
+///
+/// Used by [`AsyncSmtpTransport`], [`AsyncSendmailTransport`] and [`AsyncFileTransport`]
+/// in order to be able to work with different async runtimes.
+///
+/// [`AsyncSmtpTransport`]: crate::AsyncSmtpTransport
+/// [`AsyncSendmailTransport`]: crate::AsyncSendmailTransport
+/// [`AsyncFileTransport`]: crate::AsyncFileTransport
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
+)]
 #[async_trait]
 pub trait Executor: Send + Sync + private::Sealed {
     #[doc(hidden)]
@@ -46,6 +58,14 @@ pub trait Executor: Send + Sync + private::Sealed {
     async fn fs_write(path: &Path, contents: &[u8]) -> IoResult<()>;
 }
 
+/// Async [`Executor`] using `tokio` `0.2.x`
+///
+/// Used by [`AsyncSmtpTransport`], [`AsyncSendmailTransport`] and [`AsyncFileTransport`]
+/// in order to be able to work with different async runtimes.
+///
+/// [`AsyncSmtpTransport`]: crate::AsyncSmtpTransport
+/// [`AsyncSendmailTransport`]: crate::AsyncSendmailTransport
+/// [`AsyncFileTransport`]: crate::AsyncFileTransport
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 #[cfg(feature = "tokio02")]
@@ -103,6 +123,14 @@ impl Executor for Tokio02Executor {
     }
 }
 
+/// Async [`Executor`] using `tokio` `1.x`
+///
+/// Used by [`AsyncSmtpTransport`], [`AsyncSendmailTransport`] and [`AsyncFileTransport`]
+/// in order to be able to work with different async runtimes.
+///
+/// [`AsyncSmtpTransport`]: crate::AsyncSmtpTransport
+/// [`AsyncSendmailTransport`]: crate::AsyncSendmailTransport
+/// [`AsyncFileTransport`]: crate::AsyncFileTransport
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 #[cfg(feature = "tokio1")]
@@ -159,6 +187,14 @@ impl Executor for Tokio1Executor {
     }
 }
 
+/// Async [`Executor`] using `async-std` `1.x`
+///
+/// Used by [`AsyncSmtpTransport`], [`AsyncSendmailTransport`] and [`AsyncFileTransport`]
+/// in order to be able to work with different async runtimes.
+///
+/// [`AsyncSmtpTransport`]: crate::AsyncSmtpTransport
+/// [`AsyncSendmailTransport`]: crate::AsyncSendmailTransport
+/// [`AsyncFileTransport`]: crate::AsyncFileTransport
 #[allow(missing_copy_implementations)]
 #[non_exhaustive]
 #[cfg(feature = "async-std1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,17 @@
 //! * Pluggable email transports
 //! * Unicode support
 //! * Secure defaults
+//! * Async support
 //!
 //! Lettre requires Rust 1.45 or newer.
 //!
 //! ## Optional features
 //!
 //! * **builder**: Message builder
-//! * **file-transport**: Transport that write messages into a file
+//! * **file-transport**: Transport that writes messages into a file
 //! * **file-transport-envelope**: Allow writing the envelope into a JSON file
 //! * **smtp-transport**: Transport over SMTP
-//! * **sendmail-transport**: Transport over SMTP
+//! * **sendmail-transport**: Transport using the `sendmail` command
 //! * **rustls-tls**: TLS support with the `rustls` crate
 //! * **native-tls**: TLS support with the `native-tls` crate
 //! * **tokio02**: Allow to asyncronously send emails using tokio 0.2.x
@@ -46,7 +47,7 @@
 
 pub mod address;
 pub mod error;
-#[cfg(all(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))]
+#[cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1"))]
 mod executor;
 #[cfg(feature = "builder")]
 #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
@@ -66,29 +67,36 @@ pub use self::executor::Tokio02Executor;
 #[cfg(feature = "tokio1")]
 pub use self::executor::Tokio1Executor;
 #[cfg(all(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))]
+#[doc(inline)]
 pub use self::transport::AsyncTransport;
 pub use crate::address::Address;
 #[cfg(feature = "builder")]
+#[doc(inline)]
 pub use crate::message::Message;
 #[cfg(all(
     feature = "file-transport",
     any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
 ))]
+#[doc(inline)]
 pub use crate::transport::file::AsyncFileTransport;
 #[cfg(feature = "file-transport")]
+#[doc(inline)]
 pub use crate::transport::file::FileTransport;
 #[cfg(all(
     feature = "sendmail-transport",
     any(feature = "tokio02", feature = "tokio1", feature = "async-std1")
 ))]
+#[doc(inline)]
 pub use crate::transport::sendmail::AsyncSendmailTransport;
 #[cfg(feature = "sendmail-transport")]
+#[doc(inline)]
 pub use crate::transport::sendmail::SendmailTransport;
 #[cfg(all(
     feature = "smtp-transport",
     any(feature = "tokio02", feature = "tokio1")
 ))]
 pub use crate::transport::smtp::AsyncSmtpTransport;
+#[doc(inline)]
 pub use crate::transport::Transport;
 use crate::{address::Envelope, error::Error};
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -492,6 +492,7 @@ impl MessageBuilder {
 }
 
 /// Email message which can be formatted
+#[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
 #[derive(Clone, Debug)]
 pub struct Message {
     headers: Headers,

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -6,11 +6,11 @@
 //!
 //! ```rust
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "file-transport", feature = "builder"))]
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! use lettre::{FileTransport, Message, Transport};
 //! use std::env::temp_dir;
+//! use lettre::{FileTransport, Message, Transport};
 //!
 //! // Write to the local temp directory
 //! let sender = FileTransport::new(temp_dir());
@@ -38,11 +38,11 @@
 //!
 //! ```rust
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "file-transport-envelope", feature = "builder"))]
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! use lettre::{FileTransport, Message, Transport};
 //! use std::env::temp_dir;
+//! use lettre::{FileTransport, Message, Transport};
 //!
 //! // Write to the local temp directory
 //! let sender = FileTransport::with_envelope(temp_dir());
@@ -66,7 +66,7 @@
 //!
 //! ```rust,no_run
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "tokio1", feature = "file-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
@@ -91,7 +91,7 @@
 //!
 //! ```rust,no_run
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "async-std1", feature = "file-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use std::env::temp_dir;
@@ -153,14 +153,20 @@ type Id = String;
 /// Writes the content and the envelope information to a file
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(docsrs, doc(cfg(feature = "file-transport")))]
 pub struct FileTransport {
     path: PathBuf,
     #[cfg(feature = "file-transport-envelope")]
     save_envelope: bool,
 }
 
+/// Asynchronously writes the content and the envelope information to a file
 #[derive(Debug)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
+)]
 #[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 pub struct AsyncFileTransport<E: Executor> {
     inner: FileTransport,

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -19,19 +19,6 @@
 #[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
 use async_trait::async_trait;
 
-#[doc(hidden)]
-#[deprecated(note = "use lettre::AsyncStd1Transport")]
-#[cfg(feature = "async-std1")]
-pub use self::AsyncTransport as AsyncStd1Transport;
-#[doc(hidden)]
-#[deprecated(note = "use lettre::Tokio1Transport")]
-#[cfg(feature = "tokio1")]
-pub use self::AsyncTransport as Tokio1Transport;
-#[doc(hidden)]
-#[deprecated(note = "use lettre::Tokio02Transport")]
-#[cfg(feature = "tokio02")]
-pub use self::AsyncTransport as Tokio02Transport;
-
 use crate::Envelope;
 #[cfg(feature = "builder")]
 use crate::Message;

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -4,10 +4,10 @@
 //!
 //! ```rust
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "sendmail-transport", feature = "builder"))]
 //! # fn main() -> Result<(), Box<dyn Error>> {
-//! # use lettre::{Message, Transport, SendmailTransport};
+//! use lettre::{Message, Transport, SendmailTransport};
 //!
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
@@ -30,7 +30,7 @@
 //!
 //! ```rust,no_run
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "tokio02", feature = "sendmail-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, AsyncTransport, Tokio02Executor, AsyncSendmailTransport, SendmailTransport};
@@ -53,7 +53,7 @@
 //!
 //! ```rust,no_run
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "tokio1", feature = "sendmail-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, AsyncTransport, Tokio1Executor, AsyncSendmailTransport, SendmailTransport};
@@ -76,7 +76,7 @@
 //!
 //!```rust,no_run
 //! # use std::error::Error;
-//!
+//! #
 //! # #[cfg(all(feature = "async-std1", feature = "sendmail-transport", feature = "builder"))]
 //! # async fn run() -> Result<(), Box<dyn Error>> {
 //! use lettre::{Message, AsyncTransport, AsyncStd1Executor, AsyncSendmailTransport};
@@ -119,16 +119,22 @@ mod error;
 
 const DEFAUT_SENDMAIL: &str = "/usr/sbin/sendmail";
 
-/// Sends an email using the `sendmail` command
+/// Sends emails using the `sendmail` command
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(docsrs, doc(cfg(feature = "sendmail-transport")))]
 pub struct SendmailTransport {
     command: OsString,
 }
 
+/// Asynchronously sends emails using the `sendmail` command
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg(any(feature = "async-std1", feature = "tokio02", feature = "tokio1"))]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
+)]
 pub struct AsyncSendmailTransport<E: Executor> {
     inner: SendmailTransport,
     marker_: PhantomData<E>,

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -15,6 +15,11 @@ use crate::Tokio02Executor;
 use crate::Tokio1Executor;
 use crate::{Envelope, Executor};
 
+/// Asynchronously sends emails using the SMTP protocol
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
+)]
 #[allow(missing_debug_implementations)]
 pub struct AsyncSmtpTransport<E> {
     // TODO: pool
@@ -93,6 +98,16 @@ where
         feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "tokio02-native-tls",
+            feature = "tokio02-rustls-tls",
+            feature = "tokio1-native-tls",
+            feature = "tokio1-rustls-tls",
+            feature = "async-std1-rustls-tls"
+        )))
+    )]
     pub fn relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         use super::{Tls, TlsParameters, SUBMISSIONS_PORT};
 
@@ -122,6 +137,16 @@ where
         feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "tokio02-native-tls",
+            feature = "tokio02-rustls-tls",
+            feature = "tokio1-native-tls",
+            feature = "tokio1-rustls-tls",
+            feature = "async-std1-rustls-tls"
+        )))
+    )]
     pub fn starttls_relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         use super::{Tls, TlsParameters, SUBMISSION_PORT};
 
@@ -174,6 +199,10 @@ where
 /// Instances of this struct can be created using functions of [`AsyncSmtpTransport`].
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
+#[cfg_attr(
+    docsrs,
+    doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
+)]
 pub struct AsyncSmtpTransportBuilder {
     info: SmtpInfo,
 }
@@ -213,12 +242,22 @@ impl AsyncSmtpTransportBuilder {
         feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(
+            feature = "tokio02-native-tls",
+            feature = "tokio02-rustls-tls",
+            feature = "tokio1-native-tls",
+            feature = "tokio1-rustls-tls",
+            feature = "async-std1-rustls-tls"
+        )))
+    )]
     pub fn tls(mut self, tls: super::Tls) -> Self {
         self.info.tls = tls;
         self
     }
 
-    /// Build the transport (with default pool if enabled)
+    /// Build the transport
     pub fn build<E>(self) -> AsyncSmtpTransport<E>
     where
         E: Executor,

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -10,9 +10,10 @@ use super::{ClientId, Credentials, Error, Mechanism, Response, SmtpConnection, S
 use super::{Tls, TlsParameters, SUBMISSIONS_PORT, SUBMISSION_PORT};
 use crate::{address::Envelope, Transport};
 
+/// Sends emails using the SMTP protocol
+#[cfg_attr(docsrs, doc(cfg(feature = "smtp-transport")))]
 #[allow(missing_debug_implementations)]
 #[derive(Clone)]
-/// Transport using the SMTP protocol
 pub struct SmtpTransport {
     #[cfg(feature = "r2d2")]
     inner: Pool<SmtpClient>,


### PR DESCRIPTION
Fixes various sections of the docs:

* doc_cfg features not being documented
* `doc(inline)`s re-exports to lib.rs - _this may not be the right decision, should we instead do something like [tokio](https://docs.rs/tokio/1.3.0/tokio/#working-with-tasks), where modules and some structs are explained at the start of the docs?_
* adds and fixes various docs
* removes empty lines at the beginning of doc tests