### PR TITLE
use a generic transport trait for async connections

### DIFF
--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -29,6 +29,8 @@ use std::fmt::Debug;
 pub use self::async_connection::AsyncSmtpConnection;
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
 pub use self::async_net::AsyncNetworkStream;
+#[cfg(feature = "tokio1")]
+pub use self::async_net::AsyncTokioStream;
 use self::net::NetworkStream;
 #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
 pub(super) use self::tls::InnerTlsParameters;


### PR DESCRIPTION
Rely on a generic transport trait and allow passing in one. These are my specific use-cases, although I don't know how generic they are:

- need to bind a specific source-address because the node has multiple address on the interface, so will establish the connection before calling lettre.
- need to use a proxy tunnel to exit through another datacenter. This proxy is expressed in code as an object that implements the usual AsyncIO traits, but it's not a real tcp stream.

I understand if this is not considered the target use case.