### PR TITLE
use email_address crate for checking formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,9 @@ sha2 = { version = "0.10", optional = true }
 rsa = { version = "0.6.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
 
+# email formats
+email_address = { version = "0.2.1", default-features = false }
+
 [dev-dependencies]
 criterion = "0.3"
 tracing-subscriber = "0.3"


### PR DESCRIPTION
The email_address crate is more strict in validating user and domain
parts of email addresses. For example, it verifies the total size
of the local part, which the current method does not, and this has
caused upstream servers to fail to accept an email.