### PR TITLE
Stop using the regex crate for parsing addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 idna = "0.2"
-once_cell = "1"
+once_cell = { version = "1", optional = true }
 tracing = { version = "0.1.16", default-features = false, features = ["std"], optional = true } # feature
 
 # builder
@@ -29,7 +29,6 @@ mime = { version = "0.3.4", optional = true }
 fastrand = { version = "1.4", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
-regex = { version = "1", default-features = false, features = ["std", "unicode-case"] }
 email-encoding = { git = "https://github.com/lettre/email-encoding.git", rev = "7b4fdf44a6e8715753d9012317c019271bcbc431", optional = true }
 
 # file transport
@@ -67,6 +66,7 @@ tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
 sha2 = { version = "0.10", optional = true }
 rsa = { version = "0.6.0", optional = true }
 ed25519-dalek = { version = "1.0.1", optional = true }
+regex = { version = "1", default-features = false, features = ["std"], optional = true }
 
 # email formats
 email_address = { version = "0.2.1", default-features = false }
@@ -95,7 +95,7 @@ mime03 = ["mime"]
 file-transport = ["uuid"]
 file-transport-envelope = ["serde", "serde_json", "file-transport"]
 sendmail-transport = []
-smtp-transport = ["base64", "nom", "socket2"]
+smtp-transport = ["base64", "nom", "socket2", "once_cell"]
 
 pool = ["futures-util"]
 
@@ -109,7 +109,7 @@ tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
 
-dkim = ["sha2", "rsa", "ed25519-dalek"]
+dkim = ["sha2", "rsa", "ed25519-dalek", "regex", "once_cell"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ mime = { version = "0.3.4", optional = true }
 fastrand = { version = "1.4", optional = true }
 quoted_printable = { version = "0.4", optional = true }
 base64 = { version = "0.13", optional = true }
-email-encoding = { git = "https://github.com/lettre/email-encoding.git", rev = "7b4fdf44a6e8715753d9012317c019271bcbc431", optional = true }
+email-encoding = { git = "https://github.com/lettre/email-encoding.git", rev = "ac7ab8630b8d012ade63869c89b2855e27b3ce7a", optional = true }
 
 # file transport
 uuid = { version = "1", features = ["v4"], optional = true }


### PR DESCRIPTION
Removes the dependency on the regex crate except for when the DKIM feature is enabled. Part of #768 

Let's merge this after #774 as I don't want to rebase/merge that PR on top of master again.