### PR TITLE
Fix: example in README does not compile

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ let email = Message::builder()
     .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
     .to("Hei <hei@domain.tld>".parse().unwrap())
     .subject("Happy new year")
-    .body("Be happy!")
+    .body(String::from("Be happy!"))
     .unwrap();
 
 let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());


### PR DESCRIPTION
A missing simple string conversion prevented the example code from compiling.