### PR TITLE
Rename `timeout` to `connection_timeout`

### DIFF
--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -150,7 +150,7 @@ where
     ///
     /// * No authentication
     /// * No TLS
-    /// * A 60 seconds timeout for smtp commands
+    /// * A 30 seconds connection timeout
     /// * Port 25
     ///
     /// Consider using [`AsyncSmtpTransport::relay`](#method.relay) or
@@ -224,9 +224,15 @@ impl AsyncSmtpTransportBuilder {
         self
     }
 
-    /// Set the timeout duration
-    pub fn timeout(mut self, timeout: Option<Duration>) -> Self {
-        self.info.timeout = timeout;
+    #[doc(hidden)]
+    #[deprecated(note = "Renamed to `connection_timeout`")]
+    pub fn timeout(self, timeout: Option<Duration>) -> Self {
+        self.connection_timeout(timeout)
+    }
+
+    /// Set the connection timeout duration
+    pub fn connection_timeout(mut self, connection_timeout: Option<Duration>) -> Self {
+        self.info.connection_timeout = connection_timeout;
         self
     }
 
@@ -294,7 +300,7 @@ where
         let mut conn = E::connect(
             &self.info.server,
             self.info.port,
-            self.info.timeout,
+            self.info.connection_timeout,
             &self.info.hello_name,
             &self.info.tls,
         )

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -163,8 +163,8 @@ pub const SUBMISSION_PORT: u16 = 587;
 /// Defined in [RFC8314](https://tools.ietf.org/html/rfc8314)
 pub const SUBMISSIONS_PORT: u16 = 465;
 
-/// Default timeout
-const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
+/// Default connection timeout
+const DEFAULT_CONNECTION_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Debug, Clone)]
 struct SmtpInfo {
@@ -180,9 +180,8 @@ struct SmtpInfo {
     authentication: Vec<Mechanism>,
     /// Credentials
     credentials: Option<Credentials>,
-    /// Define network timeout
-    /// It can be changed later for specific needs (like a different timeout for each SMTP command)
-    timeout: Option<Duration>,
+    /// Define connection timeout
+    connection_timeout: Option<Duration>,
 }
 
 impl Default for SmtpInfo {
@@ -193,7 +192,7 @@ impl Default for SmtpInfo {
             hello_name: ClientId::default(),
             credentials: None,
             authentication: DEFAULT_MECHANISMS.into(),
-            timeout: Some(DEFAULT_TIMEOUT),
+            connection_timeout: Some(DEFAULT_CONNECTION_TIMEOUT),
             tls: Tls::None,
         }
     }

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -91,7 +91,7 @@ impl SmtpTransport {
     ///
     /// * No authentication
     /// * No TLS
-    /// * A 60 seconds timeout for smtp commands
+    /// * A 30 seconds connection timeout
     /// * Port 25
     ///
     /// Consider using [`SmtpTransport::relay`](#method.relay) or
@@ -140,9 +140,15 @@ impl SmtpTransportBuilder {
         self
     }
 
-    /// Set the timeout duration
-    pub fn timeout(mut self, timeout: Option<Duration>) -> Self {
-        self.info.timeout = timeout;
+    #[doc(hidden)]
+    #[deprecated(note = "Renamed to `connection_timeout`")]
+    pub fn timeout(self, timeout: Option<Duration>) -> Self {
+        self.connection_timeout(timeout)
+    }
+
+    /// Set the connection timeout duration
+    pub fn connection_timeout(mut self, connection_timeout: Option<Duration>) -> Self {
+        self.info.connection_timeout = connection_timeout;
         self
     }
 
@@ -206,7 +212,7 @@ impl SmtpClient {
         #[allow(unused_mut)]
         let mut conn = SmtpConnection::connect::<(&str, u16)>(
             (self.info.server.as_ref(), self.info.port),
-            self.info.timeout,
+            self.info.connection_timeout,
             &self.info.hello_name,
             tls_parameters,
         )?;


### PR DESCRIPTION
Renames `timeout` to `connection_timeout`, since that's all it's really controlling. If we were to add timeouts on more things in the future they would better work as separate parameters.