### PR TITLE
Feature (transport-smtp) Make peer certificate available in SmtpConnection

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -313,4 +313,10 @@ impl AsyncSmtpConnection {
 
         Err(error::response("incomplete response"))
     }
+
+    /// The X509 certificate of the server (DER encoded)
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
+        self.stream.get_ref().peer_certificate()
+    }
 }

--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -392,10 +392,10 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio1NativeTls(stream) => Ok(stream
                 .get_ref()
                 .peer_certificate()
-                .map_err(|e| error::tls(e))?
+                .map_err(error::tls)?
                 .unwrap()
                 .to_der()
-                .map_err(|e| error::tls(e))?),
+                .map_err(error::tls)?),
             #[cfg(feature = "tokio1-rustls-tls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(stream) => Ok(stream
                 .get_ref()

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -294,4 +294,10 @@ impl SmtpConnection {
 
         Err(error::response("incomplete response"))
     }
+
+    /// The X509 certificate of the server (DER encoded)
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
+        self.stream.get_ref().peer_certificate()
+    }
 }

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -28,9 +28,9 @@
 use std::fmt::Debug;
 
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
-pub(crate) use self::async_connection::AsyncSmtpConnection;
+pub use self::async_connection::AsyncSmtpConnection;
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
-pub(crate) use self::async_net::AsyncNetworkStream;
+pub use self::async_net::AsyncNetworkStream;
 use self::net::NetworkStream;
 #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
 pub(super) use self::tls::InnerTlsParameters;

--- a/src/transport/smtp/client/net.rs
+++ b/src/transport/smtp/client/net.rs
@@ -190,10 +190,10 @@ impl NetworkStream {
             #[cfg(feature = "native-tls")]
             InnerNetworkStream::NativeTls(stream) => Ok(stream
                 .peer_certificate()
-                .map_err(|e| error::tls(e))?
+                .map_err(error::tls)?
                 .unwrap()
                 .to_der()
-                .map_err(|e| error::tls(e))?),
+                .map_err(error::tls)?),
             #[cfg(feature = "rustls-tls")]
             InnerNetworkStream::RustlsTls(stream) => Ok(stream
                 .conn


### PR DESCRIPTION
Thanks for this great library! I am proposing a small change that I am using in my own project that allows access to the server's certificate.

For context: 
I am building a tool that automatically tests mail servers, and I would like to add a check to warn if a certificate is about to expire soon so that I can be warned about it.

This change adds a function to the SmtpConnection and AsyncSmtpConnection structures that exposes the peer certificate out of the underlying network stream structures.

It also makes AsyncSmtpConnection public to match SmtpConnection which was already public (I'm not sure why the mismatch).
