### PR TITLE
feat(builder): Add helper methods for attachments

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -144,46 +144,21 @@
 //!         MultiPart::mixed()
 //!             .multipart(
 //!                 MultiPart::alternative()
-//!                     .singlepart(
-//!                         SinglePart::builder()
-//!                             .header(header::ContentType("text/plain; charset=utf8".parse()?))
-//!                             .body(String::from("Hello, world! :)")),
-//!                     )
+//!                     .build()
+//!                     .html(String::from("Hello, world! :)"))
 //!                     .multipart(
 //!                         MultiPart::related()
-//!                             .singlepart(
-//!                                 SinglePart::builder()
-//!                                     .header(header::ContentType(
-//!                                         "text/html; charset=utf8".parse()?,
-//!                                     ))
-//!                                     .body(String::from(
-//!                                         "<p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>",
-//!                                     )),
-//!                             )
-//!                             .singlepart(
-//!                                 SinglePart::builder()
-//!                                     .header(header::ContentType("image/png".parse()?))
-//!                                     .header(header::ContentDisposition {
-//!                                         disposition: header::DispositionType::Inline,
-//!                                         parameters: vec![],
-//!                                     })
-//!                                     .header(header::ContentId("<123>".into()))
-//!                                     .body(image_body),
-//!                             ),
+//!                             .build()
+//!                             .html(String::from(
+//!                                 "<p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>",
+//!                             ))
+//!                             .inline_content(image_body, "image/png".parse()?, "<123>"),
 //!                     ),
 //!             )
-//!             .singlepart(
-//!                 SinglePart::builder()
-//!                     .header(header::ContentType("text/plain; charset=utf8".parse()?))
-//!                     .header(header::ContentDisposition {
-//!                         disposition: header::DispositionType::Attachment,
-//!                         parameters: vec![header::DispositionParam::Filename(
-//!                             header::Charset::Ext("utf-8".into()),
-//!                             None,
-//!                             "example.rs".as_bytes().into(),
-//!                         )],
-//!                     })
-//!                     .body(String::from("fn main() { println!(\"Hello, World!\") }")),
+//!             .attachment_content(
+//!                 String::from("fn main() { println!(\"Hello, World!\") }"),
+//!                 "example.rs",
+//!                 "text/plain; charset=utf8".parse()?,
 //!             ),
 //!     )?;
 //! # Ok(())

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -1,5 +1,7 @@
-use std::fmt::{self, Debug};
-use std::marker::PhantomData;
+use std::{
+    fmt::{self, Debug},
+    marker::PhantomData,
+};
 
 use async_trait::async_trait;
 


### PR DESCRIPTION
A first draft of shortcuts for building parts.

Still unsure if we need them bot both `SinglePart` and `MultiPart`.