### PR TITLE
WIP: support usage of r2d2 get_timeout

### DIFF
--- a/src/transport/smtp/pool/mod.rs
+++ b/src/transport/smtp/pool/mod.rs
@@ -14,6 +14,7 @@ pub struct PoolConfig {
     max_size: u32,
     connection_timeout: Duration,
     idle_timeout: Duration,
+    pub(crate) get_timeout: Option<Duration>,
 }
 
 impl PoolConfig {
@@ -55,6 +56,14 @@ impl PoolConfig {
         self.idle_timeout = idle_timeout;
         self
     }
+
+    /// Connection get timeout
+    ///
+    /// Defaults to `None`, meaning no timeout.
+    pub fn get_timeout(mut self, get_timeout: Option<Duration>) -> Self {
+        self.get_timeout = get_timeout;
+        self
+    }
 }
 
 impl Default for PoolConfig {
@@ -64,6 +73,7 @@ impl Default for PoolConfig {
             max_size: 10,
             connection_timeout: Duration::from_secs(30),
             idle_timeout: Duration::from_secs(60),
+            get_timeout: None,
         }
     }
 }


### PR DESCRIPTION
Works towards implementing #650, however it only implements the sync/r2d2 part of it which is what we're using.

Right now I'm not familiar with APIs of tokio/async-io to do the async part of it, and it looks like the pool functionality is implemented "from the ground up" in `async_impl.rs` rather than delegating to another crate. Actually I am not sure if the existing async behaviour is correct - [the only mention of max_size](https://github.com/lettre/lettre/blob/master/src/transport/smtp/pool/async_impl.rs#L184) is when existing active connections become inactive and then get recycled, but there appears to be no logic that limits new connections when there are >= max_size active connections. By contrast r2d2 (which is sync) will wait for `connection_timeout` for a connection to become available, which is where the DoS vector comes in, and is mitigated via the use of `get_timeout`
