### PR TITLE
transport/file: Derive `Clone` impls

### DIFF
--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -157,7 +157,7 @@ mod error;
 type Id = String;
 
 /// Writes the content and the envelope information to a file
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(docsrs, doc(cfg(feature = "file-transport")))]
 pub struct FileTransport {
@@ -167,7 +167,7 @@ pub struct FileTransport {
 }
 
 /// Asynchronously writes the content and the envelope information to a file
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[cfg_attr(docsrs, doc(cfg(any(feature = "tokio1", feature = "async-std1"))))]
 #[cfg(any(feature = "async-std1", feature = "tokio1"))]


### PR DESCRIPTION
While working on the crates.io codebase I noticed that most `Transport` impls have a `Clone` implementation, except for the `FileTransport`. Since the `PathBuf` inside is easy to clone I couldn't think of a reason why it shouldn't also have a `Clone` impl, so this PR adds it :)