### PR TITLE
Bump MSRV to 1.63

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,8 @@ jobs:
             rust: stable
           - name: beta
             rust: beta
-          - name: 1.60.0
-            rust: 1.60.0
+          - name: 1.63.0
+            rust: 1.63.0
 
     steps:
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Alexis Mousset <contact@amousset.me>", "Paolo Barbolini <paolo@paolo
 categories = ["email", "network-programming"]
 keywords = ["email", "smtp", "mailer", "message", "sendmail"]
 edition = "2021"
-rust-version = "1.60"
+rust-version = "1.63"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "lettre/lettre" }

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Lettre does not provide (for now):
 ## Supported Rust Versions
 
 Lettre supports all Rust versions released in the last 6 months. At the time of writing
-the minimum supported Rust version is 1.60, but this could change at any time either from
+the minimum supported Rust version is 1.63, but this could change at any time either from
 one of our dependencies bumping their MSRV or by a new patch release of lettre.
 
 ## Example
 
-This library requires Rust 1.60 or newer.
+This library requires Rust 1.63 or newer.
 To use this library, add the following to your `Cargo.toml`:
 
 ```toml

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -216,7 +216,7 @@ impl Executor for AsyncStd1Executor {
 
     #[cfg(feature = "smtp-transport")]
     fn sleep(duration: Duration) -> Self::Sleep {
-        let fut = async move { async_std::task::sleep(duration).await };
+        let fut = async_std::task::sleep(duration);
         Box::pin(fut)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! * Secure defaults
 //! * Async support
 //!
-//! Lettre requires Rust 1.60 or newer.
+//! Lettre requires Rust 1.63 or newer.
 //!
 //! ## Features
 //!

--- a/src/message/header/content.rs
+++ b/src/message/header/content.rs
@@ -13,12 +13,14 @@ use crate::BoxError;
 /// use-caches this header shouldn't be set manually.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default)]
 pub enum ContentTransferEncoding {
     /// ASCII
     SevenBit,
     /// Quoted-Printable encoding
     QuotedPrintable,
     /// base64 encoding
+    #[default]
     Base64,
     /// Requires `8BITMIME`
     EightBit,
@@ -64,12 +66,6 @@ impl FromStr for ContentTransferEncoding {
             "binary" => Ok(Self::Binary),
             _ => Err(s.into()),
         }
-    }
-}
-
-impl Default for ContentTransferEncoding {
-    fn default() -> Self {
-        ContentTransferEncoding::Base64
     }
 }
 

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -99,7 +99,7 @@ impl Debug for Tls {
 
 /// Source for the base set of root certificates to trust.
 #[allow(missing_copy_implementations)]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Default)]
 pub enum CertificateStore {
     /// Use the default for the TLS backend.
     ///
@@ -110,6 +110,7 @@ pub enum CertificateStore {
     /// enabled, or will fall back to `webpki-roots`.
     ///
     /// The boring-tls backend uses the same logic as OpenSSL on all platforms.
+    #[default]
     Default,
     /// Use a hardcoded set of Mozilla roots via the `webpki-roots` crate.
     ///
@@ -118,12 +119,6 @@ pub enum CertificateStore {
     WebpkiRoots,
     /// Don't use any system certificates.
     None,
-}
-
-impl Default for CertificateStore {
-    fn default() -> Self {
-        CertificateStore::Default
-    }
 }
 
 /// Parameters to use for secure clients


### PR DESCRIPTION
Needed by #868
I could have skipped to 1.64, but debian 12 seems to be going for Rust 1.63 (not that it really matters since I'm sure we'll get another MSRV bump before it even comes out) and also Yocto langdale is using it.