### PR TITLE
Fix tracing feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 idna = "0.2"
-tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # feature
+tracing = { version = "0.1.16", default-features = false, features = ["std", "log"], optional = true } # feature
 
 # builder
 hyperx = { version = "1", optional = true, features = ["headers"] }


### PR DESCRIPTION
I noticed that tracing doesn't work anymore with using reqwest 0.11.0 or
higher.

With some debugging and checking with some help at gitter we figured it
had to do with some feature not being enabled anymore.

Seems that lettre is missing this feature in its Cargo.toml