### PR TITLE
feat(tls-peer-certificates): Provide peer certs

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -373,4 +373,10 @@ impl AsyncSmtpConnection {
     pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
         self.stream.get_ref().peer_certificate()
     }
+
+    /// All the X509 certificates of the chain (DER encoded)
+    #[cfg(any(feature = "rustls-tls", feature = "boring-tls"))]
+    pub fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, Error> {
+        self.stream.get_ref().certificate_chain()
+    }
 }

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -307,4 +307,10 @@ impl SmtpConnection {
     pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
         self.stream.get_ref().peer_certificate()
     }
+
+    /// All the X509 certificates of the chain (DER encoded)
+    #[cfg(any(feature = "rustls-tls", feature = "boring-tls"))]
+    pub fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, Error> {
+        self.stream.get_ref().certificate_chain()
+    }
 }


### PR DESCRIPTION
Add a method that, when using a TLS toolkit that supports it, returns the entire certificate chain. This is useful, for example, when implementing DANE support which has directives that apply to the issuer and not just to the leaf certificate.

Not all TLS toolkits support this, so the code will panic if the method is called when using a TLS toolkit that has no way to return these certificates.