### PR TITLE
Fix and improve header wrapping

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ fastrand = { version = "1.4", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
 regex = { version = "1", default-features = false, features = ["std", "unicode-case"] }
-email-encoding = { git = "https://github.com/lettre/email-encoding.git", rev = "7b4fdf44a6e8715753d9012317c019271bcbc431", optional = true }
+email-encoding = { git = "https://github.com/lettre/email-encoding.git", rev = "ac7ab8630b8d012ade63869c89b2855e27b3ce7a", optional = true }
 
 # file transport
 uuid = { version = "1", features = ["v4"], optional = true }
@@ -88,7 +88,7 @@ name = "transport_smtp"
 
 [features]
 default = ["smtp-transport", "pool", "native-tls", "hostname", "builder"]
-builder = ["httpdate", "mime", "base64", "fastrand", "quoted_printable", "email-encoding"]
+builder = ["httpdate", "mime", "fastrand", "quoted_printable", "email-encoding"]
 mime03 = ["mime"]
 
 # transports
@@ -109,7 +109,7 @@ tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
-dkim = ["sha2", "rsa", "ed25519-dalek"]
+dkim = ["base64", "sha2", "rsa", "ed25519-dalek"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -480,7 +480,7 @@ cJ5Ku0OTwRtSMaseRPX+T4EfG1Caa/eunPPN4rh+CSup2BVVarOT
     fn test_headers_simple_canonicalize() {
         let message = test_message();
         dbg!(message.headers.to_string());
-        assert_eq!(dkim_canonicalize_headers(["From", "Test"], &message.headers, DkimCanonicalizationType::Simple), "From: =?utf-8?b?VGVzdCBPJ0xlYXJ5?= <test+ezrz@example.net>\r\nTest: test  test very very long with spaces and extra spaces   \twill be \r\n folded to several lines \r\n")
+        assert_eq!(dkim_canonicalize_headers(["From", "Test"], &message.headers, DkimCanonicalizationType::Simple), "From: =?utf-8?b?VGVzdCBPJ0xlYXJ5?= <test+ezrz@example.net>\r\nTest: test  test very very long with spaces and extra spaces   \twill be\r\n folded to several lines \r\n")
     }
 
     #[test]
@@ -521,18 +521,14 @@ cJ5Ku0OTwRtSMaseRPX+T4EfG1Caa/eunPPN4rh+CSup2BVVarOT
                 "From: =?utf-8?b?VGVzdCBPJ0xlYXJ5?= <test+ezrz@example.net>\r\n",
                 "To: Test2 <test2@example.org>\r\n",
                 "Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n",
-                "Test: test  test very very long with spaces and extra spaces   \twill be \r\n",
+                "Test: test  test very very long with spaces and extra spaces   \twill be\r\n",
                 " folded to several lines \r\n",
                 "Subject: Test with utf-8 =?utf-8?b?w6s=?=\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
-                "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; s=dkimtest; \r\n",
-                " c=simple/simple; q=dns/txt; t=0; h=Date:From:Subject:To; \r\n",
-                " bh=f3Zksdcjqa/xRBwdyFzIXWCcgP7XTgxjCgYsXOMKQl4=; b=UQWpUooKjVzgC7jtuEKdpCbz\r\n",
-                " sSDnOqZFg8+S7rZj89n/+AVsdcwxumeLCUYLeko2TZgVFJA7kGz+wLzH2wpzB4XnyUqrkF6PrFA\r\n",
-                " 9K11K365JDtzfMSc5eRVS8crO6F/A9QtXPndnzrXQ5HrtFgfxUlJ9cX6pTOor1NVCpfYUNBviIg\r\n",
-                " Am0LnUOKdlJ8z82kLFRpIqawMKNVfyqP8Es6H3NHM4Y1uwGgls9DM1+lZxNXxkMpoGV3rL/n/ai\r\n",
-                " s8+VifrRxPLB0mr9gbavSkCQ2QzUA/+iq8DgPCGpXDrdDrwTcrV3pL/iHyEjQZWwFSQkx+r/CGb\r\n",
-                " 8TQLqH6T3wfr69XWvg==\r\n",
+                "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; s=dkimtest;\r\n",
+                " c=simple/simple; q=dns/txt; t=0; h=Date:From:Subject:To;\r\n",
+                " bh=f3Zksdcjqa/xRBwdyFzIXWCcgP7XTgxjCgYsXOMKQl4=;\r\n",
+                " b=NhoIMMAALoSgu5lKAR0+MUQunOWnU7wpF9ORUFtpxq9sGZDo9AX43AMhFemyM5W204jpFwMU6pm7AMR1nOYBdSYye4yUALtvT2nqbJBwSh7JeYu+z22t1RFKp7qQR1il8aSrkbZuNMFHYuSEwW76QtKwcNqP4bQOzS9CzgQp0ABu8qwYPBr/EypykPTfqjtyN+ywrfdqjjGOzTpRGolH0hc3CrAETNjjHbNBgKgucXmXTN7hMRdzqWjeFPxizXwouwNAavFClPG0l33gXVArFWn+CkgA84G/s4zuJiF7QPZR87Pu4pw/vIlSXxH4a42W3tT19v9iBTH7X7ldYegtmQ==\r\n",
                 "\r\n",
                 "test\r\n",
                 "\r\n",
@@ -575,18 +571,13 @@ cJ5Ku0OTwRtSMaseRPX+T4EfG1Caa/eunPPN4rh+CSup2BVVarOT
                 "From: =?utf-8?b?VGVzdCBPJ0xlYXJ5?= <test+ezrz@example.net>\r\n",
                 "To: Test2 <test2@example.org>\r\n",
                 "Date: Thu, 01 Jan 1970 00:00:00 +0000\r\n",
-                "Test: test  test very very long with spaces and extra spaces   \twill be \r\n",
-                " folded to several lines \r\n",
-                "Subject: Test with utf-8 =?utf-8?b?w6s=?=\r\n",
+                "Test: test  test very very long with spaces and extra spaces   \twill be\r\n",
+                " folded to several lines \r\n","Subject: Test with utf-8 =?utf-8?b?w6s=?=\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
-                "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; s=dkimtest; \r\n",
-                " c=relaxed/relaxed; q=dns/txt; t=0; h=date:from:subject:to; \r\n",
-                " bh=qN8je6qJgWFGSnN2MycC/XKPbN6BOrMJyAX2h4m19Ss=; b=YaVfmH8dbGEywoLJ4uhbvYqD\r\n",
-                " yQG1UGKFH3PE7zXGgk+YFxUgkwWjoA3aQupDNQtfTjfUsNe0dnrjyZP+ylnESpZBpbCIf5/n3FE\r\n",
-                " h6j3RQthqNbQblcfH/U8mazTuRbVjYBbTZQDaQCMPTz+8D+ZQfXo2oq6dGzTuGvmuYft0CVsq/B\r\n",
-                " Ip/EkhZHqiphDeVJSHD4iKW8+L2XwEWThoY92xOYc1G0TtBwz2UJgtiHX2YulH/kRBHeK3dKn9R\r\n",
-                " TNVL3VZ+9ZrnFwIhET9TPGtU2I+q0EMSWF9H9bTrASMgW/U+E0VM2btqJlrTU6rQ7wlQeHdwecL\r\n",
-                " nzXcyhCUInF1+veMNw==\r\n",
+                "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; s=dkimtest;\r\n",
+                " c=relaxed/relaxed; q=dns/txt; t=0; h=date:from:subject:to;\r\n",
+                " bh=qN8je6qJgWFGSnN2MycC/XKPbN6BOrMJyAX2h4m19Ss=;\r\n",
+                " b=YaVfmH8dbGEywoLJ4uhbvYqDyQG1UGKFH3PE7zXGgk+YFxUgkwWjoA3aQupDNQtfTjfUsNe0dnrjyZP+ylnESpZBpbCIf5/n3FEh6j3RQthqNbQblcfH/U8mazTuRbVjYBbTZQDaQCMPTz+8D+ZQfXo2oq6dGzTuGvmuYft0CVsq/BIp/EkhZHqiphDeVJSHD4iKW8+L2XwEWThoY92xOYc1G0TtBwz2UJgtiHX2YulH/kRBHeK3dKn9RTNVL3VZ+9ZrnFwIhET9TPGtU2I+q0EMSWF9H9bTrASMgW/U+E0VM2btqJlrTU6rQ7wlQeHdwecLnzXcyhCUInF1+veMNw==\r\n",
                 "\r\n",
                 "test\r\n",
                 "\r\n",

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -364,7 +364,8 @@ impl HeaderValueEncoder {
                 self.flush_encode_buf(f)?;
 
                 if !self.fits_on_line(next_word.len())
-                    && WHITESPACE_CHARS.contains(&next_word.as_bytes()[0]) {
+                    && WHITESPACE_CHARS.contains(&next_word.as_bytes()[0])
+                {
                     // not enough space left on this line to encode word
                     self.new_line(f)?;
                 }
@@ -375,7 +376,7 @@ impl HeaderValueEncoder {
                 // This word contains unallowed characters
 
                 if !self.fits_on_line(base64_len(self.encode_buf.len() + next_word.len()))
-                     && WHITESPACE_CHARS.contains(&next_word.as_bytes()[0])
+                    && WHITESPACE_CHARS.contains(&next_word.as_bytes()[0])
                 {
                     self.flush_encode_buf(f)?;
                     self.new_line(f)?;
@@ -395,22 +396,23 @@ impl HeaderValueEncoder {
         self.line_len + bytes <= MAX_LINE_LEN
     }
 
-    fn flush_encode_buf(
-        &mut self,
-        f: &mut impl fmt::Write,
-    ) -> fmt::Result {
+    fn flush_encode_buf(&mut self, f: &mut impl fmt::Write) -> fmt::Result {
         if self.encode_buf.is_empty() {
             // nothing to encode
             return Ok(());
         }
 
         // It is important that we don't encode leading whitespace otherwise it breaks wrapping.
-        let first_not_allowed = self.encode_buf.bytes()
+        let first_not_allowed = self
+            .encode_buf
+            .bytes()
             .enumerate()
             .find(|(_i, c)| !allowed_char(*c))
             .map(|(i, _)| i);
         // May as well also write the tail in plain text.
-        let last_not_allowed = self.encode_buf.bytes()
+        let last_not_allowed = self
+            .encode_buf
+            .bytes()
             .enumerate()
             .rev()
             .find(|(_i, c)| !allowed_char(*c))
@@ -429,10 +431,8 @@ impl HeaderValueEncoder {
 
         f.write_str(prefix)?;
         f.write_str(ENCODING_START_PREFIX)?;
-        let encoded = base64::display::Base64Display::with_config(
-            to_encode.as_bytes(),
-            base64::STANDARD,
-        );
+        let encoded =
+            base64::display::Base64Display::with_config(to_encode.as_bytes(), base64::STANDARD);
         write!(f, "{}", encoded)?;
         f.write_str(ENCODING_END_SUFFIX)?;
         f.write_str(suffix)?;
@@ -488,10 +488,7 @@ fn allowed_str(s: &str) -> bool {
 }
 
 const fn allowed_char(c: u8) -> bool {
-    c >= 1 && c <= 9
-        || c == 11
-        || c == 12
-        || c >= 14 && c <= 127
+    c >= 1 && c <= 9 || c == 11 || c == 12 || c >= 14 && c <= 127
 }
 
 #[cfg(test)]

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -28,8 +28,6 @@ mod mailbox;
 mod special;
 mod textual;
 
-const WHITESPACE_CHARS: &[u8] = b" \t";
-
 /// Represents an email header
 ///
 /// Email header as defined in [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322) and extensions.
@@ -431,7 +429,7 @@ impl<'a> Iterator for WordsPlusFillIterator<'a> {
             .bytes()
             .enumerate()
             .skip(1)
-            .find(|&(_i, c)| WHITESPACE_CHARS.contains(&c))
+            .find(|&(_i, c)| c == b' ')
             .map(|(i, _)| i)
             .unwrap_or(self.s.len());
 

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -479,7 +479,7 @@ mod test {
         assert_eq!(
             String::from_utf8(part.formatted()).unwrap(),
             concat!(
-                "Content-Type: multipart/mixed; \r\n",
+                "Content-Type: multipart/mixed;\r\n",
                 " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\"\r\n",
                 "\r\n",
                 "--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\r\n",
@@ -526,8 +526,8 @@ mod test {
         assert_eq!(
             String::from_utf8(part.formatted()).unwrap(),
             concat!(
-                "Content-Type: multipart/encrypted; \r\n",
-                " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\"; \r\n",
+                "Content-Type: multipart/encrypted;\r\n",
+                " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\";\r\n",
                 " protocol=\"application/pgp-encrypted\"\r\n",
                 "\r\n",
                 "--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\r\n",
@@ -582,8 +582,8 @@ mod test {
         assert_eq!(
             String::from_utf8(part.formatted()).unwrap(),
             concat!(
-                "Content-Type: multipart/signed; \r\n",
-                " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\"; \r\n",
+                "Content-Type: multipart/signed;\r\n",
+                " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\";\r\n",
                 " protocol=\"application/pgp-signature\";",
                 " micalg=\"pgp-sha256\"\r\n",
                 "\r\n",
@@ -624,7 +624,7 @@ mod test {
                              .body(String::from("<p>Текст <em>письма</em> в <a href=\"https://ru.wikipedia.org/wiki/Юникод\">уникоде</a><p>")));
 
         assert_eq!(String::from_utf8(part.formatted()).unwrap(),
-                   concat!("Content-Type: multipart/alternative; \r\n",
+                   concat!("Content-Type: multipart/alternative;\r\n",
                            " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\"\r\n",
                            "\r\n",
                            "--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\r\n",
@@ -662,11 +662,11 @@ mod test {
                              .body(String::from("int main() { return 0; }")));
 
         assert_eq!(String::from_utf8(part.formatted()).unwrap(),
-                   concat!("Content-Type: multipart/mixed; \r\n",
+                   concat!("Content-Type: multipart/mixed;\r\n",
                            " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\"\r\n",
                            "\r\n",
                            "--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\r\n",
-                           "Content-Type: multipart/related; \r\n",
+                           "Content-Type: multipart/related;\r\n",
                            " boundary=\"0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\"\r\n",
                            "\r\n",
                            "--0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1\r\n",

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -655,7 +655,7 @@ mod test {
                 "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "From: =?utf-8?b?0JrQsNC4?= <kayo@example.com>\r\n",
                 "To: \"Pony O.P.\" <pony@domain.tld>\r\n",
-                "Subject: =?utf-8?b?0Y/So9CwINC10Lsg0LHQtdC705nQvSE=?=\r\n",
+                "Subject: =?utf-8?b?0Y/So9CwINC10Lsg0LHQtdC705nQvQ==?=!\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Happy new year!"

--- a/testdata/email_with_png.eml
+++ b/testdata/email_with_png.eml
@@ -4,7 +4,7 @@ Reply-To: Yuin <yuin@domain.tld>
 To: Hei <hei@domain.tld>
 Subject: Happy new year
 MIME-Version: 1.0
-Content-Type: multipart/related; 
+Content-Type: multipart/related;
  boundary="GUEEoEeTXtLcK2sMhmH1RfC1co13g4rtnRUFjQFA"
 
 --0oVZ2r6AoLAhLlb0gPNSKy6BEqdS2IfwxrcbUuo1


### PR DESCRIPTION
Cherry-picks the commit from @kevincox and also converts the `HeaderValueEncoder` to use the email-encoding crate.

The only thing that should be left is to fix the fact that the email-encoding implementation doesn't consider tabs as separator characters

Closes #688