### PR TITLE
readme: change code in example to show how to convert email into SendableEmail

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ fn main() {
     // Open a local connection on port 25
     let mut mailer = SmtpTransport::builder_unencrypted_localhost().unwrap()
                                                                    .build();
-    // Send the email
+    // Convert email to SendableEmail and send the email
+    let email: SendableEmail = email.into(); 
     let result = mailer.send(&email);
 
     if result.is_ok() {


### PR DESCRIPTION
The code in the readme of the repository show an incorrect example where a `Email` is passed into the `SmtpTransport` for sendint it.

The `SmtpTransport` expected a `SendableEmail` instead needing an explicit conversion.