### PR TITLE
Prepare v0.11.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+<a name="v0.11.8"></a>
+### v0.11.8 (2024-09-03)
+
+#### Features
+
+* Add mTLS support ([#974])
+* Implement `accept_invalid_hostnames` for rustls ([#977])
+* Provide certificate chain for peer certificates when using `rustls` or `boring-tls` ([#976])
+
+#### Changes
+
+* Make `HeaderName` comparisons via `PartialEq` case insensitive ([#980])
+
+#### Misc
+
+* Fix clippy warnings ([#979])
+* Replace manual impl of `#[non_exhaustive]` for `InvalidHeaderName` ([#981])
+
+[#974]: https://github.com/lettre/lettre/pull/974
+[#976]: https://github.com/lettre/lettre/pull/976
+[#977]: https://github.com/lettre/lettre/pull/977
+[#980]: https://github.com/lettre/lettre/pull/980
+[#981]: https://github.com/lettre/lettre/pull/981
+
 <a name="v0.11.7"></a>
 ### v0.11.7 (2024-04-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1291,7 +1291,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.7"
+version = "0.11.8"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.7"
+version = "0.11.8"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.7">
-    <img src="https://deps.rs/crate/lettre/0.11.7/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.8">
+    <img src="https://deps.rs/crate/lettre/0.11.8/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.7")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.8")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Features

* Add mTLS support ([#974])
* Implement `accept_invalid_hostnames` for rustls ([#977])
* Provide certificate chain for peer certificates when using `rustls` or `boring-tls` ([#976])

#### Changes

* Make `HeaderName` comparisons via `PartialEq` case insensitive ([#980])

#### Misc

* Fix clippy warnings ([#979])
* Replace manual impl of `#[non_exhaustive]` for `InvalidHeaderName` ([#981])