### PR TITLE
Bump rustls to v0.23

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "futures-rustls"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d8a2499f0fecc0492eb3e47eab4e92da7875e1028ad2528f214ac3346ca04e"
+checksum = "a8f2f12607f92c69b12ed746fabf9ca4f5c482cba46679c1a75b874ed7c26adb"
 dependencies = [
  "futures-io",
  "rustls",
@@ -1847,11 +1847,12 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.22.2"
+version = "0.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e87c9956bd9807afa1f77e0f7594af32566e830e088a5576d27c5b6f30f49d41"
+checksum = "1b3818d6051afeb6f88412bc8693cf8219799b2f2c2365f15e7534f0e198a16c"
 dependencies = [
  "log",
+ "once_cell",
  "ring",
  "rustls-pki-types",
  "rustls-webpki",
@@ -2226,9 +2227,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-rustls"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "775e0c0f0adb3a2f22a00c4745d728b479985fc15ee7ca6a2608388c5569860f"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
  "rustls",
  "rustls-pki-types",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,7 +45,7 @@ percent-encoding = { version = "2.3", optional = true }
 
 ## tls
 native-tls = { version = "0.2.5", optional = true } # feature
-rustls = { version = "0.22.1", optional = true }
+rustls = { version = "0.23.3", default-features = false, features = ["ring", "logging", "std", "tls12"], optional = true }
 rustls-pemfile = { version = "2", optional = true }
 rustls-native-certs = { version = "0.7", optional = true }
 webpki-roots = { version = "0.26", optional = true }
@@ -59,12 +59,12 @@ async-trait = { version = "0.1", optional = true }
 ## async-std
 async-std = { version = "1.8", optional = true }
 #async-native-tls = { version = "0.3.3", optional = true }
-futures-rustls = { version = "0.25", optional = true }
+futures-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
 
 ## tokio
 tokio1_crate = { package = "tokio", version = "1", optional = true }
 tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optional = true }
-tokio1_rustls = { package = "tokio-rustls", version = "0.25", optional = true }
+tokio1_rustls = { package = "tokio-rustls", version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
 tokio1_boring = { package = "tokio-boring", version = "4", optional = true }
 
 ## dkim


### PR DESCRIPTION
Keeps `ring` for now. I'm feeling like switching to `aws-lc-rs` in lettre v0.12, as it sounds like a breaking change.