### PR TITLE
Add missing Debug implementations

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,5 +1,6 @@
 use async_trait::async_trait;
 
+use std::fmt::Debug;
 #[cfg(feature = "file-transport")]
 use std::io::Result as IoResult;
 #[cfg(feature = "file-transport")]
@@ -39,7 +40,7 @@ use crate::transport::smtp::Error;
     doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
 )]
 #[async_trait]
-pub trait Executor: Send + Sync + private::Sealed {
+pub trait Executor: Debug + Send + Sync + private::Sealed {
     #[doc(hidden)]
     #[cfg(feature = "smtp-transport")]
     async fn connect(
@@ -70,6 +71,7 @@ pub trait Executor: Send + Sync + private::Sealed {
 #[non_exhaustive]
 #[cfg(feature = "tokio02")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio02")))]
+#[derive(Debug)]
 pub struct Tokio02Executor;
 
 #[async_trait]
@@ -135,6 +137,7 @@ impl Executor for Tokio02Executor {
 #[non_exhaustive]
 #[cfg(feature = "tokio1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
+#[derive(Debug)]
 pub struct Tokio1Executor;
 
 #[async_trait]
@@ -199,6 +202,7 @@ impl Executor for Tokio1Executor {
 #[non_exhaustive]
 #[cfg(feature = "async-std1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
+#[derive(Debug)]
 pub struct AsyncStd1Executor;
 
 #[async_trait]

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -1,3 +1,4 @@
+use std::fmt::{self, Debug};
 use std::marker::PhantomData;
 
 use async_trait::async_trait;
@@ -20,7 +21,6 @@ use crate::{Envelope, Executor};
     docsrs,
     doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
 )]
-#[allow(missing_debug_implementations)]
 pub struct AsyncSmtpTransport<E> {
     // TODO: pool
     inner: AsyncSmtpClient<E>,
@@ -184,6 +184,14 @@ where
     }
 }
 
+impl<E> Debug for AsyncSmtpTransport<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut builder = f.debug_struct("AsyncSmtpTransport");
+        builder.field("inner", &self.inner);
+        builder.finish()
+    }
+}
+
 impl<E> Clone for AsyncSmtpTransport<E>
 where
     E: Executor,
@@ -197,8 +205,7 @@ where
 
 /// Contains client configuration.
 /// Instances of this struct can be created using functions of [`AsyncSmtpTransport`].
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 #[cfg_attr(
     docsrs,
     doc(cfg(any(feature = "tokio02", feature = "tokio1", feature = "async-std1")))
@@ -271,9 +278,9 @@ impl AsyncSmtpTransportBuilder {
 }
 
 /// Build client
-pub struct AsyncSmtpClient<C> {
+pub struct AsyncSmtpClient<E> {
     info: SmtpInfo,
-    marker_: PhantomData<C>,
+    marker_: PhantomData<E>,
 }
 
 impl<E> AsyncSmtpClient<E>
@@ -296,6 +303,14 @@ where
             conn.auth(&self.info.authentication, &credentials).await?;
         }
         Ok(conn)
+    }
+}
+
+impl<E> Debug for AsyncSmtpClient<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut builder = f.debug_struct("AsyncSmtpClient");
+        builder.field("info", &self.info);
+        builder.finish()
     }
 }
 

--- a/src/transport/smtp/authentication.rs
+++ b/src/transport/smtp/authentication.rs
@@ -1,14 +1,14 @@
 //! Provides limited SASL authentication mechanisms
 
 use crate::transport::smtp::error::{self, Error};
-use std::fmt::{self, Display, Formatter};
+use std::fmt::{self, Debug, Display, Formatter};
 
 /// Accepted authentication mechanisms
 /// Trying LOGIN last as it is deprecated.
 pub const DEFAULT_MECHANISMS: &[Mechanism] = &[Mechanism::Plain, Mechanism::Login];
 
 /// Contains user credentials
-#[derive(PartialEq, Eq, Clone, Hash, Debug)]
+#[derive(PartialEq, Eq, Clone, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Credentials {
     authentication_identity: String,
@@ -32,6 +32,12 @@ where
 {
     fn from((username, password): (S, T)) -> Self {
         Credentials::new(username.into(), password.into())
+    }
+}
+
+impl Debug for Credentials {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Credentials").finish()
     }
 }
 

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -4,6 +4,7 @@ use crate::transport::smtp::{error, Error};
 use native_tls::{Protocol, TlsConnector};
 #[cfg(feature = "rustls-tls")]
 use rustls::{ClientConfig, RootCertStore, ServerCertVerified, ServerCertVerifier, TLSError};
+use std::fmt::{self, Debug};
 #[cfg(feature = "rustls-tls")]
 use std::sync::Arc;
 #[cfg(feature = "rustls-tls")]
@@ -32,9 +33,22 @@ pub enum Tls {
     Wrapper(TlsParameters),
 }
 
+impl Debug for Tls {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self {
+            Self::None => f.pad("None"),
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            Self::Opportunistic(_) => f.pad("Opportunistic"),
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            Self::Required(_) => f.pad("Required"),
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            Self::Wrapper(_) => f.pad("Wrapper"),
+        }
+    }
+}
+
 /// Parameters to use for secure clients
 #[derive(Clone)]
-#[allow(missing_debug_implementations)]
 pub struct TlsParameters {
     pub(crate) connector: InnerTlsParameters,
     /// The domain name which is expected in the TLS certificate from the server
@@ -42,7 +56,7 @@ pub struct TlsParameters {
 }
 
 /// Builder for `TlsParameters`
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct TlsParametersBuilder {
     domain: String,
     root_certs: Vec<Certificate>,
@@ -259,6 +273,12 @@ impl Certificate {
             #[cfg(feature = "rustls-tls")]
             rustls: rustls_cert,
         })
+    }
+}
+
+impl Debug for Certificate {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Certificate").finish()
     }
 }
 

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -166,8 +166,7 @@ pub const SUBMISSIONS_PORT: u16 = 465;
 /// Default timeout
 pub const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 struct SmtpInfo {
     /// Name sent during EHLO
     hello_name: ClientId,

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -12,7 +12,6 @@ use crate::{address::Envelope, Transport};
 
 /// Sends emails using the SMTP protocol
 #[cfg_attr(docsrs, doc(cfg(feature = "smtp-transport")))]
-#[allow(missing_debug_implementations)]
 #[derive(Clone)]
 pub struct SmtpTransport {
     #[cfg(feature = "r2d2")]
@@ -112,8 +111,7 @@ impl SmtpTransport {
 
 /// Contains client configuration.
 /// Instances of this struct can be created using functions of [`SmtpTransport`].
-#[allow(missing_debug_implementations)]
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SmtpTransportBuilder {
     info: SmtpInfo,
     #[cfg(feature = "r2d2")]
@@ -185,7 +183,7 @@ impl SmtpTransportBuilder {
 }
 
 /// Build client
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SmtpClient {
     info: SmtpInfo,
 }


### PR DESCRIPTION
Implements `Debug` for most items. Changes the debug implementation of `Credentials` to stop exposing the inner credentials.

Closes #568