### PR TITLE
Prepare 0.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="v0.11.3"></a>
+### v0.11.3 (2024-01-02)
+
+#### Features
+
+* Derive `Clone` for `FileTransport` and `AsyncFileTransport` ([#924])
+* Derive `Debug` for `SmtpTransport` ([#925])
+
+#### Misc
+
+* Upgrade `rustls` to v0.22 ([#921])
+* Drop once_cell dependency in favor of OnceLock from std ([#928])
+
+[#921]: https://github.com/lettre/lettre/pull/921
+[#924]: https://github.com/lettre/lettre/pull/924
+[#925]: https://github.com/lettre/lettre/pull/925
+[#928]: https://github.com/lettre/lettre/pull/928
+
 <a name="v0.11.2"></a>
 ### v0.11.2 (2023-11-23)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.2"
+version = "0.11.3"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.2">
-    <img src="https://deps.rs/crate/lettre/0.11.2/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.3">
+    <img src="https://deps.rs/crate/lettre/0.11.3/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.2")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.3")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
Opening as draft since we may want to include a few more PRs

---

### v0.11.3 (2024-01-02)

#### Features

* Derive `Clone` for `FileTransport` and `AsyncFileTransport` ([#924])
* Derive `Debug` for `SmtpTransport` ([#925])

#### Misc

* Upgrade `rustls` to v0.22 ([#921])
* Drop once_cell dependency in favor of OnceLock from std ([#928])
