### PR TITLE
Remove From implementations on Error for file and sendmail transport

### DIFF
--- a/src/transport/file/error.rs
+++ b/src/transport/file/error.rs
@@ -10,8 +10,6 @@ use std::{
 /// An enum of all error kinds.
 #[derive(Debug)]
 pub enum Error {
-    /// Internal client error
-    Client(&'static str),
     /// IO error
     Io(io::Error),
     /// JSON error
@@ -21,41 +19,20 @@ pub enum Error {
 
 impl Display for Error {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        match *self {
-            Client(err) => fmt.write_str(err),
-            Io(ref err) => err.fmt(fmt),
+        match &self {
+            Io(err) => err.fmt(fmt),
             #[cfg(feature = "file-transport-envelope")]
-            Json(ref err) => err.fmt(fmt),
+            Json(err) => err.fmt(fmt),
         }
     }
 }
 
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match *self {
-            Io(ref err) => Some(&*err),
+        match &self {
+            Io(err) => Some(&*err),
             #[cfg(feature = "file-transport-envelope")]
-            Json(ref err) => Some(&*err),
-            _ => None,
+            Json(err) => Some(&*err),
         }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
-        Error::Io(err)
-    }
-}
-
-#[cfg(feature = "file-transport-envelope")]
-impl From<serde_json::Error> for Error {
-    fn from(err: serde_json::Error) -> Error {
-        Error::Json(err)
-    }
-}
-
-impl From<&'static str> for Error {
-    fn from(string: &'static str) -> Error {
-        Error::Client(string)
     }
 }

--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -206,11 +206,11 @@ impl FileTransport {
         use std::fs;
 
         let eml_file = self.path.join(format!("{}.eml", email_id));
-        let eml = fs::read(eml_file)?;
+        let eml = fs::read(eml_file).map_err(Error::Io)?;
 
         let json_file = self.path.join(format!("{}.json", email_id));
-        let json = fs::read(&json_file)?;
-        let envelope = serde_json::from_slice(&json)?;
+        let json = fs::read(&json_file).map_err(Error::Io)?;
+        let envelope = serde_json::from_slice(&json).map_err(Error::Json)?;
 
         Ok((envelope, eml))
     }
@@ -253,11 +253,11 @@ where
     #[cfg(feature = "file-transport-envelope")]
     pub async fn read(&self, email_id: &str) -> Result<(Envelope, Vec<u8>), Error> {
         let eml_file = self.inner.path.join(format!("{}.eml", email_id));
-        let eml = E::fs_read(&eml_file).await?;
+        let eml = E::fs_read(&eml_file).await.map_err(Error::Io)?;
 
         let json_file = self.inner.path.join(format!("{}.json", email_id));
-        let json = E::fs_read(&json_file).await?;
-        let envelope = serde_json::from_slice(&json)?;
+        let json = E::fs_read(&json_file).await.map_err(Error::Io)?;
+        let envelope = serde_json::from_slice(&json).map_err(Error::Json)?;
 
         Ok((envelope, eml))
     }
@@ -273,13 +273,14 @@ impl Transport for FileTransport {
         let email_id = Uuid::new_v4();
 
         let file = self.path(&email_id, "eml");
-        fs::write(file, email)?;
+        fs::write(file, email).map_err(Error::Io)?;
 
         #[cfg(feature = "file-transport-envelope")]
         {
             if self.save_envelope {
                 let file = self.path(&email_id, "json");
-                fs::write(file, serde_json::to_string(&envelope)?)?;
+                let buf = serde_json::to_string(&envelope).map_err(Error::Json)?;
+                fs::write(file, buf).map_err(Error::Io)?;
             }
         }
         // use envelope anyway
@@ -302,14 +303,14 @@ where
         let email_id = Uuid::new_v4();
 
         let file = self.inner.path(&email_id, "eml");
-        E::fs_write(&file, email).await?;
+        E::fs_write(&file, email).await.map_err(Error::Io)?;
 
         #[cfg(feature = "file-transport-envelope")]
         {
             if self.inner.save_envelope {
                 let file = self.inner.path(&email_id, "json");
-                let buf = serde_json::to_vec(&envelope)?;
-                E::fs_write(&file, &buf).await?;
+                let buf = serde_json::to_vec(&envelope).map_err(Error::Json)?;
+                E::fs_write(&file, &buf).await.map_err(Error::Io)?;
             }
         }
         // use envelope anyway

--- a/src/transport/sendmail/error.rs
+++ b/src/transport/sendmail/error.rs
@@ -21,32 +21,20 @@ pub enum Error {
 
 impl Display for Error {
     fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), fmt::Error> {
-        match *self {
-            Client(ref err) => err.fmt(fmt),
-            Utf8Parsing(ref err) => err.fmt(fmt),
-            Io(ref err) => err.fmt(fmt),
+        match &self {
+            Client(err) => err.fmt(fmt),
+            Utf8Parsing(err) => err.fmt(fmt),
+            Io(err) => err.fmt(fmt),
         }
     }
 }
 
 impl StdError for Error {
     fn source(&self) -> Option<&(dyn StdError + 'static)> {
-        match *self {
-            Io(ref err) => Some(&*err),
-            Utf8Parsing(ref err) => Some(&*err),
+        match &self {
+            Io(err) => Some(&*err),
+            Utf8Parsing(err) => Some(&*err),
             _ => None,
         }
-    }
-}
-
-impl From<io::Error> for Error {
-    fn from(err: io::Error) -> Error {
-        Error::Io(err)
-    }
-}
-
-impl From<FromUtf8Error> for Error {
-    fn from(err: FromUtf8Error) -> Error {
-        Utf8Parsing(err)
     }
 }

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -269,15 +269,21 @@ impl Transport for SendmailTransport {
 
     fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
         // Spawn the sendmail command
-        let mut process = self.command(envelope).spawn()?;
+        let mut process = self.command(envelope).spawn().map_err(Error::Io)?;
 
-        process.stdin.as_mut().unwrap().write_all(email)?;
-        let output = process.wait_with_output()?;
+        process
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(email)
+            .map_err(Error::Io)?;
+        let output = process.wait_with_output().map_err(Error::Io)?;
 
         if output.status.success() {
             Ok(())
         } else {
-            Err(error::Error::Client(String::from_utf8(output.stderr)?))
+            let stderr = String::from_utf8(output.stderr).map_err(Error::Utf8Parsing)?;
+            Err(Error::Client(stderr))
         }
     }
 }
@@ -294,15 +300,22 @@ impl AsyncTransport for AsyncSendmailTransport<AsyncStd1Executor> {
         let mut command = self.async_std_command(envelope);
 
         // Spawn the sendmail command
-        let mut process = command.spawn()?;
+        let mut process = command.spawn().map_err(Error::Io)?;
 
-        process.stdin.as_mut().unwrap().write_all(&email).await?;
-        let output = process.output().await?;
+        process
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(&email)
+            .await
+            .map_err(Error::Io)?;
+        let output = process.output().await.map_err(Error::Io)?;
 
         if output.status.success() {
             Ok(())
         } else {
-            Err(Error::Client(String::from_utf8(output.stderr)?))
+            let stderr = String::from_utf8(output.stderr).map_err(Error::Utf8Parsing)?;
+            Err(Error::Client(stderr))
         }
     }
 }
@@ -319,15 +332,22 @@ impl AsyncTransport for AsyncSendmailTransport<Tokio02Executor> {
         let mut command = self.tokio02_command(envelope);
 
         // Spawn the sendmail command
-        let mut process = command.spawn()?;
+        let mut process = command.spawn().map_err(Error::Io)?;
 
-        process.stdin.as_mut().unwrap().write_all(&email).await?;
-        let output = process.wait_with_output().await?;
+        process
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(&email)
+            .await
+            .map_err(Error::Io)?;
+        let output = process.wait_with_output().await.map_err(Error::Io)?;
 
         if output.status.success() {
             Ok(())
         } else {
-            Err(Error::Client(String::from_utf8(output.stderr)?))
+            let stderr = String::from_utf8(output.stderr).map_err(Error::Utf8Parsing)?;
+            Err(Error::Client(stderr))
         }
     }
 }
@@ -344,15 +364,22 @@ impl AsyncTransport for AsyncSendmailTransport<Tokio1Executor> {
         let mut command = self.tokio1_command(envelope);
 
         // Spawn the sendmail command
-        let mut process = command.spawn()?;
+        let mut process = command.spawn().map_err(Error::Io)?;
 
-        process.stdin.as_mut().unwrap().write_all(&email).await?;
-        let output = process.wait_with_output().await?;
+        process
+            .stdin
+            .as_mut()
+            .unwrap()
+            .write_all(&email)
+            .await
+            .map_err(Error::Io)?;
+        let output = process.wait_with_output().await.map_err(Error::Io)?;
 
         if output.status.success() {
             Ok(())
         } else {
-            Err(Error::Client(String::from_utf8(output.stderr)?))
+            let stderr = String::from_utf8(output.stderr).map_err(Error::Utf8Parsing)?;
+            Err(Error::Client(stderr))
         }
     }
 }


### PR DESCRIPTION
They shouldn't be part of the public API