### PR TITLE
Add Content-Type header in documentation example

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -14,6 +14,7 @@
 //! The easiest way of creating a message, which uses a plain text body.
 //!
 //! ```rust
+//! use lettre::message::header::ContentType;
 //! use lettre::message::Message;
 //!
 //! # use std::error::Error;
@@ -23,6 +24,7 @@
 //!     .reply_to("Yuin <yuin@domain.tld>".parse()?)
 //!     .to("Hei <hei@domain.tld>".parse()?)
 //!     .subject("Happy new year")
+//!     .header(ContentType::TEXT_PLAIN)
 //!     .body(String::from("Be happy!"))?;
 //! # Ok(())
 //! # }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -14,8 +14,7 @@
 //! The easiest way of creating a message, which uses a plain text body.
 //!
 //! ```rust
-//! use lettre::message::header::ContentType;
-//! use lettre::message::Message;
+//! use lettre::message::{header::ContentType, Message};
 //!
 //! # use std::error::Error;
 //! # fn main() -> Result<(), Box<dyn Error>> {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -39,6 +39,7 @@
 //! To: Hei <hei@domain.tld>
 //! Subject: Happy new year
 //! Date: Sat, 12 Dec 2020 16:33:19 GMT
+//! Content-Type: text/plain; charset=utf-8
 //! Content-Transfer-Encoding: 7bit
 //!
 //! Be happy!


### PR DESCRIPTION
Recently, I had issues with non-ascii characters that were not displayed correctly in my mail viewer.

It turned out, setting the Content-Type header helps, because it includes the character encoding.
This additional call in the message builder
```rust
.header(ContentType::TEXT_PLAIN)
```
creates the following mail header
```
Content-Type: text/plain; charset=utf-8
```
so that non-ascii characters are displayed correctly.

I would like to add this header line to the documentation example. It might help other people not to run in the same issue.