### PR TITLE
Add bounds to AsyncTransport, Ok, and Error

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -138,11 +138,11 @@ pub trait Transport {
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio1", feature = "async-std1"))))]
 #[async_trait]
-pub trait AsyncTransport {
+pub trait AsyncTransport: Send + Sync {
     /// Response produced by the Transport
-    type Ok;
+    type Ok: Send + Sync;
     /// Error produced by the Transport
-    type Error;
+    type Error: Send + Sync;
 
     /// Sends the email
     #[cfg(feature = "builder")]


### PR DESCRIPTION
Adding Send + Sync bounds to AsyncTransport and associated types (for #770)

This reduces the amount of bounds that must be specified for a function that is generic over AsyncTransport.

In my case:

```rust
pub async fn send_alert<T>(mailer: &T, subject: &str, body: &str) -> anyhow::Result<()>
where
    T: AsyncTransport + Send + Sync,
    <T as AsyncTransport>::Error: 'static + Send + Sync,
    <T as AsyncTransport>::Error: std::error::Error,
{
```

becomes

```rust
pub async fn send_alert<T>(mailer: &T, subject: &str, body: &str) -> anyhow::Result<()>
where
    T: AsyncTransport,
    <T as AsyncTransport>::Error: 'static,
    <T as AsyncTransport>::Error: std::error::Error,
{
```

I am not certain if adding the 'static and std:error bounds would be reasonable.
