### PR TITLE
ensure connection is closed on abort

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -194,6 +194,7 @@ impl AsyncSmtpConnection {
             self.panic = true;
             let _ = self.command(Quit).await;
         }
+        let _ = self.stream.close().await;
     }
 
     /// Sets the underlying stream

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -183,6 +183,7 @@ impl SmtpConnection {
             self.panic = true;
             let _ = self.command(Quit);
         }
+        let _ = self.stream.get_mut().shutdown(std::net::Shutdown::Both);
     }
 
     /// Sets the underlying stream


### PR DESCRIPTION
When aborting a connection, ensure the underlying stream is closed
before we return.