### PR TITLE
Bump MSRV to 1.52.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -81,8 +81,8 @@ jobs:
             rust: stable
           - name: beta
             rust: beta
-          - name: 1.49.0
-            rust: 1.49.0
+          - name: 1.52.1
+            rust: 1.52.1
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Lettre does not provide (for now):
 
 ## Example
 
-This library requires Rust 1.49 or newer.
+This library requires Rust 1.52.1 or newer.
 To use this library, add the following to your `Cargo.toml`:
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! * Secure defaults
 //! * Async support
 //!
-//! Lettre requires Rust 1.46 or newer.
+//! Lettre requires Rust 1.52.1 or newer.
 //!
 //! ## Features
 //!


### PR DESCRIPTION
Raising the MSRV is becoming a bit annoying at this point, I hope nobody was still working with Rust 1.49 or even previously 1.46. In that case let us know.

Anyway with #670 we realized that `zeroize` bumped their MSRV to 1.51. `rustls` is almost ready for their next stable release (https://github.com/rustls/rustls/issues/813), which will have a MSRV of 1.52.1, so I hope that with this bump in our MSRV we'll get ahead by at least a few months.