### PR TITLE
Construct a SmtpTransport from a connection URL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ serde_json = { version = "1", optional = true }
 nom = { version = "7", optional = true }
 hostname = { version = "0.3", optional = true } # feature
 socket2 = { version = "0.5.1", optional = true }
+url = { version = "2.4", optional = true }
 
 ## tls
 native-tls = { version = "0.2.5", optional = true } # feature
@@ -103,7 +104,7 @@ mime03 = ["dep:mime"]
 file-transport = ["dep:uuid", "tokio1_crate?/fs", "tokio1_crate?/io-util"]
 file-transport-envelope = ["serde", "dep:serde_json", "file-transport"]
 sendmail-transport = ["tokio1_crate?/process", "tokio1_crate?/io-util", "async-std?/unstable"]
-smtp-transport = ["dep:base64", "dep:nom", "dep:socket2", "dep:once_cell", "tokio1_crate?/rt", "tokio1_crate?/time", "tokio1_crate?/net"]
+smtp-transport = ["dep:base64", "dep:nom", "dep:socket2", "dep:once_cell", "dep:url", "tokio1_crate?/rt", "tokio1_crate?/time", "tokio1_crate?/net"]
 
 pool = ["dep:futures-util"]
 

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -164,8 +164,53 @@ where
     /// Creates a `AsyncSmtpTransportBuilder` from a connection URL
     ///
     /// The protocol, credentials, host and port can be provided in a single URL.
-    /// Use the scheme `smtp` for an unencrypted relay, `smtps` for SMTP over TLS
-    /// and `smtp` with the query parameter tls=required or tls=opportunistic for STARTTLS
+    /// Use the scheme `smtp` for an unencrypted relay (optionally in combination with the
+    /// `tls` parameter to allow/require STARTTLS) or `smtps` for SMTP over TLS.
+    /// The path section of the url can be used to set an alternative name for
+    /// the HELO / EHLO command.
+    /// For example `smtps://username:password@smtp.example.com/client.example.com:465`
+    /// will set the HELO / EHLO name `client.example.com`.
+    ///
+    /// <table>
+    ///   <thead>
+    ///     <tr>
+    ///       <th>scheme</th>
+    ///       <th>tls parameter</th>
+    ///       <th>example</th>
+    ///       <th>remarks</th>
+    ///     </tr>
+    ///   </thead>
+    ///   <tbody>
+    ///     <tr>
+    ///      <td>smtps</td>
+    ///      <td>-</td>
+    ///      <td>smtps://smtp.example.com</td>
+    ///      <td>SMTP over TLS, recommended method</td>
+    ///     </tr>
+    ///     <tr>
+    ///      <td>smtp</td>
+    ///      <td>required</td>
+    ///      <td>smtp://smtp.example.com?tls=required</td>
+    ///      <td>SMTP with STARTTLS required, when SMTP over TLS is not available</td>
+    ///     </tr>
+    ///     <tr>
+    ///      <td>smtp</td>
+    ///      <td>opportunistic</td>
+    ///      <td>smtp://smtp.example.com?tls=opportunistic</td>
+    ///      <td>
+    ///         SMTP with optionally STARTTLS when supported by the server.
+    ///         Caution: this method is vulnerable to a man-in-the-middle attack.
+    ///         Not recommended for production use.
+    ///       </td>
+    ///     </tr>
+    ///     <tr>
+    ///      <td>smtp</td>
+    ///      <td>-</td>
+    ///      <td>smtp://smtp.example.com</td>
+    ///      <td>Unencrypted SMTP, not recommended for production use.</td>
+    ///     </tr>
+    ///   </tbody>
+    /// </table>
     ///
     /// ```rust,no_run
     /// use lettre::{

--- a/src/transport/smtp/connection_url.rs
+++ b/src/transport/smtp/connection_url.rs
@@ -1,13 +1,12 @@
 use url::Url;
 
+#[cfg(any(feature = "tokio1", feature = "async-std1"))]
+use super::AsyncSmtpTransportBuilder;
 use super::{
     authentication::Credentials,
     client::{Tls, TlsParameters},
-    error, Error, SmtpTransportBuilder, SMTP_PORT, SUBMISSIONS_PORT,
-    SUBMISSION_PORT,
+    error, Error, SmtpTransportBuilder, SMTP_PORT, SUBMISSIONS_PORT, SUBMISSION_PORT,
 };
