### PR TITLE
Replace the hyperx ContentDisposition header with our own implementation

### DIFF
--- a/src/message/header/content_disposition.rs
+++ b/src/message/header/content_disposition.rs
@@ -1,0 +1,98 @@
+use std::{fmt::Result as FmtResult, str::from_utf8};
+
+use hyperx::{
+    header::{Formatter as HeaderFormatter, Header, RawLike},
+    Error as HeaderError, Result as HyperResult,
+};
+
+/// `Content-Disposition` of an attachment
+///
+/// Defined in [RFC2183](https://tools.ietf.org/html/rfc2183)
+#[derive(Debug, Clone, PartialEq)]
+pub struct ContentDisposition(String);
+
+impl ContentDisposition {
+    /// An attachment which should be displayed inline into the message
+    pub fn inline() -> Self {
+        Self("inline".into())
+    }
+
+    /// An attachment which should be displayed inline into the message, but that also
+    /// species the filename in case it were to be downloaded
+    pub fn inline_with_name(file_name: &str) -> Self {
+        debug_assert!(!file_name.contains('"'), "file_name shouldn't contain '\"'");
+        Self(format!("inline; filename=\"{}\"", file_name))
+    }
+
+    /// An attachment which is separate from the body of the message, and can be downloaded separately
+    pub fn attachment(file_name: &str) -> Self {
+        debug_assert!(!file_name.contains('"'), "file_name shouldn't contain '\"'");
+        Self(format!("attachment; filename=\"{}\"", file_name))
+    }
+}
+
+impl Header for ContentDisposition {
+    fn header_name() -> &'static str {
+        "Content-Disposition"
+    }
+
+    // FIXME HeaderError->HeaderError, same for result
+    fn parse_header<'a, T>(raw: &'a T) -> HyperResult<Self>
+    where
+        T: RawLike<'a>,
+        Self: Sized,
+    {
+        raw.one()
+            .ok_or(HeaderError::Header)
+            .and_then(|r| from_utf8(r).map_err(|_| HeaderError::Header))
+            .map(|s| Self(s.into()))
+    }
+
+    fn fmt_header(&self, f: &mut HeaderFormatter<'_, '_>) -> FmtResult {
+        f.fmt_line(&self.0)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::ContentDisposition;
+    use hyperx::header::Headers;
+
+    #[test]
+    fn format_content_disposition() {
+        let mut headers = Headers::new();
+
+        headers.set(ContentDisposition::inline());
+
+        assert_eq!(format!("{}", headers), "Content-Disposition: inline\r\n");
+
+        headers.set(ContentDisposition::attachment("something.txt"));
+
+        assert_eq!(
+            format!("{}", headers),
+            "Content-Disposition: attachment; filename=\"something.txt\"\r\n"
+        );
+    }
+
+    #[test]
+    fn parse_content_disposition() {
+        let mut headers = Headers::new();
+
+        headers.set_raw("Content-Disposition", "inline");
+
+        assert_eq!(
+            headers.get::<ContentDisposition>(),
+            Some(&ContentDisposition::inline())
+        );
+
+        headers.set_raw(
+            "Content-Disposition",
+            "attachment; filename=\"something.txt\"",
+        );
+
+        assert_eq!(
+            headers.get::<ContentDisposition>(),
+            Some(&ContentDisposition::attachment("something.txt"))
+        );
+    }
+}

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -1,13 +1,14 @@
 //! Headers widely used in email messages
 
+pub use hyperx::header::{
+    Charset, ContentLocation, ContentType, Date, Header, Headers, HttpDate as EmailDate,
+};
+
+pub use self::content_disposition::ContentDisposition;
+pub use self::{content::*, mailbox::*, special::*, textual::*};
+
 mod content;
+mod content_disposition;
 mod mailbox;
 mod special;
 mod textual;
-
-pub use self::{content::*, mailbox::*, special::*, textual::*};
-
-pub use hyperx::header::{
-    Charset, ContentDisposition, ContentLocation, ContentType, Date, DispositionParam,
-    DispositionType, Header, Headers, HttpDate as EmailDate,
-};

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -495,14 +495,7 @@ mod test {
                     .header(header::ContentType(
                         "text/plain; charset=utf8".parse().unwrap(),
                     ))
-                    .header(header::ContentDisposition {
-                        disposition: header::DispositionType::Attachment,
-                        parameters: vec![header::DispositionParam::Filename(
-                            header::Charset::Ext("utf-8".into()),
-                            None,
-                            "example.c".into(),
-                        )],
-                    })
+                    .header(header::ContentDisposition::attachment("example.c"))
                     .header(header::ContentTransferEncoding::Binary)
                     .body(String::from("int main() { return 0; }")),
             );
