### PR TITLE
Async pool implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ async-std = { version = "1.8", optional = true, features = ["unstable"] }
 async-rustls = { version = "0.2", optional = true }
 
 ## tokio
-tokio1_crate = { package = "tokio", version = "1", features = ["fs", "process", "net", "io-util"], optional = true }
+tokio1_crate = { package = "tokio", version = "1", features = ["fs", "process", "time", "net", "io-util"], optional = true }
 tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optional = true }
 tokio1_rustls = { package = "tokio-rustls", version = "0.22", optional = true }
 
@@ -76,7 +76,7 @@ harness = false
 name = "transport_smtp"
 
 [features]
-default = ["smtp-transport", "native-tls", "hostname", "r2d2", "builder"]
+default = ["smtp-transport", "pool", "native-tls", "hostname", "r2d2", "builder"]
 builder = ["httpdate", "mime", "base64", "fastrand", "quoted_printable"]
 
 # transports
@@ -84,6 +84,8 @@ file-transport = ["uuid"]
 file-transport-envelope = ["serde", "serde_json", "file-transport"]
 sendmail-transport = []
 smtp-transport = ["base64", "nom"]
+
+pool = ["futures-util"]
 
 rustls-tls = ["webpki", "webpki-roots", "rustls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 idna = "0.2"
+once_cell = "1"
 tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # feature
 
 # builder
@@ -27,7 +28,6 @@ mime = { version = "0.3.4", optional = true }
 fastrand = { version = "1.4", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
-once_cell = "1"
 regex = { version = "1", default-features = false, features = ["std", "unicode-case"] }
 
 # file transport

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -81,7 +81,6 @@ pub trait Executor: Debug + Send + Sync + 'static + private::Sealed {
 #[doc(hidden)]
 #[cfg(feature = "smtp-transport")]
 #[async_trait]
-
 pub trait SpawnHandle: Debug + Send + Sync + 'static + private::Sealed {
     async fn shutdown(self);
 }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -1,10 +1,16 @@
 use async_trait::async_trait;
+#[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
+use futures_util::future::BoxFuture;
 
 use std::fmt::Debug;
+#[cfg(feature = "smtp-transport")]
+use std::future::Future;
 #[cfg(feature = "file-transport")]
 use std::io::Result as IoResult;
 #[cfg(feature = "file-transport")]
 use std::path::Path;
+#[cfg(feature = "smtp-transport")]
+use std::time::Duration;
 
 #[cfg(all(
     feature = "smtp-transport",
@@ -37,7 +43,23 @@ use crate::transport::smtp::Error;
 /// [`AsyncFileTransport`]: crate::AsyncFileTransport
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio1", feature = "async-std1"))))]
 #[async_trait]
-pub trait Executor: Debug + Send + Sync + private::Sealed {
+pub trait Executor: Debug + Send + Sync + 'static + private::Sealed {
+    #[cfg(feature = "smtp-transport")]
+    type Handle: SpawnHandle;
+    #[cfg(feature = "smtp-transport")]
+    type Sleep: Future<Output = ()> + Send + 'static;
+
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    fn spawn<F>(fut: F) -> Self::Handle
+    where
+        F: Future<Output = ()> + Send + 'static,
+        F::Output: Send + 'static;
+
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    fn sleep(duration: Duration) -> Self::Sleep;
+
     #[doc(hidden)]
     #[cfg(feature = "smtp-transport")]
     async fn connect(
@@ -54,6 +76,14 @@ pub trait Executor: Debug + Send + Sync + private::Sealed {
     #[doc(hidden)]
     #[cfg(feature = "file-transport")]
     async fn fs_write(path: &Path, contents: &[u8]) -> IoResult<()>;
+}
+
+#[doc(hidden)]
+#[cfg(feature = "smtp-transport")]
+#[async_trait]
+
+pub trait SpawnHandle: Debug + Send + Sync + 'static + private::Sealed {
+    async fn shutdown(self);
 }
 
 /// Async [`Executor`] using `tokio` `1.x`
@@ -74,6 +104,27 @@ pub struct Tokio1Executor;
 #[async_trait]
 #[cfg(feature = "tokio1")]
 impl Executor for Tokio1Executor {
+    #[cfg(feature = "smtp-transport")]
+    type Handle = tokio1_crate::task::JoinHandle<()>;
+    #[cfg(feature = "smtp-transport")]
+    type Sleep = tokio1_crate::time::Sleep;
+
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    fn spawn<F>(fut: F) -> Self::Handle
+    where
+        F: Future<Output = ()> + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        tokio1_crate::spawn(fut)
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    fn sleep(duration: Duration) -> Self::Sleep {
+        tokio1_crate::time::sleep(duration)
+    }
+
     #[doc(hidden)]
     #[cfg(feature = "smtp-transport")]
     async fn connect(
@@ -121,6 +172,14 @@ impl Executor for Tokio1Executor {
     }
 }
 
+#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+#[async_trait]
+impl SpawnHandle for tokio1_crate::task::JoinHandle<()> {
+    async fn shutdown(self) {
+        self.abort();
+    }
+}
+
 /// Async [`Executor`] using `async-std` `1.x`
 ///
 /// Used by [`AsyncSmtpTransport`], [`AsyncSendmailTransport`] and [`AsyncFileTransport`]
@@ -139,6 +198,28 @@ pub struct AsyncStd1Executor;
 #[async_trait]
 #[cfg(feature = "async-std1")]
 impl Executor for AsyncStd1Executor {
+    #[cfg(feature = "smtp-transport")]
+    type Handle = async_std::task::JoinHandle<()>;
+    #[cfg(feature = "smtp-transport")]
+    type Sleep = BoxFuture<'static, ()>;
+
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    fn spawn<F>(fut: F) -> Self::Handle
+    where
+        F: Future<Output = ()> + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        async_std::task::spawn(fut)
+    }
+
+    #[doc(hidden)]
+    #[cfg(feature = "smtp-transport")]
+    fn sleep(duration: Duration) -> Self::Sleep {
+        let fut = async move { async_std::task::sleep(duration).await };
+        Box::pin(fut)
+    }
+
     #[doc(hidden)]
     #[cfg(feature = "smtp-transport")]
     async fn connect(
@@ -187,6 +268,14 @@ impl Executor for AsyncStd1Executor {
     }
 }
 
+#[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
+#[async_trait]
+impl SpawnHandle for async_std::task::JoinHandle<()> {
+    async fn shutdown(self) {
+        self.cancel().await;
+    }
+}
+
 mod private {
     use super::*;
 
@@ -197,4 +286,10 @@ mod private {
 
     #[cfg(feature = "async-std1")]
     impl Sealed for AsyncStd1Executor {}
+
+    #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+    impl Sealed for tokio1_crate::task::JoinHandle<()> {}
+
+    #[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
+    impl Sealed for async_std::task::JoinHandle<()> {}
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@
 //!
 //! * **smtp-transport** 📫: Enable the SMTP transport
 //! * **r2d2** 📫: Connection pool for SMTP transport
+//! * **pool** 📫: Async connection pool for SMTP transport
 //! * **hostname** 📫: Try to use the actual system hostname for the SMTP `CLIENTID`
 //!
 //! #### SMTP over TLS via the native-tls crate

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -306,6 +306,8 @@ impl<E> Debug for AsyncSmtpClient<E> {
     }
 }
 
+// `clone` is unused when the `pool` feature is on
+#[allow(dead_code)]
 impl<E> AsyncSmtpClient<E>
 where
     E: Executor,

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -118,7 +118,7 @@
 
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
 pub use self::async_transport::{AsyncSmtpTransport, AsyncSmtpTransportBuilder};
-#[cfg(feature = "r2d2")]
+#[cfg(any(feature = "r2d2", feature = "pool"))]
 pub use self::pool::PoolConfig;
 #[cfg(feature = "r2d2")]
 pub(crate) use self::transport::SmtpClient;

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -144,7 +144,7 @@ pub mod client;
 pub mod commands;
 mod error;
 pub mod extension;
-#[cfg(feature = "r2d2")]
+#[cfg(any(feature = "r2d2", feature = "pool"))]
 mod pool;
 pub mod response;
 mod transport;

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -48,6 +48,8 @@ impl<E: Executor> Pool<E> {
             let pool = Arc::downgrade(&pool_);
 
             let handle = E::spawn(async move {
+                // prepare for tracing
+                #[allow(clippy::while_let_loop)]
                 loop {
                     match pool.upgrade() {
                         Some(pool) => {

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -72,7 +72,7 @@ impl<E: Executor> Pool<E> {
                                     .map(|i| connections.remove(i))
                                     .collect::<Vec<_>>();
 
-                                (connections.len() - dropped.len(), dropped)
+                                (connections.len(), dropped)
                             };
 
                             #[cfg(feature = "tracing")]

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -1,0 +1,247 @@
+use std::fmt::{self, Debug};
+use std::mem;
+use std::ops::{Deref, DerefMut};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use futures_util::lock::Mutex;
+
+use crate::executor::SpawnHandle;
+use crate::transport::smtp::async_transport::AsyncSmtpClient;
+use crate::Executor;
+
+use super::super::client::AsyncSmtpConnection;
+use super::super::Error;
+use super::PoolConfig;
+
+pub struct Pool<E: Executor> {
+    config: PoolConfig,
+    connections: Mutex<Vec<ParkedConnection>>,
+    client: AsyncSmtpClient<E>,
+    handle: Mutex<Option<E::Handle>>,
+}
+
+struct ParkedConnection {
+    conn: AsyncSmtpConnection,
+    since: Instant,
+}
+
+pub struct PooledConnection<E: Executor> {
+    conn: Option<AsyncSmtpConnection>,
+    pool: Arc<Pool<E>>,
+}
+
+impl<E: Executor> Pool<E> {
+    pub fn new(config: PoolConfig, client: AsyncSmtpClient<E>) -> Arc<Self> {
+        let pool = Arc::new(Self {
+            config,
+            connections: Mutex::new(Vec::new()),
+            client,
+            handle: Mutex::new(None),
+        });
+
+        {
+            let pool_ = Arc::clone(&pool);
+
+            let min_idle = pool_.config.min_idle;
+            let idle_timeout = pool_.config.idle_timeout;
+            let pool = Arc::downgrade(&pool_);
+
+            let handle = E::spawn(async move {
+                loop {
+                    match pool.upgrade() {
+                        Some(pool) => {
+                            #[allow(clippy::needless_collect)]
+                            let (count, dropped) = {
+                                let mut connections = pool.connections.lock().await;
+
+                                let to_drop = connections
+                                    .iter()
+                                    .enumerate()
+                                    .rev()
+                                    .filter(|(_, conn)| conn.idle_duration() > idle_timeout)
+                                    .map(|(i, _)| i)
+                                    .collect::<Vec<_>>();
+                                let dropped = to_drop
+                                    .into_iter()
+                                    .map(|i| connections.remove(i))
+                                    .collect::<Vec<_>>();
+
+                                (connections.len() - dropped.len(), dropped)
+                            };
+
+                            for _ in count..=(min_idle as usize) {
+                                let conn = match pool.client.connection().await {
+                                    Ok(conn) => conn,
+                                    Err(_) => break,
+                                };
+
+                                let mut connections = pool.connections.lock().await;
+                                connections.push(ParkedConnection::park(conn));
+                            }
+
+                            for conn in dropped {
+                                let mut conn = conn.unpark();
+                                conn.abort().await;
+                            }
+                        }
+                        None => break,
+                    }
+
+                    E::sleep(idle_timeout).await;
+                }
+            });
+            *pool_
+                .handle
+                .try_lock()
+                .expect("Pool handle shouldn't be locked") = Some(handle);
+        }
+
+        pool
+    }
+
+    pub async fn connection(self: &Arc<Self>) -> Result<PooledConnection<E>, Error> {
+        loop {
+            let conn = {
+                let mut connections = self.connections.lock().await;
+                connections.pop()
+            };
+
+            match conn {
+                Some(conn) => {
+                    let mut conn = conn.unpark();
+
+                    // TODO: handle the client try another connection if this one isn't good
+                    if !conn.test_connected().await {
+                        conn.abort().await;
+                        continue;
+                    }
+
+                    return Ok(PooledConnection::wrap(conn, self.clone()));
+                }
+                None => {
+                    let conn = self.client.connection().await?;
+                    return Ok(PooledConnection::wrap(conn, self.clone()));
+                }
+            }
+        }
+    }
+
+    async fn recycle(&self, mut conn: AsyncSmtpConnection) {
+        if conn.has_broken() {
+            conn.abort().await;
+            drop(conn);
+        } else {
+            let mut connections = self.connections.lock().await;
+            if connections.len() >= self.config.max_size as usize {
+                drop(connections);
+                conn.abort().await;
+            } else {
+                let conn = ParkedConnection::park(conn);
+                connections.push(conn);
+            }
+        }
+    }
+}
+
+impl<E: Executor> Debug for Pool<E> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("Pool")
+            .field("config", &self.config)
+            .field(
+                "connections",
+                &match self.connections.try_lock() {
+                    Some(connections) => format!("{} connections", connections.len()),
+
+                    None => "LOCKED".to_string(),
+                },
+            )
+            .field("client", &self.client)
+            .field(
+                "handle",
+                &match self.handle.try_lock() {
+                    Some(handle) => match &*handle {
+                        Some(_) => "Some(JoinHandle)",
+                        None => "None",
+                    },
+                    None => "LOCKED",
+                },
+            )
+            .finish()
+    }
+}
+
+impl<E: Executor> Drop for Pool<E> {
+    fn drop(&mut self) {
+        let connections = mem::take(self.connections.get_mut());
+        let handle = self
+            .handle
+            .try_lock()
+            .expect("Handle shouldn't be locked")
+            .take();
+        E::spawn(async move {
+            if let Some(handle) = handle {
+                handle.shutdown().await;
+            }
+
+            for conn in connections {
+                let mut conn = conn.unpark();
+                conn.abort().await;
+            }
+        });
+    }
+}
+
+impl ParkedConnection {
+    fn park(conn: AsyncSmtpConnection) -> Self {
+        Self {
+            conn,
+            since: Instant::now(),
+        }
+    }
+
+    fn idle_duration(&self) -> Duration {
+        self.since.elapsed()
+    }
+
+    fn unpark(self) -> AsyncSmtpConnection {
+        self.conn
+    }
+}
+
+impl<E: Executor> PooledConnection<E> {
+    fn wrap(conn: AsyncSmtpConnection, pool: Arc<Pool<E>>) -> Self {
+        Self {
+            conn: Some(conn),
+            pool,
+        }
+    }
+}
+
+impl<E: Executor> Deref for PooledConnection<E> {
+    type Target = AsyncSmtpConnection;
+
+    fn deref(&self) -> &Self::Target {
+        self.conn.as_ref().expect("conn hasn't been dropped yet")
+    }
+}
+
+impl<E: Executor> DerefMut for PooledConnection<E> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.conn.as_mut().expect("conn hasn't been dropped yet")
+    }
+}
+
+impl<E: Executor> Drop for PooledConnection<E> {
+    fn drop(&mut self) {
+        let conn = self
+            .conn
+            .take()
+            .expect("AsyncSmtpConnection hasn't been taken yet");
+        let pool = Arc::clone(&self.pool);
+
+        E::spawn(async move {
+            pool.recycle(conn).await;
+        });
+    }
+}

--- a/src/transport/smtp/pool/mod.rs
+++ b/src/transport/smtp/pool/mod.rs
@@ -1,5 +1,7 @@
 use std::time::Duration;
 
+#[cfg(all(feature = "pool", any(feature = "tokio1", feature = "async-std1")))]
+pub mod async_impl;
 #[cfg(feature = "r2d2")]
 pub mod sync_impl;
 


### PR DESCRIPTION
Turns out using an external crate for connection pooling didn't make much sense, and implementing it ourselves gives us the ability to support both tokio and async-std plus being able to customize it to make it work as we wish.