### PR TITLE
tracing: Write some logs when sending an email

### DIFF
--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -276,6 +276,8 @@ impl Transport for FileTransport {
         let email_id = Uuid::new_v4();
 
         let file = self.path(&email_id, "eml");
+        #[cfg(feature = "tracing")]
+        tracing::debug!(?file, "writing email to");
         fs::write(file, email).map_err(error::io)?;
 
         #[cfg(feature = "file-transport-envelope")]
@@ -306,6 +308,8 @@ where
         let email_id = Uuid::new_v4();
 
         let file = self.inner.path(&email_id, "eml");
+        #[cfg(feature = "tracing")]
+        tracing::debug!(?file, "writing email to");
         E::fs_write(&file, email).await.map_err(error::io)?;
 
         #[cfg(feature = "file-transport-envelope")]

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -127,6 +127,9 @@ pub trait Transport {
     #[cfg(feature = "builder")]
     #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
     fn send(&self, message: &Message) -> Result<Self::Ok, Self::Error> {
+        #[cfg(feature = "tracing")]
+        tracing::trace!("starting to send an email");
+
         let raw = message.formatted();
         self.send_raw(message.envelope(), &raw)
     }
@@ -149,6 +152,9 @@ pub trait AsyncTransport {
     #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
     // TODO take &Message
     async fn send(&self, message: Message) -> Result<Self::Ok, Self::Error> {
+        #[cfg(feature = "tracing")]
+        tracing::trace!("starting to send an email");
+
         let raw = message.formatted();
         let envelope = message.envelope();
         self.send_raw(envelope, &raw).await

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -232,6 +232,9 @@ impl Transport for SendmailTransport {
     type Error = Error;
 
     fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
+        #[cfg(feature = "tracing")]
+        tracing::debug!(command = ?self.command, "sending email with");
+
         // Spawn the sendmail command
         let mut process = self.command(envelope).spawn().map_err(error::client)?;
 
@@ -260,6 +263,9 @@ impl AsyncTransport for AsyncSendmailTransport<AsyncStd1Executor> {
 
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
         use async_std::io::prelude::WriteExt;
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(command = ?self.inner.command, "sending email with");
 
         let mut command = self.async_std_command(envelope);
 
@@ -292,6 +298,9 @@ impl AsyncTransport for AsyncSendmailTransport<Tokio1Executor> {
 
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error> {
         use tokio1_crate::io::AsyncWriteExt;
+
+        #[cfg(feature = "tracing")]
+        tracing::debug!(command = ?self.inner.command, "sending email with");
 
         let mut command = self.tokio1_command(envelope);
 


### PR DESCRIPTION
Write a trace message when sending an email. Further, write a debug message when using the sendmail transport method, containing which program is called. And write a debug message containing the target file name when the file transport method is used.

This should help improve #556 a tiny bit.