### PR TITLE
Headers::{insert_raw -> append_raw, set_raw -> insert_raw}

### DIFF
--- a/src/message/header/content.rs
+++ b/src/message/header/content.rs
@@ -93,7 +93,7 @@ mod test {
     fn parse_content_transfer_encoding() {
         let mut headers = Headers::new();
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Transfer-Encoding"),
             "7bit".to_string(),
         );
@@ -103,7 +103,7 @@ mod test {
             Some(ContentTransferEncoding::SevenBit)
         );
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Transfer-Encoding"),
             "base64".to_string(),
         );

--- a/src/message/header/content_disposition.rs
+++ b/src/message/header/content_disposition.rs
@@ -66,7 +66,7 @@ mod test {
     fn parse_content_disposition() {
         let mut headers = Headers::new();
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Disposition"),
             "inline".to_string(),
         );
@@ -76,7 +76,7 @@ mod test {
             Some(ContentDisposition::inline())
         );
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Disposition"),
             "attachment; filename=\"something.txt\"".to_string(),
         );

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -106,14 +106,14 @@ mod test {
     fn parse_content_type() {
         let mut headers = Headers::new();
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Type"),
             "text/plain; charset=utf-8".to_string(),
         );
 
         assert_eq!(headers.get::<ContentType>(), Some(ContentType::TEXT_PLAIN));
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Type"),
             "text/html; charset=utf-8".to_string(),
         );

--- a/src/message/header/date.rs
+++ b/src/message/header/date.rs
@@ -106,7 +106,7 @@ mod test {
     fn parse_date() {
         let mut headers = Headers::new();
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Date"),
             "Tue, 15 Nov 1994 08:12:31 -0000".to_string(),
         );
@@ -118,7 +118,7 @@ mod test {
             ))
         );
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Date"),
             "Tue, 15 Nov 1994 08:12:32 -0000".to_string(),
         );

--- a/src/message/header/mailbox.rs
+++ b/src/message/header/mailbox.rs
@@ -232,7 +232,7 @@ mod test {
         let from = vec!["kayo@example.com".parse().unwrap()].into();
 
         let mut headers = Headers::new();
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("From"),
             "kayo@example.com".to_string(),
         );
@@ -245,7 +245,7 @@ mod test {
         let from = vec!["K. <kayo@example.com>".parse().unwrap()].into();
 
         let mut headers = Headers::new();
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("From"),
             "K. <kayo@example.com>".to_string(),
         );
@@ -261,7 +261,7 @@ mod test {
         ];
 
         let mut headers = Headers::new();
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("From"),
             "kayo@example.com, pony@domain.tld".to_string(),
         );
@@ -277,7 +277,7 @@ mod test {
         ];
 
         let mut headers = Headers::new();
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("From"),
             "K. <kayo@example.com>, Pony P. <pony@domain.tld>".to_string(),
         );

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -71,7 +71,7 @@ impl Headers {
     /// Sets `Header` into `Headers`, overriding `Header` if it
     /// was already present in `Headers`
     pub fn set<H: Header>(&mut self, header: H) {
-        self.set_raw(H::name(), header.display());
+        self.insert_raw(H::name(), header.display());
     }
 
     /// Remove `Header` from `Headers`, returning it
@@ -97,23 +97,9 @@ impl Headers {
         self.find_header(name).map(|(_name, value)| value)
     }
 
-    /// Appends a raw header into `Headers`
-    ///
-    /// If a header with a name of `name` is already present,
-    /// appends `, ` + `value` to it's current value.
-    pub fn insert_raw(&mut self, name: HeaderName, value: String) {
-        match self.find_header_mut(&name) {
-            Some((_name, prev_value)) => {
-                prev_value.push_str(", ");
-                prev_value.push_str(&value);
-            }
-            None => self.headers.push((name, value)),
-        }
-    }
-
     /// Inserts a raw header into `Headers`, overriding `value` if it
     /// was already present in `Headers`.
-    pub fn set_raw(&mut self, name: HeaderName, value: String) {
+    pub fn insert_raw(&mut self, name: HeaderName, value: String) {
         match self.find_header_mut(&name) {
             Some((_, current_value)) => {
                 *current_value = value;
@@ -121,6 +107,20 @@ impl Headers {
             None => {
                 self.headers.push((name, value));
             }
+        }
+    }
+
+    /// Appends a raw header into `Headers`
+    ///
+    /// If a header with a name of `name` is already present,
+    /// appends `, ` + `value` to it's current value.
+    pub fn append_raw(&mut self, name: HeaderName, value: String) {
+        match self.find_header_mut(&name) {
+            Some((_name, prev_value)) => {
+                prev_value.push_str(", ");
+                prev_value.push_str(&value);
+            }
+            None => self.headers.push((name, value)),
         }
     }
 

--- a/src/message/header/special.rs
+++ b/src/message/header/special.rs
@@ -80,14 +80,14 @@ mod test {
     fn parse_mime_version() {
         let mut headers = Headers::new();
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("MIME-Version"),
             "1.0".to_string(),
         );
 
         assert_eq!(headers.get::<MimeVersion>(), Some(MIME_VERSION_1_0));
 
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("MIME-Version"),
             "0.1".to_string(),
         );

--- a/src/message/header/textual.rs
+++ b/src/message/header/textual.rs
@@ -110,7 +110,7 @@ mod test {
     #[test]
     fn parse_ascii() {
         let mut headers = Headers::new();
-        headers.set_raw(
+        headers.insert_raw(
             HeaderName::new_from_ascii_str("Subject"),
             "Sample subject".to_string(),
         );


### PR DESCRIPTION
Looking back at it the previous method naming was a bit confusing and didn't align with the naming from `HashMap` from std or `HeaderMap` from the `http` crate.