### PR TITLE
Add Serde derive for ContentType

### DIFF
--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -96,8 +96,7 @@ mod serde {
         {
             // So the value in `ContentType` is `Mime`, so we are using
             // its "essence" name as the value. For example "text/html"
-            serializer
-                .serialize_newtype_struct("ContentType", &self.0.essence_str())
+            serializer.serialize_newtype_struct("ContentType", &self.0.essence_str())
 
             // we don't serialize the two constant values `TEXT_PLAIN` and
             // `TEXT_HTML` because, well... they are constants...
@@ -116,10 +115,7 @@ mod serde {
 
                 // The error message which states what the Visitor expects to
                 // receive
-                fn expecting(
-                    &self,
-                    formatter: &mut fmt::Formatter<'_>,
-                ) -> fmt::Result {
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
                     formatter.write_str(concat![
                         "Visitor expects a string which ",
                         "represents a mime type, for example `text/plain`",

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -12,7 +12,7 @@ use crate::BoxError;
 /// `Content-Type` of the body
 ///
 /// Defined in [RFC2045](https://tools.ietf.org/html/rfc2045#section-5)
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ContentType(Mime);
 
 impl ContentType {
@@ -78,6 +78,72 @@ impl Display for ContentTypeErr {
     }
 }
 
+// ------------------
+// Serde feature
+// ------------------
+#[cfg(feature = "serde")]
+mod serde {
+    use serde::ser::{Serialize, Serializer};
+    use serde::de::{self, Deserialize, Deserializer, Visitor};
+
+    use std::fmt;
+
+    use super::ContentType;
+
+    impl Serialize for ContentType {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                // So the value in `ContentType` is `Mime`, so we are using
+                // its "essence" name as the value. For example "text/html"
+                serializer.serialize_newtype_struct(
+                    "ContentType", &self.0.essence_str())
+
+                    // we don't serialize the two constant values `TEXT_PLAIN` and
+                    // `TEXT_HTML` because, well... they are constants...
+            }
+    }
+
+    impl<'de> Deserialize<'de> for ContentType {
+        fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                struct ContentTypeVisitor;
+
+                impl<'de> Visitor<'de> for ContentTypeVisitor {
+                    type Value = ContentType;
+
+                    // The error message which states what the Visitor expects to
+                    // receive
+                    fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                        formatter.write_str(
+                            concat![
+                            "Visitor expects a string which ",
+                            "represents a mime type, for example `text/plain`",
+                            " (as a string)",
+                            ]
+                            )
+                    }
+
+                    fn visit_str<E>(self, mime: &str) -> Result<ContentType, E>
+                        where
+                            E: de::Error,
+                        {
+                            match ContentType::parse(mime) {
+                                Ok(content_type) => Ok(content_type),
+                                Err(_) => 
+                                    Err(E::custom(format!("Couldn't parse the following MIME-Type: {}", mime)))
+                            }
+                        }
+                }
+
+                deserializer.deserialize_str(ContentTypeVisitor)
+            }
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::ContentType;
@@ -92,14 +158,14 @@ mod test {
         assert_eq!(
             headers.to_string(),
             "Content-Type: text/plain; charset=utf-8\r\n"
-        );
+            );
 
         headers.set(ContentType::TEXT_HTML);
 
         assert_eq!(
             headers.to_string(),
             "Content-Type: text/html; charset=utf-8\r\n"
-        );
+            );
     }
 
     #[test]
@@ -109,14 +175,14 @@ mod test {
         headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Type"),
             "text/plain; charset=utf-8".to_string(),
-        );
+            );
 
         assert_eq!(headers.get::<ContentType>(), Some(ContentType::TEXT_PLAIN));
 
         headers.insert_raw(
             HeaderName::new_from_ascii_str("Content-Type"),
             "text/html; charset=utf-8".to_string(),
-        );
+            );
 
         assert_eq!(headers.get::<ContentType>(), Some(ContentType::TEXT_HTML));
     }

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -20,6 +20,7 @@ impl ContentType {
     ///
     /// Indicates that the body is in utf-8 encoded html.
     pub const TEXT_HTML: ContentType = Self::from_mime(mime::TEXT_HTML_UTF_8);
+
     /// A `ContentType` of type `text/plain; charset=utf-8`
     ///
     /// Indicates that the body is in utf-8 encoded plain text.


### PR DESCRIPTION
This pull request should fix [this issue](https://github.com/lettre/lettre/issues/640).

I'm sorry for the wait but this is the *first time*, that I implemented the `Serialization` and `Deserialization` trait functions so please take a careful look on my code please.