### PR TITLE
Prepare 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to be able to upgrade by only bumping the version in `Cargo.toml`.
 #### Features
 
 * Improve mailbox parsing ([#839])
+* Add construction of SMTP transport from URL ([#901])
 * Add `From<Address>` implementation for `Mailbox` ([#879])
 
 #### Misc
@@ -32,6 +33,7 @@ to be able to upgrade by only bumping the version in `Cargo.toml`.
 [#890]: https://github.com/lettre/lettre/pull/890
 [#896]: https://github.com/lettre/lettre/pull/896
 [#897]: https://github.com/lettre/lettre/pull/897
+[#901]: https://github.com/lettre/lettre/pull/901
 
 <a name="v0.10.4"></a>
 ### v0.10.4 (2023-04-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,38 @@
+<a name="v0.11.0"></a>
+### v0.11.0 (2023-08-15)
+
+While this release technically contains breaking changes, we expect most projects
+to be able to upgrade by only bumping the version in `Cargo.toml`.
+
+#### Upgrade notes
+
+* MSRV is now 1.65 ([#869] and [#881])
+* `AddressError` is now marked as `#[non_exhaustive]` ([#839])
+
+#### Features
+
+* Improve mailbox parsing ([#839])
+* Add `From<Address>` implementation for `Mailbox` ([#879])
+
+#### Misc
+
+* Bump `socket2` to v0.5 ([#868])
+* Bump `idna` to v0.4, `fastrand` to v2, `quoted_printable` to v0.5, `rsa` to v0.9 ([#882])
+* Bump `webpki-roots` to v0.25 ([#884] and [#890])
+* Bump `ed25519-dalek` to v2 fixing RUSTSEC-2022-0093 ([#896])
+* Bump `boring`ssl crates to v3 ([#897])
+
+[#839]: https://github.com/lettre/lettre/pull/839
+[#868]: https://github.com/lettre/lettre/pull/868
+[#869]: https://github.com/lettre/lettre/pull/869
+[#879]: https://github.com/lettre/lettre/pull/879
+[#881]: https://github.com/lettre/lettre/pull/881
+[#882]: https://github.com/lettre/lettre/pull/882
+[#884]: https://github.com/lettre/lettre/pull/884
+[#890]: https://github.com/lettre/lettre/pull/890
+[#896]: https://github.com/lettre/lettre/pull/896
+[#897]: https://github.com/lettre/lettre/pull/897
+
 <a name="v0.10.4"></a>
 ### v0.10.4 (2023-04-02)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.10.4"
+version = "0.11.0"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.10.4">
-    <img src="https://deps.rs/crate/lettre/0.10.4/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.0">
+    <img src="https://deps.rs/crate/lettre/0.11.0/status.svg"
       alt="dependency status" />
   </a>
 </div>
@@ -63,7 +63,7 @@ To use this library, add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-lettre = "0.10"
+lettre = "0.11"
 ```
 
 ```rust,no_run

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.10.4")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.0")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
I think it's time to release so that we don't hold on to changes users aren't have to obtain without using a git dependency on the repository.

Rendered changelog: https://github.com/lettre/lettre/blob/0.11.0-release/CHANGELOG.md