### PR TITLE
Use +0000 timezone format in Date header

### DIFF
--- a/src/message/header/date.rs
+++ b/src/message/header/date.rs
@@ -32,11 +32,11 @@ impl Header for Date {
 
     fn parse(s: &str) -> Result<Self, BoxError> {
         let mut s = String::from(s);
-        if s.ends_with(" -0000") {
+        if s.ends_with("+0000") {
             // The httpdate crate expects the `Date` to end in ` GMT`, but email
-            // uses `-0000`, so we crudely fix this issue here.
+            // uses `+0000` to indicate UTC, so we crudely fix this issue here.
 
-            s.truncate(s.len() - "-0000".len());
+            s.truncate(s.len() - "+0000".len());
             s.push_str("GMT");
         }
 
@@ -49,9 +49,9 @@ impl Header for Date {
             // The httpdate crate always appends ` GMT` to the end of the string,
             // but this is considered an obsolete date format for email
             // https://tools.ietf.org/html/rfc2822#appendix-A.6.2,
-            // so we replace `GMT` with `-0000`
+            // so we replace `GMT` with `+0000`
             val.truncate(val.len() - "GMT".len());
-            val.push_str("-0000");
+            val.push_str("+0000");
         }
 
         HeaderValue::dangerous_new_pre_encoded(Self::name(), val.clone(), val)
@@ -88,7 +88,7 @@ mod test {
 
         assert_eq!(
             headers.to_string(),
-            "Date: Tue, 15 Nov 1994 08:12:31 -0000\r\n".to_string()
+            "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n".to_string()
         );
 
         // Tue, 15 Nov 1994 08:12:32 GMT
@@ -98,7 +98,7 @@ mod test {
 
         assert_eq!(
             headers.to_string(),
-            "Date: Tue, 15 Nov 1994 08:12:32 -0000\r\n"
+            "Date: Tue, 15 Nov 1994 08:12:32 +0000\r\n"
         );
     }
 
@@ -108,7 +108,7 @@ mod test {
 
         headers.insert_raw(HeaderValue::new(
             HeaderName::new_from_ascii_str("Date"),
-            "Tue, 15 Nov 1994 08:12:31 -0000".to_string(),
+            "Tue, 15 Nov 1994 08:12:31 +0000".to_string(),
         ));
 
         assert_eq!(
@@ -120,7 +120,7 @@ mod test {
 
         headers.insert_raw(HeaderValue::new(
             HeaderName::new_from_ascii_str("Date"),
-            "Tue, 15 Nov 1994 08:12:32 -0000".to_string(),
+            "Tue, 15 Nov 1994 08:12:32 +0000".to_string(),
         ));
 
         assert_eq!(

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -650,7 +650,7 @@ mod test {
         assert_eq!(
             String::from_utf8(email.formatted()).unwrap(),
             concat!(
-                "Date: Tue, 15 Nov 1994 08:12:31 -0000\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "From: =?utf-8?b?0JrQsNC4?= <kayo@example.com>\r\n",
                 "To: \"Pony O.P.\" <pony@domain.tld>\r\n",
                 "Subject: =?utf-8?b?0Y/So9CwINC10Lsg0LHQtdC705nQvSE=?=\r\n",

--- a/testdata/email_with_png.eml
+++ b/testdata/email_with_png.eml
@@ -1,4 +1,4 @@
-Date: Tue, 15 Nov 1994 08:12:31 -0000
+Date: Tue, 15 Nov 1994 08:12:31 +0000
 From: NoBody <nobody@domain.tld>
 Reply-To: Yuin <yuin@domain.tld>
 To: Hei <hei@domain.tld>

--- a/tests/transport_file.rs
+++ b/tests/transport_file.rs
@@ -43,7 +43,7 @@ mod sync {
                 "Reply-To: Yuin <yuin@domain.tld>\r\n",
                 "To: Hei <hei@domain.tld>\r\n",
                 "Subject: Happy new year\r\n",
-                "Date: Tue, 15 Nov 1994 08:12:31 -0000\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Be happy!"
@@ -81,7 +81,7 @@ mod sync {
                 "Reply-To: Yuin <yuin@domain.tld>\r\n",
                 "To: Hei <hei@domain.tld>\r\n",
                 "Subject: Happy new year\r\n",
-                "Date: Tue, 15 Nov 1994 08:12:31 -0000\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Be happy!"
@@ -141,7 +141,7 @@ mod tokio_1 {
                 "Reply-To: Yuin <yuin@domain.tld>\r\n",
                 "To: Hei <hei@domain.tld>\r\n",
                 "Subject: Happy new year\r\n",
-                "Date: Tue, 15 Nov 1994 08:12:31 -0000\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Be happy!"
@@ -192,7 +192,7 @@ mod asyncstd_1 {
                 "Reply-To: Yuin <yuin@domain.tld>\r\n",
                 "To: Hei <hei@domain.tld>\r\n",
                 "Subject: Happy new year\r\n",
-                "Date: Tue, 15 Nov 1994 08:12:31 -0000\r\n",
+                "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Be happy!"


### PR DESCRIPTION
Since the Date we emit is UTC, it's correct to use "+0000". The previously used -0000 timezone indicator means "no timezone info".

Closes #755 