### PR TITLE
feat(email): add dkim signing capacity to message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -110,6 +110,20 @@ jobs:
       - name: Run SMTP server
         run: smtp-sink 2525 1000&
 
+      - name: Install coredns
+        run: |
+          wget -q https://github.com/coredns/coredns/releases/download/v1.8.6/coredns_1.8.6_linux_amd64.tgz
+          tar xzf coredns_1.8.6_linux_amd64.tgz
+
+      - name: Start coredns
+        run: |
+          sudo ./coredns -conf testdata/coredns.conf &
+          sudo systemctl stop systemd-resolved
+          echo "nameserver 127.0.0.54" | sudo tee /etc/resolv.conf
+
+      - name: Install dkimverify
+        run: sudo apt -y install python3-dkim
+
       - name: Test with no default features
         run: cargo test --no-default-features
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,8 +61,8 @@ tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optio
 tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 
 ## dkim
-rust-crypto = "0.2.36"
-rsa = "0.5.0"
+rust-crypto = { version = "0.2.36", optional = true }
+rsa = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -100,6 +100,8 @@ async-std1-rustls-tls = ["async-std1", "rustls-tls", "futures-rustls"]
 tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
+
+dkim = ["rust-crypto", "rsa"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,6 @@ tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 sha2 = { version = "0.9.8", optional = true }
 rsa = { version = "0.5.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
-lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -103,7 +102,7 @@ tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
-dkim = ["sha2", "rsa", "ed25519-dalek", "lazy_static"]
+dkim = ["sha2", "rsa", "ed25519-dalek"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,10 @@ tokio1_crate = { package = "tokio", version = "1", features = ["fs", "process", 
 tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optional = true }
 tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 
+## dkim
+rust-crypto = "0.2.36"
+rsa = "0.5.0"
+
 [dev-dependencies]
 criterion = "0.3"
 tracing-subscriber = "0.2.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optio
 tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 
 ## dkim
-rust-crypto = { version = "0.2.36", optional = true }
+sha2 = { version = "0.9.8", optional = true }
 rsa = { version = "0.5.0", optional = true }
 
 [dev-dependencies]
@@ -101,7 +101,7 @@ tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
-dkim = ["rust-crypto", "rsa"]
+dkim = ["sha2", "rsa"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 sha2 = { version = "0.9.8", optional = true }
 rsa = { version = "0.5.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
+lazy_static = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -102,7 +103,7 @@ tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
-dkim = ["sha2", "rsa", "ed25519-dalek"]
+dkim = ["sha2", "rsa", "ed25519-dalek", "lazy_static"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,7 @@ tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 ## dkim
 sha2 = { version = "0.9.8", optional = true }
 rsa = { version = "0.5.0", optional = true }
+ed25519-dalek = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
@@ -101,7 +102,7 @@ tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
-dkim = ["sha2", "rsa"]
+dkim = ["sha2", "rsa", "ed25519-dalek"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,6 +85,7 @@
 //! * **serde**: Serialization/Deserialization of entities
 //! * **tracing**: Logging using the `tracing` crate
 //! * **mime03**: Allow creating a [`ContentType`] from an existing [mime 0.3] `Mime` struct
+//! * **dkim**: Add support for signing email with DKIM
 //!
 //! [`SMTP`]: crate::transport::smtp
 //! [`sendmail`]: crate::transport::sendmail
@@ -97,6 +98,7 @@
 //! [Tokio 1.x]: https://docs.rs/tokio/1
 //! [async-std 1.x]: https://docs.rs/async-std/1
 //! [mime 0.3]: https://docs.rs/mime/0.3
+//! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
 #![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-rc.3")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -28,8 +28,17 @@ impl Display for DkimCanonicalizationType {
 /// Describe Canonicalization to be applied before signing
 #[derive(Copy, Clone, Debug)]
 pub struct DkimCanonicalization {
-    header: DkimCanonicalizationType,
-    body: DkimCanonicalizationType,
+    pub header: DkimCanonicalizationType,
+    pub body: DkimCanonicalizationType,
+}
+
+impl Default for DkimCanonicalization {
+    fn default() -> Self {
+        DkimCanonicalization {
+            header: DkimCanonicalizationType::Simple,
+            body: DkimCanonicalizationType::Relaxed,
+        }
+    }
 }
 
 /// Format canonicalization to be shown in Dkim header

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -118,6 +118,7 @@ impl DkimSigningKey {
 /// header with same name is not supported
 /// canonicalization: the canonicalization to be applied on the message
 /// pub signing_algorithm: the signing algorithm to be used when signing
+#[derive(Debug)]
 pub struct DkimConfig {
     selector: String,
     domain: String,

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -1,0 +1,348 @@
+use crate::message::{header::HeaderName, Headers, Message};
+use base64::encode;
+use crypto::digest::Digest;
+use crypto::sha2::Sha256;
+use regex::Regex;
+use rsa::{pkcs1::FromRsaPrivateKey, Hash, PaddingScheme, RsaPrivateKey};
+use std::fmt::Display;
+use std::time::SystemTime;
+
+/// Describe Dkim Canonicalization to apply to either body or headers
+#[derive(Copy, Clone)]
+pub enum DkimCanonicalizationType {
+    Simple,
+    Relaxed,
+}
+
+impl Display for DkimCanonicalizationType {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        match self {
+            DkimCanonicalizationType::Simple => write!(fmt, "simple"),
+            DkimCanonicalizationType::Relaxed => write!(fmt, "relaxed"),
+        }
+    }
+}
+
+/// Describe Canonicalization to be applied before signing
+#[derive(Copy, Clone)]
+pub struct DkimCanonicalization {
+    header: DkimCanonicalizationType,
+    body: DkimCanonicalizationType,
+}
+
+/// Format canonicalization to be shown in Dkim header
+impl Display for DkimCanonicalization {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter<'_>) -> std::result::Result<(), std::fmt::Error> {
+        write!(fmt, "{}/{}", self.header, self.body)
+    }
+}
+
+/// A struct to describe Dkim configuration applied when signing a message
+/// selector: the name of the key publied in DNS
+/// domain: the domain for which we sign the message
+/// private_key: private key in PKCS1 string format
+/// headers: a list of headers name to be included in the signature. Signing of more than one
+/// header with same name is not supported
+/// canonicalization: the canonicalization to be applied on the message
+#[derive(Clone)]
+pub struct DkimConfig {
+    selector: String,
+    domain: String,
+    private_key: String,
+    headers: Vec<String>,
+    canonicalization: DkimCanonicalization,
+}
+
+impl DkimConfig {
+    /// Create a default signature configuration with a set of headers and "simple/relaxed"
+    /// canonicalization
+    pub fn default_config(selector: String, domain: String, private_key: String) -> DkimConfig {
+        DkimConfig {
+            selector,
+            domain,
+            private_key,
+            headers: vec![
+                "From".to_string(),
+                "Subject".to_string(),
+                "To".to_string(),
+                "Date".to_string(),
+            ],
+            canonicalization: DkimCanonicalization {
+                header: DkimCanonicalizationType::Simple,
+                body: DkimCanonicalizationType::Relaxed,
+            },
+        }
+    }
+}
+
+/// Create a Headers struct with a Dkim-Signature Header created from given parameters
+fn dkim_header_format(
+    domain: String,
+    selector: String,
+    canon: DkimCanonicalization,
+    timestamp: String,
+    headers_list: String,
+    body_hash: String,
+    signature: String,
+) -> Headers {
+    let mut headers = Headers::new();
+    let header_name = match canon.header {
+        DkimCanonicalizationType::Simple => HeaderName::new_from_ascii_str("DKIM-Signature"),
+        DkimCanonicalizationType::Relaxed => HeaderName::new_from_ascii_str("dkim-signature"),
+    };
+    headers.append_raw(header_name, format!("v=1; a=rsa-sha256; d={domain}; s={selector}; c={canon}; q=dns/txt; t={timestamp}; h={headers_list}; bh={body_hash}; b={signature}",domain=domain, selector=selector,canon=canon,timestamp=timestamp,headers_list=headers_list,body_hash=body_hash,signature=signature));
+    headers
+}
+
+/// Canonicalize the body of an email
+fn dkim_canonicalize_body(body: &[u8], canonicalization: DkimCanonicalizationType) -> String {
+    let body = std::str::from_utf8(body).unwrap();
+    let re = Regex::new("(\r\n)+$").unwrap();
+    match canonicalization {
+        DkimCanonicalizationType::Simple => re.replace(body, "\r\n").to_string(),
+        DkimCanonicalizationType::Relaxed => {
+            let re_double_space = Regex::new("[\\t ]+").unwrap();
+            let body = re_double_space.replace_all(body, " ").to_string();
+            let re_space_eol = Regex::new("[\t ]\r\n").unwrap();
+            let body = re_space_eol.replace_all(&body, "\r\n").to_string();
+            re.replace(&body, "\r\n").to_string()
+        }
+    }
+}
+
+/// Canonicalize the value of an header
+fn dkim_canonicalize_header_value(
+    value: &str,
+    canonicalization: DkimCanonicalizationType,
+) -> String {
+    match canonicalization {
+        DkimCanonicalizationType::Simple => value.to_string(),
+        DkimCanonicalizationType::Relaxed => {
+            let re = Regex::new("\r\n").unwrap();
+            let value = re.replace_all(value, "").to_string();
+            let re = Regex::new("[\\t ]+").unwrap();
+            format!("{}\r\n", re.replace_all(&value, " ").to_string().trim_end())
+        }
+    }
+}
+
+/// Canonicalize signed headers passed as headers_list among mail_headers using canonicalization
+fn dkim_canonicalize_headers(
+    headers_list: Vec<String>,
+    mail_headers: &Headers,
+    canonicalization: DkimCanonicalizationType,
+) -> String {
+    let mut signed_headers = Headers::new();
+    let mut signed_headers_relaxed = String::new();
+    for h in headers_list.into_iter() {
+        let h = match canonicalization {
+            DkimCanonicalizationType::Simple => h,
+            DkimCanonicalizationType::Relaxed => {
+                let mut ret = String::new();
+                ret.push_str(&h);
+                ret.to_lowercase()
+            }
+        };
+        if let Some(value) = mail_headers.get_raw(&h) {
+            match canonicalization {
+                DkimCanonicalizationType::Simple => signed_headers.append_raw(
+                    HeaderName::new_from_ascii(h).unwrap(),
+                    dkim_canonicalize_header_value(value, canonicalization),
+                ),
+                DkimCanonicalizationType::Relaxed => signed_headers_relaxed.push_str(&format!(
+                    "{}:{}",
+                    h,
+                    dkim_canonicalize_header_value(value, canonicalization)
+                )),
+            }
+        }
+    }
+    match canonicalization {
+        DkimCanonicalizationType::Simple => format!("{}", signed_headers),
+        DkimCanonicalizationType::Relaxed => signed_headers_relaxed,
+    }
+}
+
+/// Hash input using Sha256 into result
+///
+/// Example
+/// ```
+/// let mut hash=[b'1';32];
+/// dkim_hash("test",&hash);
+/// assert_eq(hash,[b'\0';32])
+/// ```
+fn dkim_hash(input: String, result: &mut [u8; 32]) {
+    let mut hasher = Sha256::new();
+    *result = [b'\0'; 32];
+    hasher.input_str(&input);
+    hasher.result(result);
+}
+
+/// Sign with Dkim a message by adding Dkim-Signture header created with configuration expressed by
+/// dkim_config
+///
+
+pub fn dkim_sign(message: &mut Message, dkim_config: DkimConfig) {
+    let timestamp = format!(
+        "{}",
+        SystemTime::now()
+            .duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    );
+    let headers = message.headers();
+    let mut body_hash = [b'\0'; 32];
+    dkim_hash(
+        dkim_canonicalize_body(&message.body_raw(), dkim_config.canonicalization.body),
+        &mut body_hash,
+    );
+    let bh = encode(body_hash);
+    let signed_headers_list = match dkim_config.canonicalization.header {
+        DkimCanonicalizationType::Simple => dkim_config.headers.join(":"),
+        DkimCanonicalizationType::Relaxed => dkim_config.headers.join(":").to_lowercase(),
+    };
+    let dkim_header = dkim_header_format(
+        dkim_config.domain.clone(),
+        dkim_config.selector.clone(),
+        dkim_config.canonicalization,
+        timestamp.clone(),
+        signed_headers_list.clone(),
+        bh.clone(),
+        "".to_string(),
+    );
+    let signed_headers = dkim_canonicalize_headers(
+        dkim_config.headers.clone(),
+        headers,
+        dkim_config.canonicalization.header,
+    );
+    let private_key = RsaPrivateKey::from_pkcs1_pem(&dkim_config.private_key).unwrap();
+    let canonicalized_dkim_header = dkim_canonicalize_headers(
+        vec!["DKIM-Signature".to_string()],
+        &dkim_header,
+        dkim_config.canonicalization.header,
+    );
+    let canonicalized_dkim_header = canonicalized_dkim_header.trim_end();
+    let to_be_signed = format!("{}{}", signed_headers, canonicalized_dkim_header);
+    let to_be_signed = to_be_signed.trim_end();
+    let mut hashed_headers = [b'\0'; 32];
+    dkim_hash(to_be_signed.to_string(), &mut hashed_headers);
+    let signature = encode(
+        private_key
+            .sign(
+                PaddingScheme::new_pkcs1v15_sign(Some(Hash::SHA2_256)),
+                &hashed_headers,
+            )
+            .unwrap(),
+    );
+    let dkim_header = dkim_header_format(
+        dkim_config.domain,
+        dkim_config.selector,
+        dkim_config.canonicalization,
+        timestamp,
+        signed_headers_list,
+        bh,
+        signature,
+    );
+    let mut headers = headers.clone();
+    headers.append_raw(
+        HeaderName::new_from_ascii_str("DKIM-Signature"),
+        dkim_header.get_raw("DKIM-Signature").unwrap().to_string(),
+    );
+    message.headers = headers;
+}
+
+#[cfg(test)]
+mod test {
+    use super::{
+        super::header::HeaderName,
+        super::{Header, Message},
+        dkim_canonicalize_body, dkim_canonicalize_header_value, dkim_canonicalize_headers,
+        dkim_hash, DkimCanonicalizationType,
+    };
+    use crate::StdError;
+
+    #[derive(Clone)]
+    struct TestHeader(String);
+
+    impl Header for TestHeader {
+        fn name() -> HeaderName {
+            HeaderName::new_from_ascii_str("Test")
+        }
+
+        fn parse(s: &str) -> Result<Self, Box<dyn StdError + Send + Sync>> {
+            Ok(Self(s.into()))
+        }
+
+        fn display(&self) -> String {
+            self.0.clone()
+        }
+    }
+
+    #[test]
+    fn test_dkim_hash() {
+        let mut hash = [b'1'; 32];
+        let expected = [
+            159, 134, 208, 129, 136, 76, 125, 101, 154, 47, 234, 160, 197, 90, 208, 21, 163, 191,
+            79, 27, 43, 11, 130, 44, 209, 93, 108, 21, 176, 240, 10, 8,
+        ];
+        dkim_hash("test".to_string(), &mut hash);
+        assert_eq!(hash, expected)
+    }
+
+    #[test]
+    fn test_body_simple_canonicalize() {
+        let body = "test\r\n\r\ntest   \ttest\r\n\r\n\r\n";
+        let expected = "test\r\n\r\ntest   \ttest\r\n";
+        assert_eq!(
+            dkim_canonicalize_body(body.as_bytes(), DkimCanonicalizationType::Simple),
+            expected.to_string()
+        )
+    }
+    #[test]
+    fn test_body_relaxed_canonicalize() {
+        let body = "test\r\n\r\ntest   \ttest\r\n\r\n\r\n";
+        let expected = "test\r\n\r\ntest test\r\n";
+        assert_eq!(
+            dkim_canonicalize_body(body.as_bytes(), DkimCanonicalizationType::Relaxed),
+            expected.to_string()
+        )
+    }
+    #[test]
+    fn test_header_simple_canonicalize() {
+        let value = "test\r\n\r\ntest   \ttest\r\n";
+        let expected = "test\r\n\r\ntest   \ttest\r\n";
+        assert_eq!(
+            dkim_canonicalize_header_value(value, DkimCanonicalizationType::Simple),
+            expected.to_string()
+        )
+    }
+    #[test]
+    fn test_header_relaxed_canonicalize() {
+        let value = "test\r\n\r\ntest   \ttest\r\n";
+        let expected = "testtest test\r\n";
+        assert_eq!(
+            dkim_canonicalize_header_value(value, DkimCanonicalizationType::Relaxed),
+            expected.to_string()
+        )
+    }
+
+    fn test_message() -> Message {
+        Message::builder()
+            .from("Test <test+ezrz@example.net>".parse().unwrap())
+            .to("Test2 <test2@example.org>".parse().unwrap())
+            .header(TestHeader("test  test very very long with spaces and extra spaces   \twill be folded to several lines ".to_string()))
+            .subject("Test with utf-8 ë")
+            .body("test\r\n\r\ntest   \ttest\r\n\r\n\r\n".to_string()).unwrap()
+    }
+
+    #[test]
+    fn test_headers_simple_canonicalize() {
+        let message = test_message();
+        assert_eq!(dkim_canonicalize_headers(vec!["From".to_string(), "Test".to_string()], &message.headers, DkimCanonicalizationType::Simple),"From: Test <test+ezrz@example.net>\r\nTest: test  test very very long with spaces and extra spaces   \twill be \r\n folded to several lines \r\n")
+    }
+    #[test]
+    fn test_headers_relaxed_canonicalize() {
+        let message = test_message();
+        assert_eq!(dkim_canonicalize_headers(vec!["From".to_string(), "Test".to_string()], &message.headers, DkimCanonicalizationType::Relaxed),"from:Test <test+ezrz@example.net>\r\ntest:test test very very long with spaces and extra spaces will be folded to several lines\r\n")
+    }
+}

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -192,7 +192,7 @@ fn dkim_canonicalize_headers(
 /// dkim_config
 ///
 
-pub fn dkim_sign(message: &mut Message, dkim_config: DkimConfig) {
+pub fn dkim_sign(message: &mut Message, dkim_config: &DkimConfig) {
     let timestamp = format!(
         "{}",
         SystemTime::now()
@@ -210,7 +210,7 @@ pub fn dkim_sign(message: &mut Message, dkim_config: DkimConfig) {
         DkimCanonicalizationType::Relaxed => dkim_config.headers.join(":").to_lowercase(),
     };
     let dkim_header = dkim_header_format(
-        &dkim_config,
+        dkim_config,
         timestamp.clone(),
         signed_headers_list.clone(),
         bh.clone(),
@@ -249,13 +249,11 @@ pub fn dkim_sign(message: &mut Message, dkim_config: DkimConfig) {
         }
     };
     let dkim_header =
-        dkim_header_format(&dkim_config, timestamp, signed_headers_list, bh, signature);
-    let mut headers = headers.clone();
-    headers.append_raw(
+        dkim_header_format(dkim_config, timestamp, signed_headers_list, bh, signature);
+    message.headers.append_raw(
         HeaderName::new_from_ascii_str("DKIM-Signature"),
         dkim_header.get_raw("DKIM-Signature").unwrap().to_string(),
     );
-    message.headers = headers;
 }
 
 #[cfg(test)]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -511,7 +511,7 @@ impl Message {
     /// Example:
     /// ```rust
     /// use lettre::Message;
-    /// use lettre::message::dkim::DkimConfig;
+    /// use lettre::message::dkim::{DkimConfig, DkimSigningAlgorithm, DkimSigningKey};
     ///
     /// let mut message = Message::builder()
     /// .from("Alice <alice@example.org>".parse().unwrap())
@@ -547,7 +547,8 @@ impl Message {
     /// JcaBbL6ZSBIMA3AdaIjtvNRiomueHqh0GspTgOeCE2585TSFnw6vEOJ8RlR4A0Mw
     /// I45fbR4l+3D/30WMfZlM6bzZbwPXEnr2s1mirmuQpjumY9wLhK25
     /// -----END RSA PRIVATE KEY-----";
-    /// message.sign(&DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
+    /// let signing_key = DkimSigningKey::new(key.to_string(), DkimSigningAlgorithm::Rsa).unwrap();
+    /// message.sign(&DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),signing_key));
     /// println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
     /// ```
     #[cfg(feature = "dkim")]

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -513,10 +513,9 @@ impl Message {
     /// use lettre::Message;
     /// use lettre::message::dkim::DkimConfig;
     ///
-    /// println!("Hello, world!");
     /// let mut message = Message::builder()
     /// .from("Alice <alice@example.org>".parse().unwrap())
-    /// .reply_to("Bob <bob@example.org".parse().unwrap())
+    /// .reply_to("Bob <bob@example.org>".parse().unwrap())
     /// .to("Carla <carla@example.net>".parse().unwrap())
     /// .subject("Hello")
     /// .body("Hi there, it's a test email, with utf-8 chars ë!\n\n\n".to_string())

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -510,16 +510,15 @@ impl Message {
     /// use lettre::Message;
     /// use lettre::message::dkim::DkimConfig;
     ///
-    /// fn main() {
-    ///     println!("Hello, world!");
-    ///     let mut message = Message::builder()
-    ///     .from("Alice <alice@example.org>".parse().unwrap())
-    ///     .reply_to("Bob <bob@example.org".parse().unwrap())
-    ///     .to("Carla <carla@example.net>".parse().unwrap())
-    ///     .subject("Hello")
-    ///     .body("Hi there, it's a test email, with utf-8 chars ë!\n\n\n".to_string())
-    ///     .unwrap();
-    ///     let key = "-----BEGIN RSA PRIVATE KEY-----
+    /// println!("Hello, world!");
+    /// let mut message = Message::builder()
+    /// .from("Alice <alice@example.org>".parse().unwrap())
+    /// .reply_to("Bob <bob@example.org".parse().unwrap())
+    /// .to("Carla <carla@example.net>".parse().unwrap())
+    /// .subject("Hello")
+    /// .body("Hi there, it's a test email, with utf-8 chars ë!\n\n\n".to_string())
+    /// .unwrap();
+    /// let key = "-----BEGIN RSA PRIVATE KEY-----
     /// MIIEowIBAAKCAQEAt2gawjoybf0mAz0mSX0cq1ah5F9cPazZdCwLnFBhRufxaZB8
     /// NLTdc9xfPIOK8l/xGrN7Nd63J4cTATqZukumczkA46O8YKHwa53pNT6NYwCNtDUL
     /// eBu+7xUW18GmDzkIFkxGO2R5kkTeWPlKvKpEiicIMfl0OmyW/fI3AbtM7e/gmqQ4
@@ -546,9 +545,8 @@ impl Message {
     /// JcaBbL6ZSBIMA3AdaIjtvNRiomueHqh0GspTgOeCE2585TSFnw6vEOJ8RlR4A0Mw
     /// I45fbR4l+3D/30WMfZlM6bzZbwPXEnr2s1mirmuQpjumY9wLhK25
     /// -----END RSA PRIVATE KEY-----";
-    ///     message.sign(DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
-    ///     println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
-    /// }
+    /// message.sign(DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
+    /// println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
     /// ```
 
     pub fn sign(&mut self, dkim_config: DkimConfig) {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -199,11 +199,13 @@ use std::{convert::TryFrom, io::Write, iter, time::SystemTime};
 
 pub use attachment::Attachment;
 pub use body::{Body, IntoBody, MaybeString};
+pub use dkim::*;
 pub use mailbox::*;
 pub use mimebody::*;
 
 mod attachment;
 mod body;
+pub mod dkim;
 pub mod header;
 mod mailbox;
 mod mimebody;
@@ -488,6 +490,69 @@ impl Message {
         let mut out = Vec::new();
         self.format(&mut out);
         out
+    }
+
+    /// Format body for signing
+    pub(crate) fn body_raw(&self) -> Vec<u8> {
+        let mut out = Vec::new();
+        match &self.body {
+            MessageBody::Mime(p) => p.format(&mut out),
+            MessageBody::Raw(r) => out.extend_from_slice(r),
+        };
+        out.extend_from_slice(b"\r\n");
+        out
+    }
+
+    /// Sign the message using Dkim
+    ///
+    /// Example:
+    /// ```rust
+    /// use lettre::Message;
+    /// use lettre::message::dkim::DkimConfig;
+    ///
+    /// fn main() {
+    ///     println!("Hello, world!");
+    ///     let mut message = Message::builder()
+    ///     .from("Alice <alice@example.org>".parse().unwrap())
+    ///     .reply_to("Bob <bob@example.org".parse().unwrap())
+    ///     .to("Carla <carla@example.net>".parse().unwrap())
+    ///     .subject("Hello")
+    ///     .body("Hi there, it's a test email, with utf-8 chars ë!\n\n\n".to_string())
+    ///     .unwrap();
+    ///     let key = "-----BEGIN RSA PRIVATE KEY-----
+    /// MIIEowIBAAKCAQEAt2gawjoybf0mAz0mSX0cq1ah5F9cPazZdCwLnFBhRufxaZB8
+    /// NLTdc9xfPIOK8l/xGrN7Nd63J4cTATqZukumczkA46O8YKHwa53pNT6NYwCNtDUL
+    /// eBu+7xUW18GmDzkIFkxGO2R5kkTeWPlKvKpEiicIMfl0OmyW/fI3AbtM7e/gmqQ4
+    /// kEYIO0mTjPT+jTgWE4JIi5KUTHudUBtfMKcSFyM2HkUOExl1c9+A4epjRFQwEXMA
+    /// hM5GrqZoOdUm4fIpvGpLIGIxFgHPpZYbyq6yJZzH3+5aKyCHrsHawPuPiCD45zsU
+    /// re31zCE6b6k1sDiiBR4CaRHnbL7hxFp0aNLOVQIDAQABAoIBAGMK3gBrKxaIcUGo
+    /// gQeIf7XrJ6vK72YC9L8uleqI4a9Hy++E7f4MedZ6eBeWta8jrnEL4Yp6xg+beuDc
+    /// A24+Mhng+6Dyp+TLLqj+8pQlPnbrMprRVms7GIXFrrs+wO1RkBNyhy7FmH0roaMM
+    /// pJZzoGW2pE9QdbqjL3rdlWTi/60xRX9eZ42nNxYnbc+RK03SBd46c3UBha6Y9iQX
+    /// 562yWilDnB5WCX2tBoSN39bEhJvuZDzMwOuGw68Q96Hdz82Iz1xVBnRhH+uNStjR
+    /// VnAssSHVxPSpwWrm3sHlhjBHWPnNIaOKIKl1lbL+qWfVQCj/6a5DquC+vYAeYR6L
+    /// 3mA0z0ECgYEA5YkNYcILSXyE0hZ8eA/t58h8eWvYI5iqt3nT4fznCoYJJ74Vukeg
+    /// 6BTlq/CsanwT1lDtvDKrOaJbA7DPTES/bqT0HoeIdOvAw9w/AZI5DAqYp61i6RMK
+    /// xfAQL/Ik5MDFN8gEMLLXRVMe/aR27f6JFZpShJOK/KCzHqikKfYVJ+UCgYEAzI2F
+    /// ZlTyittWSyUSl5UKyfSnFOx2+6vNy+lu5DeMJu8Wh9rqBk388Bxq98CfkCseWESN
+    /// pTCGdYltz9DvVNBdBLwSMdLuYJAI6U+Zd70MWyuNdHFPyWVHUNqMUBvbUtj2w74q
+    /// Hzu0GI0OrRjdX6C63S17PggmT/N2R9X7P4STxbECgYA+AZAD4I98Ao8+0aQ+Ks9x
+    /// 1c8KXf+9XfiAKAD9A3zGcv72JXtpHwBwsXR5xkJNYcdaFfKi7G0k3J8JmDHnwIqW
+    /// MSlhNeu+6hDg2BaNLhsLDbG/Wi9mFybJ4df9m8Qrp4efUgEPxsAwkgvFKTCXijMu
+    /// CspP1iutoxvAJH50d22voQKBgDIsSFtIXNGYaTs3Va8enK3at5zXP3wNsQXiNRP/
+    /// V/44yNL77EktmewfXFF2yuym1uOZtRCerWxpEClYO0wXa6l8pA3aiiPfUIBByQfo
+    /// s/4s2Z6FKKfikrKPWLlRi+NvWl+65kQQ9eTLvJzSq4IIP61+uWsGvrb/pbSLFPyI
+    /// fWKRAoGBALFCStBXvdMptjq4APUzAdJ0vytZzXkOZHxgmc+R0fQn22OiW0huW6iX
+    /// JcaBbL6ZSBIMA3AdaIjtvNRiomueHqh0GspTgOeCE2585TSFnw6vEOJ8RlR4A0Mw
+    /// I45fbR4l+3D/30WMfZlM6bzZbwPXEnr2s1mirmuQpjumY9wLhK25
+    /// -----END RSA PRIVATE KEY-----";
+    ///     message.sign(DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
+    ///     println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
+    /// }
+    /// ```
+
+    pub fn sign(&mut self, dkim_config: DkimConfig) {
+        dkim_sign(self, dkim_config);
     }
 }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -199,12 +199,14 @@ use std::{convert::TryFrom, io::Write, iter, time::SystemTime};
 
 pub use attachment::Attachment;
 pub use body::{Body, IntoBody, MaybeString};
+#[cfg(feature = "dkim")]
 pub use dkim::*;
 pub use mailbox::*;
 pub use mimebody::*;
 
 mod attachment;
 mod body;
+#[cfg(feature = "dkim")]
 pub mod dkim;
 pub mod header;
 mod mailbox;
@@ -492,6 +494,7 @@ impl Message {
         out
     }
 
+    #[cfg(feature = "dkim")]
     /// Format body for signing
     pub(crate) fn body_raw(&self) -> Vec<u8> {
         let mut out = Vec::new();
@@ -549,6 +552,7 @@ impl Message {
     /// println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
     /// ```
 
+    #[cfg(feature = "dkim")]
     pub fn sign(&mut self, dkim_config: DkimConfig) {
         dkim_sign(self, dkim_config);
     }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -550,7 +550,6 @@ impl Message {
     /// message.sign(&DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
     /// println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
     /// ```
-
     #[cfg(feature = "dkim")]
     pub fn sign(&mut self, dkim_config: &DkimConfig) {
         dkim_sign(self, dkim_config);

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -547,12 +547,12 @@ impl Message {
     /// JcaBbL6ZSBIMA3AdaIjtvNRiomueHqh0GspTgOeCE2585TSFnw6vEOJ8RlR4A0Mw
     /// I45fbR4l+3D/30WMfZlM6bzZbwPXEnr2s1mirmuQpjumY9wLhK25
     /// -----END RSA PRIVATE KEY-----";
-    /// message.sign(DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
+    /// message.sign(&DkimConfig::default_config("dkimtest".to_string(),"example.org".to_string(),key.to_string()));
     /// println!("message: {}", std::str::from_utf8(&message.formatted()).unwrap());
     /// ```
 
     #[cfg(feature = "dkim")]
-    pub fn sign(&mut self, dkim_config: DkimConfig) {
+    pub fn sign(&mut self, dkim_config: &DkimConfig) {
         dkim_sign(self, dkim_config);
     }
 }

--- a/testdata/coredns.conf
+++ b/testdata/coredns.conf
@@ -1,0 +1,7 @@
+. {
+  bind 127.0.0.54
+  forward . 9.9.9.9 8.8.8.8 1.1.1.1 {
+    except example.org
+  }
+  file testdata/db.example.org example.org
+}

--- a/testdata/db.example.org
+++ b/testdata/db.example.org
@@ -1,0 +1,2 @@
+@       600     IN      SOA     ns.example.org hostmaster.example.org 1 10800 3600 604800 3600
+dkimtest._domainkey 600 IN TXT  "v=DKIM1; k=rsa; p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAz+FHbM8BwkBBz/Ux5OYLQ5Bp1HVuCHTP6Rr3HXTnome/2cGl/ze0tsmmFbCjjsS89MXbMGs9xJhjv18LmL1N0UTllblOizzVjorQyN4RwBOfG34j7SS56pwzrA738Ry8FAbL5InPWEgVzbOhXuTCs8yuzcqTnm4sH/csnIl7cMWeQkVn1FR9LKMtUG0fjhDPkdX0jx3qTX1L3Z7a7gX6geY191yNd9i9DvE2/+wMigMYz1LAts4alk2g86MQhtbjc8AOR7EC15hSw37/lmamlunYLa3wC+PzHNMA8sAfnmkgNvipssjh8LnelD9qn+VtsjQB5ppkeQx3TcUPvz5z+QIDAQAB"


### PR DESCRIPTION
a new module was created to provide dkim_signing capabilities to
message given a configuration. I tried to make as few changes as
possible in `Message` struct. It's rust beginner work, so comments are
more than welcome.
Using existing dkim create was on option but I did not find easy to
implement it in the existing code base. I started from the RFC and
implement it from scratch. Choices that were made to keep it manageable
to develop quickly.
* Only sha256 hashing with rsa signatures is implemented
* Repeating headers to be signed not supported since multiple headers
does not seem to be implemented in the lib
* l dkim paramtere was not implemented to keep things simple
* the sign function is not tested yet, didn't find a way to do so
properly using another implementation to check it