### PR TITLE
Hide internal optional dependencies using cargo's 1.60 `dep:` syntax

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -122,10 +122,10 @@ jobs:
         run: cargo test
 
       - name: Test with all features (-native-tls)
-        run: cargo test --no-default-features --features async-std,async-std1,async-std1-rustls-tls,async-trait,base64,boring,boring-tls,builder,dkim,ed25519-dalek,email-encoding,fastrand,file-transport,file-transport-envelope,futures-io,futures-rustls,futures-util,hostname,httpdate,mime,mime03,nom,once_cell,pool,quoted_printable,rsa,rustls,rustls-native-certs,rustls-pemfile,rustls-tls,sendmail-transport,serde,serde_json,sha2,smtp-transport,socket2,tokio1,tokio1-boring-tls,tokio1-rustls-tls,tokio1_boring,tokio1_crate,tokio1_rustls,tracing,uuid,webpki-roots
+        run: cargo test --no-default-features --features async-std1,async-std1-rustls-tls,boring-tls,builder,dkim,file-transport,file-transport-envelope,hostname,mime03,pool,rustls-native-certs,rustls-tls,sendmail-transport,smtp-transport,tokio1,tokio1-boring-tls,tokio1-rustls-tls,tracing
   
       - name: Test with all features (-boring-tls)
-        run: cargo test --no-default-features --features async-std,async-std1,async-std1-rustls-tls,async-trait,base64,builder,dkim,ed25519-dalek,email-encoding,fastrand,file-transport,file-transport-envelope,futures-io,futures-rustls,futures-util,hostname,httpdate,mime,mime03,native-tls,nom,once_cell,pool,quoted_printable,rsa,rustls,rustls-native-certs,rustls-pemfile,rustls-tls,sendmail-transport,serde,serde_json,sha2,smtp-transport,socket2,tokio1,tokio1-native-tls,tokio1-rustls-tls,tokio1_crate,tokio1_native_tls_crate,tokio1_rustls,tracing,uuid,webpki-roots
+        run: cargo test --no-default-features --features async-std1,async-std1-rustls-tls,builder,dkim,file-transport,file-transport-envelope,hostname,mime03,native-tls,pool,rustls-native-certs,rustls-tls,sendmail-transport,smtp-transport,tokio1,tokio1-native-tls,tokio1-rustls-tls,tracing
 
 #  coverage:
 #    name: Coverage

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,31 +91,31 @@ name = "transport_smtp"
 
 [features]
 default = ["smtp-transport", "pool", "native-tls", "hostname", "builder"]
-builder = ["httpdate", "mime", "fastrand", "quoted_printable", "email-encoding"]
-mime03 = ["mime"]
+builder = ["dep:httpdate", "dep:mime", "dep:fastrand", "dep:quoted_printable", "dep:email-encoding"]
+mime03 = ["dep:mime"]
 
 # transports
-file-transport = ["uuid", "tokio1_crate?/fs", "tokio1_crate?/io-util"]
-file-transport-envelope = ["serde", "serde_json", "file-transport"]
+file-transport = ["dep:uuid", "tokio1_crate?/fs", "tokio1_crate?/io-util"]
+file-transport-envelope = ["serde", "dep:serde_json", "file-transport"]
 sendmail-transport = ["tokio1_crate?/process", "tokio1_crate?/io-util", "async-std?/unstable"]
-smtp-transport = ["base64", "nom", "socket2", "once_cell", "tokio1_crate?/rt", "tokio1_crate?/time", "tokio1_crate?/net"]
+smtp-transport = ["dep:base64", "dep:nom", "dep:socket2", "dep:once_cell", "tokio1_crate?/rt", "tokio1_crate?/time", "tokio1_crate?/net"]
 
-pool = ["futures-util"]
+pool = ["dep:futures-util"]
 
-rustls-tls = ["webpki-roots", "rustls", "rustls-pemfile"]
+rustls-tls = ["dep:webpki-roots", "dep:rustls", "dep:rustls-pemfile"]
 
-boring-tls = ["boring"]
+boring-tls = ["dep:boring"]
 
 # async
-async-std1 = ["async-std", "async-trait", "futures-io", "futures-util"]
-#async-std1-native-tls = ["async-std1", "native-tls", "async-native-tls"]
-async-std1-rustls-tls = ["async-std1", "rustls-tls", "futures-rustls"]
-tokio1 = ["tokio1_crate", "async-trait", "futures-io", "futures-util"]
-tokio1-native-tls = ["tokio1", "native-tls", "tokio1_native_tls_crate"]
-tokio1-rustls-tls = ["tokio1", "rustls-tls", "tokio1_rustls"]
-tokio1-boring-tls = ["tokio1", "boring-tls", "tokio1_boring"]
+async-std1 = ["dep:async-std", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
+#async-std1-native-tls = ["dep:async-std1", "dep:native-tls", "dep:async-native-tls"]
+async-std1-rustls-tls = ["async-std1", "rustls-tls", "dep:futures-rustls"]
+tokio1 = ["dep:tokio1_crate", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
+tokio1-native-tls = ["tokio1", "native-tls", "dep:tokio1_native_tls_crate"]
+tokio1-rustls-tls = ["tokio1", "rustls-tls", "dep:tokio1_rustls"]
+tokio1-boring-tls = ["tokio1", "boring-tls", "dep:tokio1_boring"]
 
-dkim = ["base64", "sha2", "rsa", "ed25519-dalek"]
+dkim = ["dep:base64", "dep:sha2", "dep:rsa", "dep:ed25519-dalek"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,7 +108,7 @@ boring-tls = ["dep:boring"]
 
 # async
 async-std1 = ["dep:async-std", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
-#async-std1-native-tls = ["dep:async-std1", "dep:native-tls", "dep:async-native-tls"]
+#async-std1-native-tls = ["async-std1", "native-tls", "dep:async-native-tls"]
 async-std1-rustls-tls = ["async-std1", "rustls-tls", "dep:futures-rustls"]
 tokio1 = ["dep:tokio1_crate", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "dep:tokio1_native_tls_crate"]

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -87,11 +87,11 @@ impl Debug for Tls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Self::None => f.pad("None"),
-            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
             Self::Opportunistic(_) => f.pad("Opportunistic"),
-            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
             Self::Required(_) => f.pad("Required"),
-            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
             Self::Wrapper(_) => f.pad("Wrapper"),
         }
     }


### PR DESCRIPTION
Depends on #860 (goes in lettre 0.11)