### PR TITLE
Prepare 0.11.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+<a name="v0.11.7"></a>
+### v0.11.7 (2024-04-23)
+
+#### Misc
+
+* Bump `hostname` to v0.4 ([#956])
+* Fix `tracing` message consistency ([#960])
+* Bump minimum required `rustls` to v0.23.5 ([#958])
+* Dropped use of `ref` syntax in the entire project ([#959])
+
+[#956]: https://github.com/lettre/lettre/pull/956
+[#958]: https://github.com/lettre/lettre/pull/958
+[#959]: https://github.com/lettre/lettre/pull/959
+[#960]: https://github.com/lettre/lettre/pull/960
+
 <a name="v0.11.6"></a>
 ### v0.11.6 (2024-03-28)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,7 +1151,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.6"
+version = "0.11.7"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.6"
+version = "0.11.7"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.6">
-    <img src="https://deps.rs/crate/lettre/0.11.6/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.7">
+    <img src="https://deps.rs/crate/lettre/0.11.7/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.6")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.7")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### v0.11.7 (2024-04-23)

#### Misc

* Bump `hostname` to v0.4 (#956)
* Fix `tracing` message consistency (#960)
* Bump minimum required `rustls` to v0.23.5 (#958)
* Dropped use of `ref` syntax in the entire project (#959)