-#[cfg(any(feature = "tokio1", feature = "async-std1"))]
-use super::AsyncSmtpTransportBuilder;
 
 pub(crate) trait TransportBuilder {
     fn new<T: Into<String>>(server: T) -> Self;

--- a/src/transport/smtp/connection_url.rs
+++ b/src/transport/smtp/connection_url.rs
@@ -1,0 +1,102 @@
+use url::Url;
+
+use super::{
+    authentication::Credentials,
+    client::{Tls, TlsParameters},
+    error, Error, SmtpTransportBuilder, SMTP_PORT, SUBMISSIONS_PORT,
+    SUBMISSION_PORT,
+};
+#[cfg(any(feature = "tokio1", feature = "async-std1"))]
+use super::AsyncSmtpTransportBuilder;
+
+pub(crate) trait TransportBuilder {
+    fn new<T: Into<String>>(server: T) -> Self;
+    fn tls(self, tls: super::Tls) -> Self;
+    fn port(self, port: u16) -> Self;
+    fn credentials(self, credentials: Credentials) -> Self;
+}
+
+impl TransportBuilder for SmtpTransportBuilder {
+    fn new<T: Into<String>>(server: T) -> Self {
+        Self::new(server)
+    }
+
+    fn tls(self, tls: super::Tls) -> Self {
+        self.tls(tls)
+    }
+
+    fn port(self, port: u16) -> Self {
+        self.port(port)
+    }
+
+    fn credentials(self, credentials: Credentials) -> Self {
+        self.credentials(credentials)
+    }
+}
+
+#[cfg(any(feature = "tokio1", feature = "async-std1"))]
+impl TransportBuilder for AsyncSmtpTransportBuilder {
+    fn new<T: Into<String>>(server: T) -> Self {
+        Self::new(server)
+    }
+
+    fn tls(self, tls: super::Tls) -> Self {
+        self.tls(tls)
+    }
+
+    fn port(self, port: u16) -> Self {
+        self.port(port)
+    }
+
+    fn credentials(self, credentials: Credentials) -> Self {
+        self.credentials(credentials)
+    }
+}
+
+/// Create a new SmtpTransportBuilder or AsyncSmtpTransportBuilder from a connection URL
+pub(crate) fn from_connection_url<B: TransportBuilder>(connection_url: &str) -> Result<B, Error> {
+    let connection_url = Url::parse(connection_url).map_err(error::connection)?;
+    let tls: Option<String> = connection_url
+        .query_pairs()
+        .find(|(k, _)| k == "tls")
+        .map(|(_, v)| v.to_string());
+
+    let host = connection_url
+        .host_str()
+        .ok_or_else(|| error::connection("smtp host undefined"))?;
+
+    let mut builder = B::new(host);
+
+    match (connection_url.scheme(), tls.as_deref()) {
+        ("smtp", None) => {
+            builder = builder.port(connection_url.port().unwrap_or(SMTP_PORT));
+        }
+        ("smtp", Some("required")) => {
+            builder = builder
+                .port(connection_url.port().unwrap_or(SUBMISSION_PORT))
+                .tls(Tls::Required(TlsParameters::new(host.into())?))
+        }
+        ("smtp", Some("opportunistic")) => {
+            builder = builder
+                .port(connection_url.port().unwrap_or(SUBMISSION_PORT))
+                .tls(Tls::Opportunistic(TlsParameters::new(host.into())?))
+        }
+        ("smtps", _) => {
+            builder = builder
+                .port(connection_url.port().unwrap_or(SUBMISSIONS_PORT))
+                .tls(Tls::Wrapper(TlsParameters::new(host.into())?))
+        }
+        (scheme, tls) => {
+            return Err(error::connection(format!(
+                "unknown scheme '{scheme}' or tls parameter '{tls:?}'"
+            )))
+        }
+    };
+
+    if let Some(password) = connection_url.password() {
+        let credentials = Credentials::new(connection_url.username().into(), password.into());
+        builder = builder.credentials(credentials);
+    }
+
+    Ok(builder)
+}

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -154,6 +154,8 @@ mod async_transport;
 pub mod authentication;
 pub mod client;
 pub mod commands;
+#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+mod connection_url;
 mod error;
 pub mod extension;
 #[cfg(feature = "pool")]

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -154,7 +154,6 @@ mod async_transport;
 pub mod authentication;
 pub mod client;
 pub mod commands;
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
 mod connection_url;
 mod error;
 pub mod extension;

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -149,6 +149,11 @@ impl SmtpTransport {
     ///     Err(e) => panic!("Could not send email: {e:?}"),
     /// }
     /// ```
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
     pub fn from_url(connection_string: &str) -> Result<SmtpTransportBuilder, Error> {
         let connection_url = Url::parse(connection_string).map_err(error::connection)?;
 
@@ -164,7 +169,7 @@ impl SmtpTransport {
             }
             "smtp+tls" => {
                 builder = builder
-                    .port(connection_url.port().unwrap_or(SUBMISSION_PORT))
+                    .port(connection_url.port().unwrap_or(SUBMISSIONS_PORT))
                     .tls(Tls::Wrapper(TlsParameters::new(host.into())?))
             }
             "smtps" => {

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -108,8 +108,53 @@ impl SmtpTransport {
     /// Creates a `SmtpTransportBuilder` from a connection URL
     ///
     /// The protocol, credentials, host and port can be provided in a single URL.
-    /// Use the scheme `smtp` for an unencrypted relay, `smtps` for SMTP over TLS
-    /// and `smtp` with the query parameter tls=required or tls=opportunistic for STARTTLS
+    /// Use the scheme `smtp` for an unencrypted relay (optionally in combination with the
+    /// `tls` parameter to allow/require STARTTLS) or `smtps` for SMTP over TLS.
+    /// The path section of the url can be used to set an alternative name for
+    /// the HELO / EHLO command.
+    /// For example `smtps://username:password@smtp.example.com/client.example.com:465`
+    /// will set the HELO / EHLO name `client.example.com`.
+    ///
+    /// <table>
+    ///   <thead>
+    ///     <tr>
+    ///       <th>scheme</th>
+    ///       <th>tls parameter</th>
+    ///       <th>example</th>
+    ///       <th>remarks</th>
+    ///     </tr>
+    ///   </thead>
+    ///   <tbody>
+    ///     <tr>
+    ///      <td>smtps</td>
+    ///      <td>-</td>
+    ///      <td>smtps://smtp.example.com</td>
+    ///      <td>SMTP over TLS, recommended method</td>
+    ///     </tr>
+    ///     <tr>
+    ///      <td>smtp</td>
+    ///      <td>required</td>
+    ///      <td>smtp://smtp.example.com?tls=required</td>
+    ///      <td>SMTP with STARTTLS required, when SMTP over TLS is not available</td>
+    ///     </tr>
+    ///     <tr>
+    ///      <td>smtp</td>
+    ///      <td>opportunistic</td>
+    ///      <td>smtp://smtp.example.com?tls=opportunistic</td>
+    ///      <td>
+    ///         SMTP with optionally STARTTLS when supported by the server.
+    ///         Caution: this method is vulnerable to a man-in-the-middle attack.
+    ///         Not recommended for production use.
+    ///       </td>
+    ///     </tr>
+    ///     <tr>
+    ///      <td>smtp</td>
+    ///      <td>-</td>
+    ///      <td>smtp://smtp.example.com</td>
+    ///      <td>Unencrypted SMTP, not recommended for production use.</td>
+    ///     </tr>
+    ///   </tbody>
+    /// </table>
     ///
     /// ```rust,no_run
     /// use lettre::{


### PR DESCRIPTION
Allow a SmtpTransportBuilder to be created from a URL like `smtps://username:password@smtp.example.com:465`

Note that this is a proof-of-concept.
It introduces a dependency on `url`.

Would you consider the construction of a SmtpTransport(Builder) using a URL? Using such a configuration mechanism would simplify a lot of our codebases. Typically we use different transport configurations for development, testing and production. Currently this involves writing some conditionals / boilerplate code to construct the applicable transport. Using an URL would simplify this process, for example:

```rust
let mailer = SmtpTransport::from_url("smtps://smtp_username:smtp_password@smtp.gmail.com:587")
    .unwrap()
    .build();
```

or in practice:

```rust
let mailer = SmtpTransport::from_url(env::var("MAILER_URL")?)? .build();
```

Inspired by https://nodemailer.com/smtp/ and https://symfony.com/doc/current/mailer.html

If you are interested, I can implement this for async or even create a generic method to create sendmail, file or smtp transport from a URL.