### PR TITLE
Prepare 0.11.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+<a name="v0.11.4"></a>
+### v0.11.4 (2024-01-28)
+
+#### Bug fixes
+
+* Percent decode credentials in SMTP connect URL ([#932], [#934])
+* Fix mimebody DKIM body-hash computation ([#923])
+
+[#923]: https://github.com/lettre/lettre/pull/923
+[#932]: https://github.com/lettre/lettre/pull/932
+[#934]: https://github.com/lettre/lettre/pull/934
+
 <a name="v0.11.3"></a>
 ### v0.11.3 (2024-01-02)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.3"
+version = "0.11.4"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.3">
-    <img src="https://deps.rs/crate/lettre/0.11.3/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.4">
+    <img src="https://deps.rs/crate/lettre/0.11.4/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.3")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.4")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Bug fixes

* Percent decode credentials in SMTP connect URL ([#932], [#934])
* Fix mimebody DKIM body-hash computation ([#923])
