### PR TITLE
don't attempt to send commands when aborting

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -229,11 +229,7 @@ impl AsyncSmtpConnection {
     }
 
     pub async fn abort(&mut self) {
-        // Only try to quit if we are not already broken
-        if !self.panic {
-            self.panic = true;
-            let _ = self.command(Quit).await;
-        }
+        self.panic = true;
         let _ = self.stream.close().await;
     }
 

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -178,11 +178,7 @@ impl SmtpConnection {
     }
 
     pub fn abort(&mut self) {
-        // Only try to quit if we are not already broken
-        if !self.panic {
-            self.panic = true;
-            let _ = self.command(Quit);
-        }
+        self.panic = true;
         let _ = self.stream.get_mut().shutdown(std::net::Shutdown::Both);
     }
 


### PR DESCRIPTION
Currently abort() still tries to send a QUIT command on the smtp connection before closing it. However, we may be in a state where we can't write to the stream anymore and there is no other method to close the connection.

For example, when upgrading the connection with TLS, we replace the `inner` object with InnerAsyncNetworkStream::None. If the upgrade fails, and if we try to abort the connection afterwards, we hit a debug_assert() when writing.