### PR TITLE
clippy: make rules stricter

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -279,15 +279,13 @@ impl SpawnHandle for async_std::task::JoinHandle<()> {
 }
 
 mod private {
-    use super::*;
-
     pub trait Sealed {}
 
     #[cfg(feature = "tokio1")]
-    impl Sealed for Tokio1Executor {}
+    impl Sealed for super::Tokio1Executor {}
 
     #[cfg(feature = "async-std1")]
-    impl Sealed for AsyncStd1Executor {}
+    impl Sealed for super::AsyncStd1Executor {}
 
     #[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
     impl Sealed for tokio1_crate::task::JoinHandle<()> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,7 +112,21 @@
     unused_import_braces,
     rust_2018_idioms,
     clippy::string_add,
-    clippy::string_add_assign
+    clippy::string_add_assign,
+    clippy::clone_on_ref_ptr,
+    clippy::verbose_file_reads,
+    clippy::unnecessary_self_imports,
+    clippy::string_to_string,
+    clippy::mem_forget,
+    clippy::cast_lossless,
+    clippy::inefficient_to_string,
+    clippy::inline_always,
+    clippy::linkedlist,
+    clippy::macro_use_imports,
+    clippy::manual_assert,
+    clippy::unnecessary_join,
+    clippy::wildcard_imports,
+    clippy::zero_sized_map_values
 )]
 #![cfg_attr(docsrs, feature(doc_cfg))]
 

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -198,6 +198,9 @@ where
 {
     fn clone(&self) -> Self {
         Self {
+            #[cfg(feature = "pool")]
+            inner: Arc::clone(&self.inner),
+            #[cfg(not(feature = "pool"))]
             inner: self.inner.clone(),
         }
     }

--- a/src/transport/smtp/authentication.rs
+++ b/src/transport/smtp/authentication.rs
@@ -99,11 +99,11 @@ impl Mechanism {
                     .ok_or_else(|| error::client("This mechanism does expect a challenge"))?;
 
                 if vec!["User Name", "Username:", "Username"].contains(&decoded_challenge) {
-                    return Ok(credentials.authentication_identity.to_string());
+                    return Ok(credentials.authentication_identity.clone());
                 }
 
                 if vec!["Password", "Password:"].contains(&decoded_challenge) {
-                    return Ok(credentials.secret.to_string());
+                    return Ok(credentials.secret.clone());
                 }
 
                 Err(error::client("Unrecognized challenge"))

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -8,7 +8,7 @@ use super::{AsyncNetworkStream, ClientCodec, TlsParameters};
 use crate::{
     transport::smtp::{
         authentication::{Credentials, Mechanism},
-        commands::*,
+        commands::{Auth, Data, Ehlo, Mail, Noop, Quit, Rcpt, Starttls},
         error,
         error::Error,
         extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -12,7 +12,7 @@ use crate::{
     address::Envelope,
     transport::smtp::{
         authentication::{Credentials, Mechanism},
-        commands::*,
+        commands::{Auth, Data, Ehlo, Mail, Noop, Quit, Rcpt, Starttls},
         error,
         error::Error,
         extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},

--- a/src/transport/smtp/client/net.rs
+++ b/src/transport/smtp/client/net.rs
@@ -2,6 +2,7 @@ use std::{
     io::{self, Read, Write},
     mem,
     net::{IpAddr, Ipv4Addr, Shutdown, SocketAddr, SocketAddrV4, TcpStream, ToSocketAddrs},
+    sync::Arc,
     time::Duration,
 };
 
@@ -175,8 +176,8 @@ impl NetworkStream {
             InnerTlsParameters::RustlsTls(connector) => {
                 let domain = ServerName::try_from(tls_parameters.domain())
                     .map_err(|_| error::connection("domain isn't a valid DNS name"))?;
-                let connection =
-                    ClientConnection::new(connector.clone(), domain).map_err(error::connection)?;
+                let connection = ClientConnection::new(Arc::clone(connector), domain)
+                    .map_err(error::connection)?;
                 let stream = StreamOwned::new(connection, tcp_stream);
                 InnerNetworkStream::RustlsTls(stream)
             }

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -158,14 +158,14 @@ impl<E: Executor> Pool<E> {
                     #[cfg(feature = "tracing")]
                     tracing::debug!("reusing a pooled connection");
 
-                    return Ok(PooledConnection::wrap(conn, self.clone()));
+                    return Ok(PooledConnection::wrap(conn, Arc::clone(self)));
                 }
                 None => {
                     #[cfg(feature = "tracing")]
                     tracing::debug!("creating a new connection");
 
                     let conn = self.client.connection().await?;
-                    return Ok(PooledConnection::wrap(conn, self.clone()));
+                    return Ok(PooledConnection::wrap(conn, Arc::clone(self)));
                 }
             }
         }

--- a/src/transport/smtp/pool/sync_impl.rs
+++ b/src/transport/smtp/pool/sync_impl.rs
@@ -141,14 +141,14 @@ impl Pool {
                     #[cfg(feature = "tracing")]
                     tracing::debug!("reusing a pooled connection");
 
-                    return Ok(PooledConnection::wrap(conn, self.clone()));
+                    return Ok(PooledConnection::wrap(conn, Arc::clone(self)));
                 }
                 None => {
                     #[cfg(feature = "tracing")]
                     tracing::debug!("creating a new connection");
 
                     let conn = self.client.connection()?;
-                    return Ok(PooledConnection::wrap(conn, self.clone()));
+                    return Ok(PooledConnection::wrap(conn, Arc::clone(self)));
                 }
             }
         }

--- a/src/transport/smtp/util.rs
+++ b/src/transport/smtp/util.rs
@@ -41,7 +41,7 @@ mod tests {
         ]
         .iter()
         {
-            assert_eq!(format!("{}", XText(input)), expect.to_string());
+            assert_eq!(format!("{}", XText(input)), (*expect).to_string());
         }
     }
 }


### PR DESCRIPTION
Denies some allow-by-default clippy lints that I like to have around.