### PR TITLE
change: Add `From<Address>` implementation for `Mailbox`

### DIFF
--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -125,6 +125,12 @@ impl FromStr for Mailbox {
     }
 }
 
+impl From<Address> for Mailbox {
+    fn from(value: Address) -> Self {
+        Self::new(None, value)
+    }
+}
+
 /// Represents a sequence of [`Mailbox`] instances.
 ///
 /// This type contains a sequence of mailboxes (_Some Name \<user@domain.tld\>, Another Name \<other@domain.tld\>, withoutname@domain.tld, ..._).


### PR DESCRIPTION
This PR simply adds a small implementation for `From<Address>`.

Instead of writing this every time you want to convert an address to a mailbox:
```rust
Mailbox::new(None, address)
``` 
You can now write this:
```rust
address.into()
``` 

