### PR TITLE
Prepare 0.11.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="v0.11.6"></a>
+### v0.11.6 (2024-03-28)
+
+#### Bug fixes
+
+* Upgraded `email-encoding` to v0.3 - fixing multiple encoding bugs in the process ([#952])
+
+#### Misc
+
+* Updated copyright year in license ([#954])
+
+[#952]: https://github.com/lettre/lettre/pull/952
+[#954]: https://github.com/lettre/lettre/pull/954
+
 <a name="v0.11.5"></a>
 ### v0.11.5 (2024-03-25)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.5"
+version = "0.11.6"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.5">
-    <img src="https://deps.rs/crate/lettre/0.11.5/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.6">
+    <img src="https://deps.rs/crate/lettre/0.11.6/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.5")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.6")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### v0.11.6 (2024-03-28)

#### Bug fixes

* Upgraded `email-encoding` to v0.3 - fixing multiple encoding bugs in the process (#952)

#### Misc

* Updated copyright year in license (#954)