### PR TITLE
Replace hyperx ContentType header with our own implementation

### DIFF
--- a/examples/basic_html.rs
+++ b/examples/basic_html.rs
@@ -29,16 +29,12 @@ fn main() {
             MultiPart::alternative() // This is composed of two parts.
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType(
-                            "text/plain; charset=utf8".parse().unwrap(),
-                        ))
+                        .header(header::ContentType::PLAIN_STRING)
                         .body(String::from("Hello from Lettre! A mailer library for Rust")), // Every message should have a plain text fallback.
                 )
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType(
-                            "text/html; charset=utf8".parse().unwrap(),
-                        ))
+                        .header(header::ContentType::HTML_STRING)
                         .body(String::from(html)),
                 ),
         )

--- a/examples/basic_html.rs
+++ b/examples/basic_html.rs
@@ -29,12 +29,12 @@ fn main() {
             MultiPart::alternative() // This is composed of two parts.
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType::PLAIN_STRING)
+                        .header(header::ContentType::TEXT_PLAIN)
                         .body(String::from("Hello from Lettre! A mailer library for Rust")), // Every message should have a plain text fallback.
                 )
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType::HTML_STRING)
+                        .header(header::ContentType::TEXT_HTML)
                         .body(String::from(html)),
                 ),
         )

--- a/examples/maud_html.rs
+++ b/examples/maud_html.rs
@@ -38,12 +38,12 @@ fn main() {
             MultiPart::alternative() // This is composed of two parts.
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType::PLAIN_STRING)
+                        .header(header::ContentType::TEXT_PLAIN)
                         .body(String::from("Hello from Lettre! A mailer library for Rust")), // Every message should have a plain text fallback.
                 )
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType::HTML_STRING)
+                        .header(header::ContentType::TEXT_HTML)
                         .body(html.into_string()),
                 ),
         )

--- a/examples/maud_html.rs
+++ b/examples/maud_html.rs
@@ -38,16 +38,12 @@ fn main() {
             MultiPart::alternative() // This is composed of two parts.
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType(
-                            "text/plain; charset=utf8".parse().unwrap(),
-                        ))
+                        .header(header::ContentType::PLAIN_STRING)
                         .body(String::from("Hello from Lettre! A mailer library for Rust")), // Every message should have a plain text fallback.
                 )
                 .singlepart(
                     SinglePart::builder()
-                        .header(header::ContentType(
-                            "text/html; charset=utf8".parse().unwrap(),
-                        ))
+                        .header(header::ContentType::HTML_STRING)
                         .body(html.into_string()),
                 ),
         )

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -1,0 +1,128 @@
+use std::{
+    error::Error as StdError,
+    fmt::{self, Display, Result as FmtResult},
+    str::{from_utf8, FromStr},
+};
+
+use hyperx::{
+    header::{Formatter as HeaderFormatter, Header, RawLike},
+    Error as HeaderError, Result as HyperResult,
+};
+use mime::Mime;
+
+/// `Content-Type` of the body
+///
+/// Defined in [RFC2045](https://tools.ietf.org/html/rfc2045#section-5)
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContentType(Mime);
+
+impl ContentType {
+    /// A `ContentType` of type `text/plain; charset=utf-8`
+    pub const PLAIN_STRING: ContentType = Self::from_mime(mime::TEXT_PLAIN_UTF_8);
+
+    /// A `ContentType` of type `text/html; charset=utf-8`
+    pub const HTML_STRING: ContentType = Self::from_mime(mime::TEXT_HTML_UTF_8);
+
+    /// Parse `s` into `ContentType`
+    pub fn parse(s: &str) -> Result<ContentType, ContentTypeErr> {
+        Ok(Self::from_mime(s.parse().map_err(ContentTypeErr)?))
+    }
+
+    pub(crate) const fn from_mime(mime: Mime) -> Self {
+        Self(mime)
+    }
+
+    pub(crate) fn as_ref(&self) -> &Mime {
+        &self.0
+    }
+}
+
+impl Header for ContentType {
+    fn header_name() -> &'static str {
+        "Content-Type"
+    }
+
+    // FIXME HeaderError->HeaderError, same for result
+    fn parse_header<'a, T>(raw: &'a T) -> HyperResult<Self>
+    where
+        T: RawLike<'a>,
+        Self: Sized,
+    {
+        raw.one()
+            .ok_or(HeaderError::Header)
+            .and_then(|r| from_utf8(r).map_err(|_| HeaderError::Header))
+            .and_then(|s| s.parse::<Mime>().map(Self).map_err(|_| HeaderError::Header))
+    }
+
+    fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
+        f.fmt_line(&self.0)
+    }
+}
+
+impl FromStr for ContentType {
+    type Err = ContentTypeErr;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+#[derive(Debug)]
+pub struct ContentTypeErr(mime::FromStrError);
+
+impl StdError for ContentTypeErr {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        Some(&self.0)
+    }
+}
+
+impl Display for ContentTypeErr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        Display::fmt(&self.0, f)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use hyperx::header::Headers;
+
+    use super::ContentType;
+
+    #[test]
+    fn format_content_type() {
+        let mut headers = Headers::new();
+
+        headers.set(ContentType::PLAIN_STRING);
+
+        assert_eq!(
+            format!("{}", headers),
+            "Content-Type: text/plain; charset=utf-8\r\n"
+        );
+
+        headers.set(ContentType::HTML_STRING);
+
+        assert_eq!(
+            format!("{}", headers),
+            "Content-Type: text/html; charset=utf-8\r\n"
+        );
+    }
+
+    #[test]
+    fn parse_content_type() {
+        let mut headers = Headers::new();
+
+        headers.set_raw("Content-Type", "text/plain; charset=utf-8");
+
+        assert_eq!(
+            headers.get::<ContentType>(),
+            Some(&ContentType::PLAIN_STRING)
+        );
+
+        headers.set_raw("Content-Type", "text/html; charset=utf-8");
+
+        assert_eq!(
+            headers.get::<ContentType>(),
+            Some(&ContentType::HTML_STRING)
+        );
+    }
+}

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -67,6 +67,7 @@ impl FromStr for ContentType {
     }
 }
 
