### PR TITLE
fix(transport): return whole smtp error string

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -317,7 +317,7 @@ impl AsyncSmtpConnection {
                     } else {
                         Err(error::code(
                             response.code(),
-                            response.first_line().map(|s| s.to_owned()),
+                            Some(response.message().collect()),
                         ))
                     }
                 }

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -285,7 +285,7 @@ impl SmtpConnection {
                     } else {
                         Err(error::code(
                             response.code(),
-                            response.first_line().map(|s| s.to_owned()),
+                            Some(response.message().collect()),
                         ))
                     };
                 }


### PR DESCRIPTION
We were only returning the first line of the error message, but that may not be enough to get the whole context of the error. Since we have already parsed the response, just return the whole error to the user.

Related to #694