### PR TITLE
ContentTransferEncoding derives changes

### DIFF
--- a/src/message/header/content.rs
+++ b/src/message/header/content.rs
@@ -11,7 +11,8 @@ use crate::BoxError;
 /// The `Message` builder takes care of choosing the most
 /// efficient encoding based on the chosen body, so in most
 /// use-caches this header shouldn't be set manually.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum ContentTransferEncoding {
     /// ASCII
     SevenBit,

--- a/src/message/header/content_type.rs
+++ b/src/message/header/content_type.rs
@@ -83,9 +83,7 @@ impl Display for ContentTypeErr {
     }
 }
 
-// --------------------------------------
-// Serialization and Deserialization
-// --------------------------------------
+// -- Serialization and Deserialization --
 #[cfg(feature = "serde")]
 mod serde {
     use serde::de::{self, Deserialize, Deserializer, Visitor};


### PR DESCRIPTION
- Removed/reduced comment block for "ContentType"
- Added Serliaze and Deserialize derives for "ContentTransferEncoding" if
  "serde" feature is on