+/// An error occurred while trying to [`ContentType::parse`].
 #[derive(Debug)]
 pub struct ContentTypeErr(mime::FromStrError);
 

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -18,10 +18,14 @@ pub struct ContentType(Mime);
 
 impl ContentType {
     /// A `ContentType` of type `text/plain; charset=utf-8`
-    pub const PLAIN_STRING: ContentType = Self::from_mime(mime::TEXT_PLAIN_UTF_8);
+    ///
+    /// Indicates that the body is in utf-8 encoded plain text.
+    pub const TEXT_PLAIN: ContentType = Self::from_mime(mime::TEXT_PLAIN_UTF_8);
 
     /// A `ContentType` of type `text/html; charset=utf-8`
-    pub const HTML_STRING: ContentType = Self::from_mime(mime::TEXT_HTML_UTF_8);
+    ///
+    /// Indicates that the body is in utf-8 encoded html.
+    pub const TEXT_HTML: ContentType = Self::from_mime(mime::TEXT_HTML_UTF_8);
 
     /// Parse `s` into `ContentType`
     pub fn parse(s: &str) -> Result<ContentType, ContentTypeErr> {
@@ -93,14 +97,14 @@ mod test {
     fn format_content_type() {
         let mut headers = Headers::new();
 
-        headers.set(ContentType::PLAIN_STRING);
+        headers.set(ContentType::TEXT_PLAIN);
 
         assert_eq!(
             format!("{}", headers),
             "Content-Type: text/plain; charset=utf-8\r\n"
         );
 
-        headers.set(ContentType::HTML_STRING);
+        headers.set(ContentType::TEXT_HTML);
 
         assert_eq!(
             format!("{}", headers),
@@ -114,16 +118,10 @@ mod test {
 
         headers.set_raw("Content-Type", "text/plain; charset=utf-8");
 
-        assert_eq!(
-            headers.get::<ContentType>(),
-            Some(&ContentType::PLAIN_STRING)
-        );
+        assert_eq!(headers.get::<ContentType>(), Some(&ContentType::TEXT_PLAIN));
 
         headers.set_raw("Content-Type", "text/html; charset=utf-8");
 
-        assert_eq!(
-            headers.get::<ContentType>(),
-            Some(&ContentType::HTML_STRING)
-        );
+        assert_eq!(headers.get::<ContentType>(), Some(&ContentType::TEXT_HTML));
     }
 }

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -5,7 +5,7 @@ pub use hyperx::header::{
     Headers, HttpDate as EmailDate,
 };
 
-pub use self::content_type::ContentType;
+pub use self::content_type::{ContentType, ContentTypeErr};
 pub use self::{content::*, mailbox::*, special::*, textual::*};
 
 mod content;

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -1,13 +1,15 @@
 //! Headers widely used in email messages
 
+pub use hyperx::header::{
+    Charset, ContentDisposition, ContentLocation, Date, DispositionParam, DispositionType, Header,
+    Headers, HttpDate as EmailDate,
+};
+
+pub use self::content_type::ContentType;
+pub use self::{content::*, mailbox::*, special::*, textual::*};
+
 mod content;
+mod content_type;
 mod mailbox;
 mod special;
 mod textual;
-
-pub use self::{content::*, mailbox::*, special::*, textual::*};
-
-pub use hyperx::header::{
-    Charset, ContentDisposition, ContentLocation, ContentType, Date, DispositionParam,
-    DispositionType, Header, Headers, HttpDate as EmailDate,
-};

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -94,7 +94,7 @@ impl Default for SinglePartBuilder {
 /// # use std::error::Error;
 /// # fn main() -> Result<(), Box<dyn Error>> {
 /// let part = SinglePart::builder()
-///     .header(header::ContentType::PLAIN_STRING)
+///     .header(header::ContentType::TEXT_PLAIN)
 ///     .body(String::from("Текст письма в уникоде"));
 /// # Ok(())
 /// # }
@@ -416,7 +416,7 @@ mod test {
     #[test]
     fn single_part_binary() {
         let part = SinglePart::builder()
-            .header(header::ContentType::PLAIN_STRING)
+            .header(header::ContentType::TEXT_PLAIN)
             .header(header::ContentTransferEncoding::Binary)
             .body(String::from("Текст письма в уникоде"));
 
@@ -434,7 +434,7 @@ mod test {
     #[test]
     fn single_part_quoted_printable() {
         let part = SinglePart::builder()
-            .header(header::ContentType::PLAIN_STRING)
+            .header(header::ContentType::TEXT_PLAIN)
             .header(header::ContentTransferEncoding::QuotedPrintable)
             .body(String::from("Текст письма в уникоде"));
 
@@ -453,7 +453,7 @@ mod test {
     #[test]
     fn single_part_base64() {
         let part = SinglePart::builder()
-            .header(header::ContentType::PLAIN_STRING)
+            .header(header::ContentType::TEXT_PLAIN)
             .header(header::ContentTransferEncoding::Base64)
             .body(String::from("Текст письма в уникоде"));
 
@@ -474,13 +474,13 @@ mod test {
             .boundary("F2mTKN843loAAAAA8porEdAjCKhArPxGeahYoZYSftse1GT/84tup+O0bs8eueVuAlMK")
             .part(Part::Single(
                 SinglePart::builder()
-                    .header(header::ContentType::PLAIN_STRING)
+                    .header(header::ContentType::TEXT_PLAIN)
                     .header(header::ContentTransferEncoding::Binary)
                     .body(String::from("Текст письма в уникоде")),
             ))
             .singlepart(
                 SinglePart::builder()
-                    .header(header::ContentType::PLAIN_STRING)
+                    .header(header::ContentType::TEXT_PLAIN)
                     .header(header::ContentDisposition {
                         disposition: header::DispositionType::Attachment,
                         parameters: vec![header::DispositionParam::Filename(
@@ -572,7 +572,7 @@ mod test {
         .boundary("F2mTKN843loAAAAA8porEdAjCKhArPxGeahYoZYSftse1GT/84tup+O0bs8eueVuAlMK")
         .part(Part::Single(
             SinglePart::builder()
-                .header(header::ContentType::PLAIN_STRING)
+                .header(header::ContentType::TEXT_PLAIN)
                 .body(String::from("Test email for signature")),
         ))
         .singlepart(
@@ -632,11 +632,11 @@ mod test {
         let part = MultiPart::alternative()
             .boundary("F2mTKN843loAAAAA8porEdAjCKhArPxGeahYoZYSftse1GT/84tup+O0bs8eueVuAlMK")
             .part(Part::Single(SinglePart::builder()
-                             .header(header::ContentType::PLAIN_STRING)
+                             .header(header::ContentType::TEXT_PLAIN)
                              .header(header::ContentTransferEncoding::Binary)
                              .body(String::from("Текст письма в уникоде"))))
             .singlepart(SinglePart::builder()
-                             .header(header::ContentType::HTML_STRING)
+                             .header(header::ContentType::TEXT_HTML)
                              .header(header::ContentTransferEncoding::Binary)
                              .body(String::from("<p>Текст <em>письма</em> в <a href=\"https://ru.wikipedia.org/wiki/Юникод\">уникоде</a><p>")));
 
@@ -664,7 +664,7 @@ mod test {
             .multipart(MultiPart::related()
                             .boundary("E912L4JH3loAAAAAFu/33Gx7PEoTMmhGaxG3FlbVMQHctj96q4nHvBM+7DTtXo/im8gh")
                             .singlepart(SinglePart::builder()
-                                             .header(header::ContentType::HTML_STRING)
+                                             .header(header::ContentType::TEXT_HTML)
                                              .header(header::ContentTransferEncoding::Binary)
                                              .body(String::from("<p>Текст <em>письма</em> в <a href=\"https://ru.wikipedia.org/wiki/Юникод\">уникоде</a><p>")))
                             .singlepart(SinglePart::builder()
@@ -673,7 +673,7 @@ mod test {
                                              .header(header::ContentTransferEncoding::Base64)
                                              .body(String::from("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"))))
             .singlepart(SinglePart::builder()
-                             .header(header::ContentType::PLAIN_STRING)
+                             .header(header::ContentType::TEXT_PLAIN)
                              .header(header::ContentDisposition {
                                  disposition: header::DispositionType::Attachment,
                                  parameters: vec![header::DispositionParam::Filename(header::Charset::Ext("utf-8".into()), None, "example.c".into())]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -75,12 +75,12 @@
 //!         MultiPart::alternative()
 //!             .singlepart(
 //!                 SinglePart::builder()
-//!                     .header(header::ContentType("text/plain; charset=utf8".parse()?))
+//!                     .header(header::ContentType::PLAIN_STRING)
 //!                     .body(String::from("Hello, world! :)")),
 //!             )
 //!             .singlepart(
 //!                 SinglePart::builder()
-//!                     .header(header::ContentType("text/html; charset=utf8".parse()?))
+//!                     .header(header::ContentType::HTML_STRING)
 //!                     .body(String::from(
 //!                         "<p><b>Hello</b>, <i>world</i>! <img src=\"cid:123\"></p>",
 //!                     )),
@@ -146,23 +146,21 @@
 //!                 MultiPart::alternative()
 //!                     .singlepart(
 //!                         SinglePart::builder()
-//!                             .header(header::ContentType("text/plain; charset=utf8".parse()?))
+//!                             .header(header::ContentType::PLAIN_STRING)
 //!                             .body(String::from("Hello, world! :)")),
 //!                     )
 //!                     .multipart(
 //!                         MultiPart::related()
 //!                             .singlepart(
 //!                                 SinglePart::builder()
-//!                                     .header(header::ContentType(
-//!                                         "text/html; charset=utf8".parse()?,
-//!                                     ))
+//!                                     .header(header::ContentType::HTML_STRING)
 //!                                     .body(String::from(
 //!                                         "<p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>",
 //!                                     )),
 //!                             )
 //!                             .singlepart(
 //!                                 SinglePart::builder()
-//!                                     .header(header::ContentType("image/png".parse()?))
+//!                                     .header(header::ContentType::parse("image/png")?)
 //!                                     .header(header::ContentDisposition {
 //!                                         disposition: header::DispositionType::Inline,
 //!                                         parameters: vec![],
@@ -174,7 +172,7 @@
 //!             )
 //!             .singlepart(
 //!                 SinglePart::builder()
-//!                     .header(header::ContentType("text/plain; charset=utf8".parse()?))
+//!                     .header(header::ContentType::PLAIN_STRING)
 //!                     .header(header::ContentDisposition {
 //!                         disposition: header::DispositionType::Attachment,
 //!                         parameters: vec![header::DispositionParam::Filename(
@@ -241,8 +239,6 @@
 pub use body::{Body, IntoBody, MaybeString};
 pub use mailbox::*;
 pub use mimebody::*;
-
-pub use mime;
 
 mod body;
 pub mod header;
@@ -628,16 +624,14 @@ mod test {
                 MultiPart::related()
                     .singlepart(
                         SinglePart::builder()
-                            .header(header::ContentType(
-                                "text/html; charset=utf8".parse().unwrap(),
-                            ))
+                            .header(header::ContentType::HTML_STRING)
                             .body(String::from(
                                 "<p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>",
                             )),
                     )
                     .singlepart(
                         SinglePart::builder()
-                            .header(header::ContentType("image/png".parse().unwrap()))
+                            .header(header::ContentType::parse("image/png").unwrap())
                             .header(header::ContentDisposition {
                                 disposition: header::DispositionType::Inline,
                                 parameters: vec![],

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -75,12 +75,12 @@
 //!         MultiPart::alternative()
 //!             .singlepart(
 //!                 SinglePart::builder()
-//!                     .header(header::ContentType::PLAIN_STRING)
+//!                     .header(header::ContentType::TEXT_PLAIN)
 //!                     .body(String::from("Hello, world! :)")),
 //!             )
 //!             .singlepart(
 //!                 SinglePart::builder()
-//!                     .header(header::ContentType::HTML_STRING)
+//!                     .header(header::ContentType::TEXT_HTML)
 //!                     .body(String::from(
 //!                         "<p><b>Hello</b>, <i>world</i>! <img src=\"cid:123\"></p>",
 //!                     )),
@@ -146,14 +146,14 @@
 //!                 MultiPart::alternative()
 //!                     .singlepart(
 //!                         SinglePart::builder()
-//!                             .header(header::ContentType::PLAIN_STRING)
+//!                             .header(header::ContentType::TEXT_PLAIN)
 //!                             .body(String::from("Hello, world! :)")),
 //!                     )
 //!                     .multipart(
 //!                         MultiPart::related()
 //!                             .singlepart(
 //!                                 SinglePart::builder()
-//!                                     .header(header::ContentType::HTML_STRING)
+//!                                     .header(header::ContentType::TEXT_HTML)
 //!                                     .body(String::from(
 //!                                         "<p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>",
 //!                                     )),
@@ -172,7 +172,7 @@
 //!             )
 //!             .singlepart(
 //!                 SinglePart::builder()
-//!                     .header(header::ContentType::PLAIN_STRING)
+//!                     .header(header::ContentType::TEXT_PLAIN)
 //!                     .header(header::ContentDisposition {
 //!                         disposition: header::DispositionType::Attachment,
 //!                         parameters: vec![header::DispositionParam::Filename(
@@ -633,7 +633,7 @@ mod test {
                 MultiPart::related()
                     .singlepart(
                         SinglePart::builder()
-                            .header(header::ContentType::HTML_STRING)
+                            .header(header::ContentType::TEXT_HTML)
                             .body(String::from(
                                 "<p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>",
                             )),

--- a/testdata/email_with_png.eml
+++ b/testdata/email_with_png.eml
@@ -7,7 +7,7 @@ MIME-Version: 1.0
 Content-Type: multipart/related; boundary="0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1"
 
 --0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1
-Content-Type: text/html; charset=utf8
+Content-Type: text/html; charset=utf-8
 Content-Transfer-Encoding: 7bit
 
 <p><b>Hello</b>, <i>world</i>! <img src=cid:123></p>


### PR DESCRIPTION
Replaces the `hyperx` `ContentType` header implementation with our own version, which has a better API, is easier to build and doesn't expose the `mime` crate anymore (#443).

While implementing this I realized we where using `utf8` instead of `utf-8` everywhere as the charset :scream:. I don't know if `utf8` is an alternative acceptable value, but `utf-8` is the correct one and the one I am seeing in all of my emails.

Split off from #593 