### PR TITLE
Fix mimebody DKIM body-hash computation

### DIFF
--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -525,7 +525,7 @@ impl Message {
     pub(crate) fn body_raw(&self) -> Vec<u8> {
         let mut out = Vec::new();
         match &self.body {
-            MessageBody::Mime(p) => out = p.body_raw(),
+            MessageBody::Mime(p) => p.format_body(&mut out),
             MessageBody::Raw(r) => out.extend_from_slice(r),
         };
         out.extend_from_slice(b"\r\n");

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -525,7 +525,7 @@ impl Message {
     pub(crate) fn body_raw(&self) -> Vec<u8> {
         let mut out = Vec::new();
         match &self.body {
-            MessageBody::Mime(p) => p.format(&mut out),
+            MessageBody::Mime(p) => out = p.body_raw(),
             MessageBody::Raw(r) => out.extend_from_slice(r),
         };
         out.extend_from_slice(b"\r\n");


### PR DESCRIPTION
This PR fixes the DKIM body-hash computation of singlepart and multipart bodies.

I opted for a `fn body_raw(&self) -> Vec<u8>` method for these bodies, but if it would be preferable with a `fn format_body(&self, out: &mut Vec<u8>)` instead I could do that change.

This fixes #922