### PR TITLE
tls: use rustls if both native-tls and rustls-tls are enabled

### DIFF
--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -128,18 +128,12 @@ impl TlsParametersBuilder {
     /// depending on which one is available
     #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
     #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
-    // TODO: remove below line once native-tls is supported with async-std
-    #[allow(unreachable_code)]
     pub fn build(self) -> Result<TlsParameters, Error> {
-        // TODO: remove once native-tls is supported with async-std
-        #[cfg(all(feature = "rustls-tls", feature = "async-std1"))]
+        #[cfg(feature = "rustls-tls")]
         return self.build_rustls();
 
-        #[cfg(feature = "native-tls")]
+        #[cfg(not(feature = "rustls-tls"))]
         return self.build_native();
-
-        #[cfg(not(feature = "native-tls"))]
-        return self.build_rustls();
     }
 
     /// Creates a new `TlsParameters` using native-tls with the provided configuration


### PR DESCRIPTION
Since native-tls is a default feature, library consumers who enable rustls most likely do it expecting to use it, so this makes it behave like so in cases where default features weren't disabled.

Fixes #585 