### PR TITLE
Prepare 0.10.0-rc.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 Several breaking changes were made between 0.9 and 0.10, but changes should be straightforward:
 
-* MSRV is now 1.49
+* MSRV is now 1.52.1
 * The `lettre_email` crate has been merged into `lettre`. To migrate, replace `lettre_email` with `lettre::message`
   and make sure to enable the `builder` feature (it's enabled by default).
 * `SendableEmail` has been renamed to `Email` and `EmailBuilder::build()` produces it directly. To migrate,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.10.0-rc.3"
+version = "0.10.0-rc.4"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.10.0-rc.3">
-    <img src="https://deps.rs/crate/lettre/0.10.0-rc.3/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.10.0-rc.4">
+    <img src="https://deps.rs/crate/lettre/0.10.0-rc.4/status.svg"
       alt="dependency status" />
   </a>
 </div>
@@ -71,7 +71,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lettre = "0.10.0-rc.3"
+lettre = "0.10.0-rc.4"
 ```
 
 ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,7 +98,7 @@
 //! [async-std 1.x]: https://docs.rs/async-std/1
 //! [mime 0.3]: https://docs.rs/mime/0.3
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-rc.3")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.0-rc.4")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
I propose we do a new release now so that we can dedicate the next one to header API and encoding changes and fixes.