### PR TITLE
Stop using the `uuid` crate for generating the Message-Id

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ tracing = { version = "0.1.16", default-features = false, features = ["std"], op
 # builder
 hyperx = { version = "1", optional = true, features = ["headers"] }
 mime = { version = "0.3.4", optional = true }
-uuid = { version = "0.8", features = ["v4"] }
 fastrand = { version = "1.4", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
@@ -32,6 +31,7 @@ once_cell = "1"
 regex = { version = "1", default-features = false, features = ["std", "unicode-case"] }
 
 # file transport
+uuid = { version = "0.8", features = ["v4"], optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 serde_json = { version = "1", optional = true }
 
@@ -84,7 +84,7 @@ default = ["smtp-transport", "native-tls", "hostname", "r2d2", "builder"]
 builder = ["mime", "base64", "hyperx", "fastrand", "quoted_printable"]
 
 # transports
-file-transport = []
+file-transport = ["uuid"]
 file-transport-envelope = ["serde", "serde_json", "file-transport"]
 sendmail-transport = []
 smtp-transport = ["base64", "nom"]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -250,9 +250,7 @@ mod mailbox;
 mod mimebody;
 mod utf8_b;
 
-use std::{convert::TryFrom, io::Write, time::SystemTime};
-
-use uuid::Uuid;
+use std::{convert::TryFrom, io::Write, iter, time::SystemTime};
 
 use crate::{
     address::Envelope,
@@ -412,7 +410,7 @@ impl MessageBuilder {
 
                 self.header(header::MessageId::from(
                     // https://tools.ietf.org/html/rfc5322#section-3.6.4
-                    format!("<{}@{}>", Uuid::new_v4(), hostname),
+                    format!("<{}@{}>", make_message_id(), hostname),
                 ))
             }
         }
@@ -552,9 +550,15 @@ impl Default for MessageBuilder {
     }
 }
 
+/// Create a random message id.
+/// (Not cryptographically random)
+fn make_message_id() -> String {
+    iter::repeat_with(fastrand::alphanumeric).take(36).collect()
+}
+
 #[cfg(test)]
 mod test {
-    use crate::message::{header, mailbox::Mailbox, Message, MultiPart, SinglePart};
+    use super::{header, mailbox::Mailbox, make_message_id, Message, MultiPart, SinglePart};
 
     #[test]
     fn email_missing_originator() {
@@ -659,6 +663,22 @@ mod test {
             }
 
             assert_eq!(line.0, line.1)
+        }
+    }
+
+    #[test]
+    fn test_make_message_id() {
+        let mut ids = std::collections::HashSet::with_capacity(10);
+        for _ in 0..1000 {
+            ids.insert(make_message_id());
+        }
+
+        // Ensure there are no duplicates
+        assert_eq!(1000, ids.len());
+
+        // Ensure correct length
+        for id in ids {
+            assert_eq!(36, id.len());
         }
     }
 }


### PR DESCRIPTION
One less dependency for most users