### PR TITLE
Implement accept_invalid_hostnames for rustls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1322,6 +1322,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "rustls-pemfile",
+ "rustls-pki-types",
  "serde",
  "serde_json",
  "sha2",
@@ -2026,9 +2027,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.3.0"
+version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "048a63e5b3ac996d78d402940b5fa47973d2d080c6c6fffa1d0f19c4445310b7"
+checksum = "976295e77ce332211c0d24d92c0e83e50f5c5f046d11082cea19f3df13a3562d"
 
 [[package]]
 name = "rustls-webpki"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,6 +48,7 @@ native-tls = { version = "0.2.5", optional = true } # feature
 rustls = { version = "0.23.5", default-features = false, features = ["ring", "logging", "std", "tls12"], optional = true }
 rustls-pemfile = { version = "2", optional = true }
 rustls-native-certs = { version = "0.7", optional = true }
+rustls-pki-types = { version = "1.7", optional = true }
 webpki-roots = { version = "0.26", optional = true }
 boring = { version = "4", optional = true }
 
@@ -108,7 +109,7 @@ smtp-transport = ["dep:base64", "dep:nom", "dep:socket2", "dep:url", "dep:percen
 
 pool = ["dep:futures-util"]
 
-rustls-tls = ["dep:webpki-roots", "dep:rustls", "dep:rustls-pemfile"]
+rustls-tls = ["dep:webpki-roots", "dep:rustls", "dep:rustls-pemfile", "dep:rustls-pki-types"]
 
 boring-tls = ["dep:boring"]
 

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -198,7 +198,7 @@ impl TlsParametersBuilder {
     ///
     /// This method introduces significant vulnerabilities to man-in-the-middle attacks.
     #[cfg(any(feature = "native-tls", feature = "boring-tls"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature="rustls-tls" feature = "boring-tls"))))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))))]
     pub fn dangerous_accept_invalid_hostnames(mut self, accept_invalid_hostnames: bool) -> Self {
         self.accept_invalid_hostnames = accept_invalid_hostnames;
         self

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -198,7 +198,10 @@ impl TlsParametersBuilder {
     ///
     /// This method introduces significant vulnerabilities to man-in-the-middle attacks.
     #[cfg(any(feature = "native-tls", feature = "boring-tls"))]
-    #[cfg_attr(docsrs, doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+    )]
     pub fn dangerous_accept_invalid_hostnames(mut self, accept_invalid_hostnames: bool) -> Self {
         self.accept_invalid_hostnames = accept_invalid_hostnames;
         self


### PR DESCRIPTION
Fixes #957

Hi this is pretty straight forward and based on the PR mentioned in the linked issue.

This allows setting accept_invalid_hostnames when using rustls while still checking the provided root certificates.