### PR TITLE
docs: improve docs for lettre::transport

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -32,10 +32,12 @@
 //!
 //! ```rust,no_run
 //! # use std::error::Error;
+//! #
+//! # #[cfg(all(feature = "builder", feature = "smtp-transport"))]
+//! # fn main() -> Result<(), Box<dyn Error>> {
 //! use lettre::transport::smtp::authentication::Credentials;
 //! use lettre::{Message, SmtpTransport, Transport};
 //!
-//! # fn main() -> Result<(), Box<dyn Error>> {
 //! let email = Message::builder()
 //!     .from("NoBody <nobody@domain.tld>".parse()?)
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -55,6 +55,7 @@
 //!     Ok(_) => println!("Email sent successfully!"),
 //!     Err(e) => panic!("Could not send email: {:?}", e),
 //! }
+//! # Ok(())
 //! # }
 //! ```
 //!

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -1,29 +1,30 @@
 //! ## Transports for sending emails
 //!
 //! This module contains `Transport`s for sending emails. A `Transport` implements a high-level API
-//! for sending emails.
+//! for sending emails. It automatically manages the underlying resources and doesn't require any
+//! specific knowledge of email protocols in order to be used.
 //!
 //! The following transports are available:
 //!
-//! | Module       | Protocol | Sync API              | Async API                  | Description                                |
-//! | ------------ | -------- | --------------------- | -------------------------- | ------------------------------------------ |
-//! | [`smtp`]     | SMTP     | [`SmtpTransport`]     | [`AsyncSmtpTransport`]     | Uses the SMTP protocol to send emails      |
-//! | [`sendmail`] | Sendmail | [`SendmailTransport`] | [`AsyncSendmailTransport`] | Uses the `sendmail` command to send emails |
-//! | [`file`]     | File     | [`FileTransport`]     | [`AsyncFileTransport`]     | Saves the email as an `.eml` file          |
-//! | [`stub`]     | Debug    | [`StubTransport`]     | [`StubTransport`]          | Drops the email - Useful for debugging     |
+//! | Module       | Protocol | Sync API              | Async API                  | Description                                             |
+//! | ------------ | -------- | --------------------- | -------------------------- | ------------------------------------------------------- |
+//! | [`smtp`]     | SMTP     | [`SmtpTransport`]     | [`AsyncSmtpTransport`]     | Uses the SMTP protocol to send emails to a relay server |
+//! | [`sendmail`] | Sendmail | [`SendmailTransport`] | [`AsyncSendmailTransport`] | Uses the `sendmail` command to send emails              |
+//! | [`file`]     | File     | [`FileTransport`]     | [`AsyncFileTransport`]     | Saves the email as an `.eml` file                       |
+//! | [`stub`]     | Debug    | [`StubTransport`]     | [`StubTransport`]          | Drops the email - Useful for debugging                  |
 //!
 //! ## Building an email
 //!
 //! Emails can either be built though [`Message`], which is a typed API for constructing emails
-//! (more info about it can be found in the [`message`] module) or via an external means.
+//! (find out more about it by going over the [`message`] module), or via external means.
 //!
-//! [`Message`]s can be sent via [`Transport::send`] or [`AsyncTransport::send`], while those who
-//! haven't been built via [`Message`] can be sent via [`Transport::send_raw`] or
+//! [`Message`]s can be sent via [`Transport::send`] or [`AsyncTransport::send`], while messages
+//! built without lettre's [`message`] APIs can be sent via [`Transport::send_raw`] or
 //! [`AsyncTransport::send_raw`].
 //!
 //! ## Brief example
 //!
-//! This example shows how to build an email and send it via SMTP.
+//! This example shows how to build an email and send it via an SMTP relay server.
 //! It is in no way a complete example, but it shows how to get started with lettre.
 //! More examples can be found by looking at the specific modules, linked in the _Module_ column
 //! of the [table above](#transports-for-sending-emails).

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -59,6 +59,8 @@
 //! }
 //! # Ok(())
 //! # }
+//! # #[cfg(not(all(feature = "builder", feature = "smtp-transport")))]
+//! # fn main() {}
 //! ```
 //!
 //! [`Message`]: crate::Message

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -16,11 +16,12 @@
 //! ## Building an email
 //!
 //! Emails can either be built though [`Message`], which is a typed API for constructing emails
-//! (find out more about it by going over the [`message`] module), or via external means.
+//! (find out more about it by going over the [`message`][crate::message] module),
+//! or via external means.
 //!
 //! [`Message`]s can be sent via [`Transport::send`] or [`AsyncTransport::send`], while messages
-//! built without lettre's [`message`] APIs can be sent via [`Transport::send_raw`] or
-//! [`AsyncTransport::send_raw`].
+//! built without lettre's [`message`][crate::message] APIs can be sent via [`Transport::send_raw`]
+//! or [`AsyncTransport::send_raw`].
 //!
 //! ## Brief example
 //!
@@ -58,7 +59,6 @@
 //! ```
 //!
 //! [`Message`]: crate::Message
-//! [`message`]: crate::message
 //! [`file`]: self::file
 //! [`SmtpTransport`]: crate::SmtpTransport
 //! [`AsyncSmtpTransport`]: crate::AsyncSmtpTransport

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -1,4 +1,4 @@
-//! The sendmail transport sends the email using the local sendmail command.
+//! The sendmail transport sends the email using the local `sendmail` command.
 //!
 //! ## Sync example
 //!


### PR DESCRIPTION
Improves the docs for `lettre::transport`.

## Rendered version

![part1](https://user-images.githubusercontent.com/6215781/111029338-874e8780-83fc-11eb-9cc4-62e038e13903.png)

![part2](https://user-images.githubusercontent.com/6215781/111029343-8e759580-83fc-11eb-9281-0ab56ca125e6.png)
