### PR TITLE
feat: add lmtp support to smtp transport

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -137,6 +137,10 @@ name = "smtp"
 required-features = ["smtp-transport", "builder"]
 
 [[example]]
+name = "lmtp"
+required-features = ["smtp-transport", "builder"]
+
+[[example]]
 name = "smtp_tls"
 required-features = ["smtp-transport", "native-tls", "builder"]
 

--- a/benches/transport_smtp.rs
+++ b/benches/transport_smtp.rs
@@ -2,7 +2,7 @@ use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use lettre::{Message, SmtpTransport, Transport};
 
 fn bench_simple_send(c: &mut Criterion) {
-    let sender = SmtpTransport::builder_dangerous("127.0.0.1")
+    let sender = <SmtpTransport<false>>::builder_dangerous("127.0.0.1")
         .port(2525)
         .build();
 
@@ -22,7 +22,7 @@ fn bench_simple_send(c: &mut Criterion) {
 }
 
 fn bench_reuse_send(c: &mut Criterion) {
-    let sender = SmtpTransport::builder_dangerous("127.0.0.1")
+    let sender = <SmtpTransport<false>>::builder_dangerous("127.0.0.1")
         .port(2525)
         .build();
     c.bench_function("send email with connection reuse", move |b| {

--- a/examples/autoconfigure.rs
+++ b/examples/autoconfigure.rs
@@ -20,7 +20,7 @@ fn main() {
             smtp_host
         );
 
-        let transport = SmtpTransport::relay(&smtp_host)
+        let transport = <SmtpTransport<false>>::relay(&smtp_host)
             .expect("build SmtpTransport::relay")
             .timeout(Some(Duration::from_secs(10)))
             .build();
@@ -43,7 +43,7 @@ fn main() {
     {
         tracing::info!("Trying to establish a plaintext connection to {} and then updating it via the SMTP STARTTLS extension", smtp_host);
 
-        let transport = SmtpTransport::starttls_relay(&smtp_host)
+        let transport = <SmtpTransport<false>>::starttls_relay(&smtp_host)
             .expect("build SmtpTransport::starttls_relay")
             .timeout(Some(Duration::from_secs(10)))
             .build();
@@ -72,7 +72,7 @@ fn main() {
             smtp_host
         );
 
-        let transport = SmtpTransport::builder_dangerous(&smtp_host)
+        let transport = <SmtpTransport<false>>::builder_dangerous(&smtp_host)
             .timeout(Some(Duration::from_secs(10)))
             .build();
         match transport.test_connection() {

--- a/examples/lmtp.rs
+++ b/examples/lmtp.rs
@@ -7,16 +7,20 @@ fn main() {
         .from("NoBody <nobody@domain.tld>".parse().unwrap())
         .reply_to("Yuin <yuin@domain.tld>".parse().unwrap())
         .to("Hei <hei@domain.tld>".parse().unwrap())
+        .to("Idk <idk@domain.tld>".parse().unwrap())
         .subject("Happy new year")
         .body(String::from("Be happy!"))
         .unwrap();
 
-    // Open a local connection on port 25
-    let mailer = <SmtpTransport<false>>::unencrypted_localhost();
+    // Open a local connection on port 11200
+    let mailer = <SmtpTransport<true>>::builder_dangerous("localhost").build();
 
     // Send the email
     match mailer.send(&email) {
-        Ok(_) => println!("Email sent successfully!"),
+        Ok(responses) => {
+            let responses: Vec<_> = responses;
+            println!("Email sent successfully: {responses:?}")
+        }
         Err(e) => panic!("Could not send email: {:?}", e),
     }
 }

--- a/examples/smtp_selfsigned.rs
+++ b/examples/smtp_selfsigned.rs
@@ -30,7 +30,7 @@ fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to the smtp server
-    let mailer = SmtpTransport::builder_dangerous("smtp.server.com")
+    let mailer = <SmtpTransport<false>>::builder_dangerous("smtp.server.com")
         .port(465)
         .tls(Tls::Wrapper(tls))
         .credentials(creds)

--- a/examples/smtp_starttls.rs
+++ b/examples/smtp_starttls.rs
@@ -14,7 +14,7 @@ fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail using STARTTLS
-    let mailer = SmtpTransport::starttls_relay("smtp.gmail.com")
+    let mailer = <SmtpTransport<false>>::starttls_relay("smtp.gmail.com")
         .unwrap()
         .credentials(creds)
         .build();

--- a/examples/smtp_tls.rs
+++ b/examples/smtp_tls.rs
@@ -14,7 +14,7 @@ fn main() {
     let creds = Credentials::new("smtp_username".to_string(), "smtp_password".to_string());
 
     // Open a remote connection to gmail
-    let mailer = SmtpTransport::relay("smtp.gmail.com")
+    let mailer = <SmtpTransport<false>>::relay("smtp.gmail.com")
         .unwrap()
         .credentials(creds)
         .build();

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -62,13 +62,13 @@ pub trait Executor: Debug + Send + Sync + 'static + private::Sealed {
 
     #[doc(hidden)]
     #[cfg(feature = "smtp-transport")]
-    async fn connect(
+    async fn connect<const LMTP: bool>(
         hostname: &str,
         port: u16,
         timeout: Option<Duration>,
         hello_name: &ClientId,
         tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error>;
+    ) -> Result<AsyncSmtpConnection<LMTP>, Error>;
 
     #[doc(hidden)]
     #[cfg(feature = "file-transport-envelope")]
@@ -124,13 +124,13 @@ impl Executor for Tokio1Executor {
     }
 
     #[cfg(feature = "smtp-transport")]
-    async fn connect(
+    async fn connect<const LMTP: bool>(
         hostname: &str,
         port: u16,
         timeout: Option<Duration>,
         hello_name: &ClientId,
         tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error> {
+    ) -> Result<AsyncSmtpConnection<LMTP>, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match tls {
             #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
@@ -221,13 +221,13 @@ impl Executor for AsyncStd1Executor {
     }
 
     #[cfg(feature = "smtp-transport")]
-    async fn connect(
+    async fn connect<const LMTP: bool>(
         hostname: &str,
         port: u16,
         timeout: Option<Duration>,
         hello_name: &ClientId,
         tls: &Tls,
-    ) -> Result<AsyncSmtpConnection, Error> {
+    ) -> Result<AsyncSmtpConnection<LMTP>, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match tls {
             #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -25,7 +25,7 @@ use crate::{Envelope, Executor};
 
 /// Asynchronously sends emails using the SMTP protocol
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio1", feature = "async-std1"))))]
-pub struct AsyncSmtpTransport<E: Executor, const LMTP: bool> {
+pub struct AsyncSmtpTransport<E: Executor, const LMTP: bool = false> {
     #[cfg(feature = "pool")]
     inner: Arc<Pool<E, LMTP>>,
     #[cfg(not(feature = "pool"))]

--- a/src/transport/smtp/commands.rs
+++ b/src/transport/smtp/commands.rs
@@ -326,7 +326,7 @@ mod test {
             keyword: "TEST".to_string(),
             value: Some("value".to_string()),
         };
-        assert_eq!(format!("{}", Ehlo::new(id)), "EHLO localhost\r\n");
+        assert_eq!(format!("{}", Ehlo::new(id.clone())), "EHLO localhost\r\n");
         assert_eq!(format!("{}", Lhlo::new(id)), "LHLO localhost\r\n");
         assert_eq!(
             format!("{}", Mail::new(Some(email.clone()), vec![])),

--- a/src/transport/smtp/commands.rs
+++ b/src/transport/smtp/commands.rs
@@ -32,6 +32,26 @@ impl Ehlo {
     }
 }
 
+/// LHLO command
+#[derive(PartialEq, Eq, Clone, Debug)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct Lhlo {
+    client_id: ClientId,
+}
+
+impl Display for Lhlo {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "LHLO {}\r\n", self.client_id)
+    }
+}
+
+impl Lhlo {
+    /// Creates a LHLO command
+    pub fn new(client_id: ClientId) -> Lhlo {
+        Lhlo { client_id }
+    }
+}
+
 /// STARTTLS command
 #[derive(PartialEq, Eq, Clone, Debug, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -307,6 +327,7 @@ mod test {
             value: Some("value".to_string()),
         };
         assert_eq!(format!("{}", Ehlo::new(id)), "EHLO localhost\r\n");
+        assert_eq!(format!("{}", Lhlo::new(id)), "LHLO localhost\r\n");
         assert_eq!(
             format!("{}", Mail::new(Some(email.clone()), vec![])),
             "MAIL FROM:<test@example.com>\r\n"

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -168,6 +168,8 @@ pub(super) mod util;
 
 /// Default smtp port
 pub const SMTP_PORT: u16 = 25;
+/// Default lmtp port
+pub const LMTP_PORT: u16 = 11200;
 /// Default submission port
 pub const SUBMISSION_PORT: u16 = 587;
 /// Default submission over TLS port
@@ -179,7 +181,7 @@ pub const SUBMISSIONS_PORT: u16 = 465;
 const DEFAULT_TIMEOUT: Duration = Duration::from_secs(60);
 
 #[derive(Debug, Clone)]
-struct SmtpInfo {
+struct SmtpInfo<const LMTP: bool> {
     /// Name sent during EHLO
     hello_name: ClientId,
     /// Server we are connecting to
@@ -197,11 +199,11 @@ struct SmtpInfo {
     timeout: Option<Duration>,
 }
 
-impl Default for SmtpInfo {
+impl<const LMTP: bool> Default for SmtpInfo<LMTP> {
     fn default() -> Self {
         Self {
             server: "localhost".to_string(),
-            port: SMTP_PORT,
+            port: if LMTP { LMTP_PORT } else { SMTP_PORT },
             hello_name: ClientId::default(),
             credentials: None,
             authentication: DEFAULT_MECHANISMS.into(),

--- a/src/transport/smtp/pool/sync_impl.rs
+++ b/src/transport/smtp/pool/sync_impl.rs
@@ -13,24 +13,24 @@ use super::{
 };
 use crate::transport::smtp::transport::SmtpClient;
 
-pub struct Pool {
+pub struct Pool<const LMTP: bool> {
     config: PoolConfig,
-    connections: Mutex<Vec<ParkedConnection>>,
-    client: SmtpClient,
+    connections: Mutex<Vec<ParkedConnection<LMTP>>>,
+    client: SmtpClient<LMTP>,
 }
 
-struct ParkedConnection {
-    conn: SmtpConnection,
+struct ParkedConnection<const LMTP: bool> {
+    conn: SmtpConnection<LMTP>,
     since: Instant,
 }
 
-pub struct PooledConnection {
-    conn: Option<SmtpConnection>,
+pub struct PooledConnection<const LMTP: bool> {
+    conn: Option<SmtpConnection<LMTP>>,
     pool: Arc<Pool>,
 }
 
-impl Pool {
-    pub fn new(config: PoolConfig, client: SmtpClient) -> Arc<Self> {
+impl<const LMTP: bool> Pool<LMTP> {
+    pub fn new(config: PoolConfig, client: SmtpClient<LMTP>) -> Arc<Self> {
         let pool = Arc::new(Self {
             config,
             connections: Mutex::new(Vec::new()),
@@ -118,7 +118,7 @@ impl Pool {
         pool
     }
 
-    pub fn connection(self: &Arc<Self>) -> Result<PooledConnection, Error> {
+    pub fn connection(self: &Arc<Self>) -> Result<PooledConnection<LMTP>, Error> {
         loop {
             let conn = {
                 let mut connections = self.connections.lock().unwrap();

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -67,7 +67,7 @@ impl<const LMTP: bool> SmtpTransport<LMTP> {
         docsrs,
         doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
     )]
-    pub fn relay(relay: &str) -> Result<SmtpTransportBuilder, Error> {
+    pub fn relay(relay: &str) -> Result<SmtpTransportBuilder<LMTP>, Error> {
         let tls_parameters = TlsParameters::new(relay.into())?;
 
         Ok(Self::builder_dangerous(relay)
@@ -91,7 +91,7 @@ impl<const LMTP: bool> SmtpTransport<LMTP> {
         docsrs,
         doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
     )]
-    pub fn starttls_relay(relay: &str) -> Result<SmtpTransportBuilder, Error> {
+    pub fn starttls_relay(relay: &str) -> Result<SmtpTransportBuilder<LMTP>, Error> {
         let tls_parameters = TlsParameters::new(relay.into())?;
 
         Ok(Self::builder_dangerous(relay)

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -13,7 +13,7 @@ mod sync {
             .body(String::from("Be happy!"))
             .unwrap();
 
-        let sender = SmtpTransport::builder_dangerous("127.0.0.1")
+        let sender = <SmtpTransport<false>>::builder_dangerous("127.0.0.1")
             .port(2525)
             .build();
         sender.send(&email).unwrap();

--- a/tests/transport_smtp_pool.rs
+++ b/tests/transport_smtp_pool.rs
@@ -14,7 +14,7 @@ mod sync {
 
     #[test]
     fn send_one() {
-        let mailer = SmtpTransport::builder_dangerous("127.0.0.1")
+        let mailer = <SmtpTransport<false>>::builder_dangerous("127.0.0.1")
             .port(2525)
             .build();
 
@@ -24,7 +24,7 @@ mod sync {
 
     #[test]
     fn send_from_thread() {
-        let mailer = SmtpTransport::builder_dangerous("127.0.0.1")
+        let mailer = <SmtpTransport<false>>::builder_dangerous("127.0.0.1")
             .port(2525)
             .build();
 


### PR DESCRIPTION
I'm not sure what this API should look like, but I have tried my best to reuse most of the code.

Maybe it would be better to store LMTP as a config parameter and return multiple responses for plain SMTP too, instead of specializing on LMTP protocol using const generic?

I have tried implementing separate struct for LMTP protocol, wrapping SMTP, however it would be too much boilerplate to delegate every method except `send` to wrapped SMTP connection.

I also have tried to use sealed generic instead of boolean const, but this didn't go well too (But maybe this approach can be implemented, if I'll try harder?)
```rust
trait Protocol;
struct Smtp;
struct Lmtp;
impl Protocol for Smtp {}
impl Protocol for Lmtp {}

impl<P: Protocol> MtpConnection<P> {...}
impl MtpConnection<Smtp> {...}
impl MtpConnection<Lmtp> {...}
```

Fixes: https://github.com/lettre/lettre/issues/820