### PR TITLE
add support for boring TLS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,9 +133,12 @@ jobs:
       - name: Test with default features
         run: cargo test
 
-      - name: Test with all features
-        run: cargo test --all-features
+      - name: Test with all features (-native-tls)
+        run: cargo test --no-default-features --features async-std,async-std1,async-std1-rustls-tls,async-trait,base64,boring,boring-tls,builder,dkim,ed25519-dalek,email-encoding,fastrand,file-transport,file-transport-envelope,futures-io,futures-rustls,futures-util,hostname,httpdate,mime,mime03,nom,once_cell,pool,quoted_printable,regex,rsa,rustls,rustls-pemfile,rustls-tls,sendmail-transport,serde,serde_json,sha2,smtp-transport,socket2,tokio1,tokio1-boring-tls,tokio1-rustls-tls,tokio1_boring,tokio1_crate,tokio1_rustls,tracing,uuid,webpki-roots
   
+      - name: Test with all features (-boring-tls)
+        run: cargo test --no-default-features --features async-std,async-std1,async-std1-rustls-tls,async-trait,base64,builder,dkim,ed25519-dalek,email-encoding,fastrand,file-transport,file-transport-envelope,futures-io,futures-rustls,futures-util,hostname,httpdate,mime,mime03,native-tls,nom,once_cell,pool,quoted_printable,regex,rsa,rustls,rustls-pemfile,rustls-tls,sendmail-transport,serde,serde_json,sha2,smtp-transport,socket2,tokio1,tokio1-native-tls,tokio1-rustls-tls,tokio1_crate,tokio1_native_tls_crate,tokio1_rustls,tracing,uuid,webpki-roots
+
 #  coverage:
 #    name: Coverage
 #    runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ native-tls = { version = "0.2", optional = true } # feature
 rustls = { version = "0.20", features = ["dangerous_configuration"], optional = true }
 rustls-pemfile = { version = "1", optional = true }
 webpki-roots = { version = "0.22", optional = true }
+boring = { version = "2.0.0", optional = true }
 
 # async
 futures-io = { version = "0.3.7", optional = true }
@@ -61,6 +62,7 @@ futures-rustls = { version = "0.22", optional = true }
 tokio1_crate = { package = "tokio", version = "1", features = ["fs", "rt", "process", "time", "net", "io-util"], optional = true }
 tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optional = true }
 tokio1_rustls = { package = "tokio-rustls", version = "0.23", optional = true }
+tokio1_boring = { package = "tokio-boring", version = "2.1.4", optional = true }
 
 ## dkim
 sha2 = { version = "0.10", optional = true }
@@ -102,6 +104,8 @@ pool = ["futures-util"]
 
 rustls-tls = ["webpki-roots", "rustls", "rustls-pemfile"]
 
+boring-tls = ["boring"]
+
 # async
 async-std1 = ["async-std", "async-trait", "futures-io", "futures-util"]
 #async-std1-native-tls = ["async-std1", "native-tls", "async-native-tls"]
@@ -109,6 +113,7 @@ async-std1-rustls-tls = ["async-std1", "rustls-tls", "futures-rustls"]
 tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
 tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
