### PR TITLE
feat(transport-smtp): Support to SASL draft login challenge

### DIFF
--- a/src/transport/smtp/authentication.rs
+++ b/src/transport/smtp/authentication.rs
@@ -100,8 +100,8 @@ impl Mechanism {
 
                 let decode = |data: &str| -> Result<String, Error> {
                     crate::base64::decode(data)
-                        .map_err(error::response)
-                        .and_then(|bytes| String::from_utf8(bytes).map_err(error::response))
+                        .map_err(error::client)
+                        .and_then(|bytes| String::from_utf8(bytes).map_err(error::client))
                 };
 
                 let user_name_text = decode("VXNlciBOYW1lAA==")?;

--- a/src/transport/smtp/authentication.rs
+++ b/src/transport/smtp/authentication.rs
@@ -98,27 +98,13 @@ impl Mechanism {
                 let decoded_challenge = challenge
                     .ok_or_else(|| error::client("This mechanism does expect a challenge"))?;
 
-                let decode = |data: &str| -> Result<String, Error> {
-                    crate::base64::decode(data)
-                        .map_err(error::client)
-                        .and_then(|bytes| String::from_utf8(bytes).map_err(error::client))
-                };
-
-                let user_name_text = decode("VXNlciBOYW1lAA==")?;
-                let password_text = decode("UGFzc3dvcmQA")?;
-
-                if [
-                    "User Name",
-                    "Username:",
-                    "Username",
-                    user_name_text.as_str(),
-                ]
-                .contains(&decoded_challenge)
+                if ["User Name", "Username:", "Username", "User Name\0"]
+                    .contains(&decoded_challenge)
                 {
                     return Ok(credentials.authentication_identity.clone());
                 }
 
-                if ["Password", "Password:", password_text.as_str()].contains(&decoded_challenge) {
+                if ["Password", "Password:", "Password\0"].contains(&decoded_challenge) {
                     return Ok(credentials.secret.clone());
                 }
 


### PR DESCRIPTION
~~In~~ https://www.ietf.org/archive/id/draft-murchison-sasl-login-00.txt,

~~base64 encoded "User Name" is "VXNlciBOYW1lAA==",~~
~~and "Password" is "UGFzc3dvcmQA".~~

~~But using the base64 crate (or any other base64 converter),~~
~~"User Name" is "VXNlciBOYW1l",~~
~~and "Password" is "UGFzc3dvcmQ=".~~

~~This means "VXNlciBOYW1lAA==" and "UGFzc3dvcmQA" is not accepted by lettre-based programs.~~
~~I think something is wrong with the sasl draft document, but many programs already follow this standard.~~
~~So I added the code to accept these Strings.~~

**Edited**:
Currently, the lettre library does not support "User Name\0" and "Password\0" as described in the ietf draft, and this can cause compatibility issues with projects like [stalwart mail](https://github.com/stalwartlabs/mail-server) that follow the ietf draft. Therefore, I would like to address the compatibility issue with this request.