### PR TITLE
Bump MSRV to 1.46.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -79,8 +79,8 @@ jobs:
             rust: stable
           - name: beta
             rust: beta
-          - name: 1.45.2
-            rust: 1.45.2
+          - name: 1.46.0
+            rust: 1.46.0
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Lettre does not provide (for now):
 
 ## Example
 
-This library requires Rust 1.45 or newer.
+This library requires Rust 1.46 or newer.
 To use this library, add the following to your `Cargo.toml`:
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! * Secure defaults
 //! * Async support
 //!
-//! Lettre requires Rust 1.45 or newer.
+//! Lettre requires Rust 1.46 or newer.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
One of async-std's dependencies bumped their MSRV to 1.46, and tokio is going to do the same soon.