### PR TITLE
RFC 2047 fixup

### DIFF
--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -373,9 +373,9 @@ impl<'a> HeaderValueEncoder<'a> {
                 // This word contains unallowed characters
                 // self.encode_buf.push_str(next_word);
                 // It is important that we don't encode leading whitespace otherwise it breaks wrapping.
-                if next_word.chars().next() == Some(' ') {
+                if next_word.starts_with(' ') {
                     self.writer.folding().write_str(" ")?;
-                    email_encoding::headers::rfc2047::encode(&next_word.chars().skip(1).collect::<String>(), &mut self.writer)?;
+                    email_encoding::headers::rfc2047::encode(&next_word[1..], &mut self.writer)?;
                 } else {
                     email_encoding::headers::rfc2047::encode(next_word, &mut self.writer)?;
                 }

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -353,12 +353,7 @@ impl<'a> HeaderValueEncoder<'a> {
         let line_len = name.len() + ": ".len();
         let writer = EmailWriter::new(writer, line_len, false);
 
-        (
-            WordsPlusFillIterator { s: value },
-            Self {
-                writer,
-            },
-        )
+        (WordsPlusFillIterator { s: value }, Self { writer })
     }
 
     fn format(mut self, words_iter: WordsPlusFillIterator<'_>) -> fmt::Result {

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -368,9 +368,9 @@ impl<'a> HeaderValueEncoder<'a> {
                 // This word contains unallowed characters
                 // self.encode_buf.push_str(next_word);
                 // It is important that we don't encode leading whitespace otherwise it breaks wrapping.
-                if next_word.starts_with(' ') {
+                if let Some(suffix) = next_word.strip_prefix(" ") {
                     self.writer.folding().write_str(" ")?;
-                    email_encoding::headers::rfc2047::encode(&next_word[1..], &mut self.writer)?;
+                    email_encoding::headers::rfc2047::encode(suffix, &mut self.writer)?;
                 } else {
                     email_encoding::headers::rfc2047::encode(next_word, &mut self.writer)?;
                 }

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -368,7 +368,7 @@ impl<'a> HeaderValueEncoder<'a> {
                 // This word contains unallowed characters
                 // self.encode_buf.push_str(next_word);
                 // It is important that we don't encode leading whitespace otherwise it breaks wrapping.
-                if let Some(suffix) = next_word.strip_prefix(" ") {
+                if let Some(suffix) = next_word.strip_prefix(' ') {
                     self.writer.folding().write_str(" ")?;
                     email_encoding::headers::rfc2047::encode(suffix, &mut self.writer)?;
                 } else {

--- a/src/message/header/textual.rs
+++ b/src/message/header/textual.rs
@@ -105,7 +105,18 @@ mod test {
 
         assert_eq!(
             headers.to_string(),
-            "Subject: =?utf-8?b?0KLQtdC80LAg0YHQvtC+0LHRidC10L3QuNGP?=\r\n"
+            "Subject: =?utf-8?b?0KLQtdC80LA=?= =?utf-8?b?0YHQvtC+0LHRidC10L3QuNGP?=\r\n"
+        );
+    }
+
+    #[test]
+    fn format_utf8_word() {
+        let mut headers = Headers::new();
+        headers.set(Subject("Administratör".into()));
+
+        assert_eq!(
+            headers.to_string(),
+            "Subject: =?utf-8?b?QWRtaW5pc3RyYXTDtnI=?=\r\n"
         );
     }
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -673,7 +673,8 @@ mod test {
                 "Date: Tue, 15 Nov 1994 08:12:31 +0000\r\n",
                 "From: =?utf-8?b?0JrQsNC4?= <kayo@example.com>\r\n",
                 "To: \"Pony O.P.\" <pony@domain.tld>\r\n",
-                "Subject: =?utf-8?b?0Y/So9CwINC10Lsg0LHQtdC705nQvQ==?=!\r\n",
+                "Subject: =?utf-8?b?0Y/So9Cw?= =?utf-8?b?0LXQuw==?= =?utf-8?b?0LHQtdC7?=\r\n",
+                " =?utf-8?b?05nQvSE=?=\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Happy new year!"
@@ -711,7 +712,8 @@ mod test {
                 "Bcc: hidden@example.com\r\n",
                 "From: =?utf-8?b?0JrQsNC4?= <kayo@example.com>\r\n",
                 "To: \"Pony O.P.\" <pony@domain.tld>\r\n",
-                "Subject: =?utf-8?b?0Y/So9CwINC10Lsg0LHQtdC705nQvQ==?=!\r\n",
+                "Subject: =?utf-8?b?0Y/So9Cw?= =?utf-8?b?0LXQuw==?= =?utf-8?b?0LHQtdC7?=\r\n",
+                " =?utf-8?b?05nQvSE=?=\r\n",
                 "Content-Transfer-Encoding: 7bit\r\n",
                 "\r\n",
                 "Happy new year!"


### PR DESCRIPTION
RFC2047 chapter 5 talks about encoding words, but the existing encoding both coalesced words as well as tried to just encode substrings of words, causing at least two mail user agents (Thunderbird and Apple Mail) to misrepresent subjects.  Instead take care to only encode single words.

Esp. point (1) says:

Ordinary ASCII text and 'encoded-word's may appear together in the
    same header field.  However, an 'encoded-word' that appears in a
    header field defined as '*text' MUST be separated from any adjacent
    'encoded-word' or 'text' by 'linear-white-space'.

This was not what the former code was doing, e.g. the word "Administratör" would separate into three: "administrat" "ö" and "r". and even if the encoded representation was without space in between, at least two well known MUAs (Thunderbird and Applemail") would insert whitespace in between.