### PR TITLE
Replace rand with fastrand

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1.16", default-features = false, features = ["std"], op
 hyperx = { version = "1", optional = true, features = ["headers"] }
 mime = { version = "0.3.4", optional = true }
 uuid = { version = "0.8", features = ["v4"] }
-rand = { version = "0.8", optional = true }
+fastrand = { version = "1.4", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
 once_cell = "1"
@@ -81,7 +81,7 @@ name = "transport_smtp"
 
 [features]
 default = ["smtp-transport", "native-tls", "hostname", "r2d2", "builder"]
-builder = ["mime", "base64", "hyperx", "rand", "quoted_printable"]
+builder = ["mime", "base64", "hyperx", "fastrand", "quoted_printable"]
 
 # transports
 file-transport = []

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -5,7 +5,7 @@ use crate::message::{
     EmailFormat, IntoBody,
 };
 use mime::Mime;
-use rand::Rng;
+use std::iter::repeat_with;
 
 /// MIME part variants
 #[derive(Debug, Clone)]
@@ -168,12 +168,9 @@ pub enum MultiPartKind {
 }
 
 /// Create a random MIME boundary.
+/// (Not cryptographically random)
 fn make_boundary() -> String {
-    rand::thread_rng()
-        .sample_iter(rand::distributions::Alphanumeric)
-        .take(40)
-        .map(char::from)
-        .collect()
+    repeat_with(fastrand::alphanumeric).take(40).collect()
 }
 
 impl MultiPartKind {


### PR DESCRIPTION
We don't need cryptographically secure random numbers, this simplifies
the dependency tree and speeds up builds.

See #596 