### PR TITLE
Re-enable pool tests

### DIFF
--- a/tests/transport_smtp_pool.rs
+++ b/tests/transport_smtp_pool.rs
@@ -1,4 +1,4 @@
-#[cfg(all(test, feature = "smtp-transport", feature = "r2d2"))]
+#[cfg(all(test, feature = "smtp-transport", feature = "pool"))]
 mod sync {
     use lettre::{address::Envelope, SmtpTransport, Transport};
     use std::{sync::mpsc, thread};


### PR DESCRIPTION
The pool tests have been implicitly disabled by testing for a feature that has been removed.