### PR TITLE
Add headers_mut function on Message

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -503,6 +503,11 @@ impl Message {
         &self.headers
     }
 
+    /// Get a mutable reference to the headers
+    pub fn headers_mut(&mut self) -> &mut Headers {
+        &mut self.headers
+    }
+
     /// Get `Message` envelope
     pub fn envelope(&self) -> &Envelope {
         &self.envelope


### PR DESCRIPTION
Hello,

My current usecase involves adding custom headers to messages, however this is not currently possible because there is no way to insert raw headers on the message itself, even though it is possible for `MultiPart`.

Thus I simply added a `headers_mut` function to achieve this.

Relates to #661 and #693.