@@ -542,14 +535,9 @@ mod test {
                             .parse()
                             .unwrap(),
                     ))
-                    .header(header::ContentDisposition {
-                        disposition: header::DispositionType::Inline,
-                        parameters: vec![header::DispositionParam::Filename(
-                            header::Charset::Ext("utf-8".into()),
-                            None,
-                            "encrypted.asc".into(),
-                        )],
-                    })
+                    .header(header::ContentDisposition::inline_with_name(
+                        "encrypted.asc",
+                    ))
                     .body(String::from(concat!(
                         "-----BEGIN PGP MESSAGE-----\r\n",
                         "wV4D0dz5vDXklO8SAQdA5lGX1UU/eVQqDxNYdHa7tukoingHzqUB6wQssbMfHl8w\r\n",
@@ -599,14 +587,7 @@ mod test {
                         .parse()
                         .unwrap(),
                 ))
-                .header(header::ContentDisposition {
-                    disposition: header::DispositionType::Attachment,
-                    parameters: vec![header::DispositionParam::Filename(
-                        header::Charset::Ext("utf-8".into()),
-                        None,
-                        "signature.asc".into(),
-                    )],
-                })
+                .header(header::ContentDisposition::attachment("signature.asc"))
                 .body(String::from(concat!(
                     "-----BEGIN PGP SIGNATURE-----\r\n",
                     "\r\n",
@@ -692,10 +673,7 @@ mod test {
                                              .body(String::from("1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"))))
             .singlepart(SinglePart::builder()
                              .header(header::ContentType("text/plain; charset=utf8".parse().unwrap()))
-                             .header(header::ContentDisposition {
-                                 disposition: header::DispositionType::Attachment,
-                                 parameters: vec![header::DispositionParam::Filename(header::Charset::Ext("utf-8".into()), None, "example.c".into())]
-                             })
+                             .header(header::ContentDisposition::attachment("example.c"))
                              .header(header::ContentTransferEncoding::Binary)
                              .body(String::from("int main() { return 0; }")));
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -163,10 +163,7 @@
 //!                             .singlepart(
 //!                                 SinglePart::builder()
 //!                                     .header(header::ContentType("image/png".parse()?))
-//!                                     .header(header::ContentDisposition {
-//!                                         disposition: header::DispositionType::Inline,
-//!                                         parameters: vec![],
-//!                                     })
+//!                                     .header(header::ContentDisposition::inline())
 //!                                     .header(header::ContentId::from(String::from("<123>")))
 //!                                     .body(image_body),
 //!                             ),
@@ -175,14 +172,7 @@
 //!             .singlepart(
 //!                 SinglePart::builder()
 //!                     .header(header::ContentType("text/plain; charset=utf8".parse()?))
-//!                     .header(header::ContentDisposition {
-//!                         disposition: header::DispositionType::Attachment,
-//!                         parameters: vec![header::DispositionParam::Filename(
-//!                             header::Charset::Ext("utf-8".into()),
-//!                             None,
-//!                             "example.rs".as_bytes().into(),
-//!                         )],
-//!                     })
+//!                     .header(header::ContentDisposition::attachment("example.rs"))
 //!                     .body(String::from("fn main() { println!(\"Hello, World!\") }")),
 //!             ),
 //!     )?;
@@ -639,10 +629,7 @@ mod test {
                     .singlepart(
                         SinglePart::builder()
                             .header(header::ContentType("image/png".parse().unwrap()))
-                            .header(header::ContentDisposition {
-                                disposition: header::DispositionType::Inline,
-                                parameters: vec![],
-                            })
+                            .header(header::ContentDisposition::inline())
                             .header(header::ContentId::from(String::from("<123>")))
                             .body(img),
                     ),


### PR DESCRIPTION
Replaces the `hyperx` `ContentDisposition` header implementation with our own version, which has been made with an intentionally simpler API which we can expand in the future.

Split off from #593 