+tokio1-boring-tls = ["tokio1", "boring-tls", "tokio1_boring"]
 
 dkim = ["base64", "sha2", "rsa", "ed25519-dalek", "regex", "once_cell"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -132,6 +132,10 @@
 
 #[cfg(not(lettre_ignore_tls_mismatch))]
 mod compiletime_checks {
+    #[cfg(all(feature = "native-tls", feature = "boring-tls"))]
+    compile_error!("feature \"native-tls\" and feature \"boring-tls\" cannot be enabled at the same time, otherwise
+    the executable will fail to link.");
+
     #[cfg(all(
         feature = "tokio1",
         feature = "native-tls",
@@ -148,6 +152,15 @@ mod compiletime_checks {
     ))]
     compile_error!("Lettre is being built with the `tokio1` and the `rustls-tls` features, but the `tokio1-rustls-tls` feature hasn't been turned on.
     If you'd like to use `native-tls` make sure that the `rustls-tls` feature hasn't been enabled by mistake.
+    Make sure to apply the same to any of your crate dependencies that use the `lettre` crate.");
+
+    #[cfg(all(
+        feature = "tokio1",
+        feature = "boring-tls",
+        not(feature = "tokio1-boring-tls")
+    ))]
+    compile_error!("Lettre is being built with the `tokio1` and the `boring-tls` features, but the `tokio1-boring-tls` feature hasn't been turned on.
+    If you'd like to use `boring-tls` make sure that the `rustls-tls` feature hasn't been enabled by mistake.
     Make sure to apply the same to any of your crate dependencies that use the `lettre` crate.");
 
     /*

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -320,7 +320,7 @@ impl AsyncSmtpConnection {
     }
 
     /// The X509 certificate of the server (DER encoded)
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
     pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
         self.stream.get_ref().peer_certificate()
     }

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -143,7 +143,7 @@ impl SmtpConnection {
         hello_name: &ClientId,
     ) -> Result<(), Error> {
         if self.server_info.supports_feature(Extension::StartTls) {
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
             {
                 try_smtp!(self.command(Starttls), self);
                 self.stream.get_mut().upgrade_tls(tls_parameters)?;
@@ -153,7 +153,11 @@ impl SmtpConnection {
                 try_smtp!(self.ehlo(hello_name), self);
                 Ok(())
             }
-            #[cfg(not(any(feature = "native-tls", feature = "rustls-tls")))]
+            #[cfg(not(any(
+                feature = "native-tls",
+                feature = "rustls-tls",
+                feature = "boring-tls"
+            )))]
             // This should never happen as `Tls` can only be created
             // when a TLS library is enabled
             unreachable!("TLS support required but not supported");
@@ -297,7 +301,7 @@ impl SmtpConnection {
     }
 
     /// The X509 certificate of the server (DER encoded)
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
     pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
         self.stream.get_ref().peer_certificate()
     }

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -30,7 +30,7 @@ pub use self::async_connection::AsyncSmtpConnection;
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
 pub use self::async_net::AsyncNetworkStream;
 use self::net::NetworkStream;
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
 pub(super) use self::tls::InnerTlsParameters;
 pub use self::{
     connection::SmtpConnection,

--- a/src/transport/smtp/error.rs
+++ b/src/transport/smtp/error.rs
@@ -68,8 +68,11 @@ impl Error {
     }
 
     /// Returns true if the error is from TLS
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
     pub fn is_tls(&self) -> bool {
         matches!(self.inner.kind, Kind::Tls)
     }
@@ -102,8 +105,11 @@ pub(crate) enum Kind {
     /// Underlying network i/o error
     Network,
     /// TLS error
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
     Tls,
 }
 
@@ -128,7 +134,7 @@ impl fmt::Display for Error {
             Kind::Client => f.write_str("internal client error")?,
             Kind::Network => f.write_str("network error")?,
             Kind::Connection => f.write_str("Connection error")?,
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
             Kind::Tls => f.write_str("tls error")?,
             Kind::Transient(ref code) => {
                 write!(f, "transient error ({})", code)?;
@@ -179,7 +185,7 @@ pub(crate) fn connection<E: Into<BoxError>>(e: E) -> Error {
     Error::new(Kind::Connection, Some(e))
 }
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
 pub(crate) fn tls<E: Into<BoxError>>(e: E) -> Error {
     Error::new(Kind::Tls, Some(e))
 }

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -140,7 +140,7 @@ pub use self::{
     error::Error,
     transport::{SmtpTransport, SmtpTransportBuilder},
 };
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
 use crate::transport::smtp::client::TlsParameters;
 use crate::transport::smtp::{
     authentication::{Credentials, Mechanism, DEFAULT_MECHANISMS},

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -7,7 +7,7 @@ use super::pool::sync_impl::Pool;
 #[cfg(feature = "pool")]
 use super::PoolConfig;
 use super::{ClientId, Credentials, Error, Mechanism, Response, SmtpConnection, SmtpInfo};
-#[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
 use super::{Tls, TlsParameters, SUBMISSIONS_PORT, SUBMISSION_PORT};
 use crate::{address::Envelope, Transport};
 
@@ -45,8 +45,11 @@ impl SmtpTransport {
     ///
     /// Creates an encrypted transport over submissions port, using the provided domain
     /// to validate TLS certificates.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
     pub fn relay(relay: &str) -> Result<SmtpTransportBuilder, Error> {
         let tls_parameters = TlsParameters::new(relay.into())?;
 
@@ -66,8 +69,11 @@ impl SmtpTransport {
     ///
     /// An error is returned if the connection can't be upgraded. No credentials
     /// or emails will be sent to the server, protecting from downgrade attacks.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
     pub fn starttls_relay(relay: &str) -> Result<SmtpTransportBuilder, Error> {
         let tls_parameters = TlsParameters::new(relay.into())?;
 
@@ -166,8 +172,11 @@ impl SmtpTransportBuilder {
     }
 
     /// Set the TLS settings to use
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls"))))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
     pub fn tls(mut self, tls: Tls) -> Self {
         self.info.tls = tls;
         self
@@ -210,7 +219,7 @@ impl SmtpClient {
     pub fn connection(&self) -> Result<SmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match self.info.tls {
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
             Tls::Wrapper(ref tls_parameters) => Some(tls_parameters),
             _ => None,
         };
@@ -224,7 +233,7 @@ impl SmtpClient {
             None,
         )?;
 
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls"))]
+        #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
         match self.info.tls {
             Tls::Opportunistic(ref tls_parameters) => {
                 if conn.can_starttls() {


### PR DESCRIPTION
In contexts where FIPS certification is mandatory, having the
ability to use the certified boring TLS library is sometimes necessary.
Added initial support for it, only one TLS toolkit can be enabled at
one time.