### PR TITLE
Prepare 0.10.0-beta.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.10.0-beta.3"
+version = "0.10.0-beta.4"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.10.0-beta.3">
-    <img src="https://deps.rs/crate/lettre/0.10.0-beta.3/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.10.0-beta.4">
+    <img src="https://deps.rs/crate/lettre/0.10.0-beta.4/status.svg"
       alt="dependency status" />
   </a>
 </div>
@@ -66,7 +66,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lettre = "0.10.0-beta.3"
+lettre = "0.10.0-beta.4"
 ```
 
 ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,7 +99,7 @@
 //! [Tokio 1.x]: https://docs.rs/tokio/1
 //! [async-std 1.x]: https://docs.rs/async-std/1
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-beta.3")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-beta.4")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
It probably makes sense to release another beta in order to get the headers changes out before the final 0.10.0 release.
Depends on: #612 