### PR TITLE
Fix latest clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ async-trait = { version = "0.1", optional = true }
 
 ## async-std
 async-std = { version = "1.8", optional = true }
-#async-native-tls = { version = "0.3.3", optional = true }
 futures-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
 
 ## tokio
@@ -115,7 +114,6 @@ boring-tls = ["dep:boring"]
 
 # async
 async-std1 = ["dep:async-std", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
-#async-std1-native-tls = ["async-std1", "native-tls", "dep:async-native-tls"]
 async-std1-rustls-tls = ["async-std1", "rustls-tls", "dep:futures-rustls"]
 tokio1 = ["dep:tokio1_crate", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "dep:tokio1_native_tls_crate"]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -230,7 +230,7 @@ impl Executor for AsyncStd1Executor {
     ) -> Result<AsyncSmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match tls {
-            #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]
+            #[cfg(feature = "async-std1-rustls-tls")]
             Tls::Wrapper(tls_parameters) => Some(tls_parameters.clone()),
             _ => None,
         };
@@ -243,7 +243,7 @@ impl Executor for AsyncStd1Executor {
         )
         .await?;
 
-        #[cfg(any(feature = "async-std1-native-tls", feature = "async-std1-rustls-tls"))]
+        #[cfg(feature = "async-std1-rustls-tls")]
         match tls {
             Tls::Opportunistic(tls_parameters) => {
                 if conn.can_starttls() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,21 +174,7 @@ mod compiletime_checks {
     If you'd like to use `boring-tls` make sure that the `rustls-tls` feature hasn't been enabled by mistake.
     Make sure to apply the same to any of your crate dependencies that use the `lettre` crate.");
 
-    /*
-    #[cfg(all(
-        feature = "async-std1",
-        feature = "native-tls",
-        not(feature = "async-std1-native-tls")
-    ))]
-    compile_error!("Lettre is being built with the `async-std1` and the `native-tls` features, but the `async-std1-native-tls` feature hasn't been turned on.
-    If you'd like to use rustls make sure that the `native-tls` hasn't been enabled by mistake (you may need to import lettre without default features)
-    If you're building a library which depends on lettre import it without default features and enable just the features you need.");
-    */
-    #[cfg(all(
-        feature = "async-std1",
-        feature = "native-tls",
-        not(feature = "async-std1-native-tls")
-    ))]
+    #[cfg(all(feature = "async-std1", feature = "native-tls",))]
     compile_error!("Lettre is being built with the `async-std1` and the `native-tls` features, but the async-std integration doesn't support native-tls yet.
 If you'd like to work on the issue please take a look at https://github.com/lettre/lettre/issues/576.
 If you were trying to opt into `rustls-tls` and did not activate `native-tls`, disable the default-features of lettre in `Cargo.toml` and manually add the required features.

--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -189,10 +189,7 @@ pub struct HeaderName(Cow<'static, str>);
 impl HeaderName {
     /// Creates a new header name
     pub fn new_from_ascii(ascii: String) -> Result<Self, InvalidHeaderName> {
-        if !ascii.is_empty()
-            && ascii.len() <= 76
-            && ascii.is_ascii()
-            && !ascii.contains(|c| c == ':' || c == ' ')
+        if !ascii.is_empty() && ascii.len() <= 76 && ascii.is_ascii() && !ascii.contains([':', ' '])
         {
             Ok(Self(Cow::Owned(ascii)))
         } else {

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -82,7 +82,6 @@ where
     #[cfg(any(
         feature = "tokio1-native-tls",
         feature = "tokio1-rustls-tls",
-        feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
     #[cfg_attr(
@@ -117,7 +116,6 @@ where
     #[cfg(any(
         feature = "tokio1-native-tls",
         feature = "tokio1-rustls-tls",
-        feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
     #[cfg_attr(
@@ -353,7 +351,6 @@ impl AsyncSmtpTransportBuilder {
     #[cfg(any(
         feature = "tokio1-native-tls",
         feature = "tokio1-rustls-tls",
-        feature = "async-std1-native-tls",
         feature = "async-std1-rustls-tls"
     ))]
     #[cfg_attr(

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -139,7 +139,7 @@ mod test {
     }
 
     #[test]
-    #[cfg(feature = "log")]
+    #[cfg(feature = "tracing")]
     fn test_escape_crlf() {
         assert_eq!(escape_crlf("\r\n"), "<CRLF>");
         assert_eq!(escape_crlf("EHLO my_name\r\n"), "EHLO my_name<CRLF>");

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -380,7 +380,7 @@ impl TlsParametersBuilder {
 
         let tls = ClientConfig::builder_with_protocol_versions(supported_versions);
         let provider = rustls::crypto::CryptoProvider::get_default()
-            .map(|arc| arc.clone())
+            .cloned()
             .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
 
         // Build TLS config
@@ -659,7 +659,7 @@ impl ServerCertVerifier for InvalidCertsVerifier {
         end_entity: &CertificateDer<'_>,
         intermediates: &[CertificateDer<'_>],
         server_name: &ServerName<'_>,
-        ocsp_response: &[u8],
+        _ocsp_response: &[u8],
         now: UnixTime,
     ) -> Result<ServerCertVerified, TlsError> {
         let cert = ParsedCertificate::try_from(end_entity)?;


### PR DESCRIPTION
This also rips out the `async-std1-native-tls` feature because clippy complained about it and no one seems interested in implementing it.