### PR TITLE
Fix parsing Mailbox with spaces

### DIFF
--- a/src/message/mailbox/parsers/rfc2822.rs
+++ b/src/message/mailbox/parsers/rfc2822.rs
@@ -170,7 +170,9 @@ fn phrase() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
 // mailbox         =       name-addr / addr-spec
 pub(crate) fn mailbox() -> impl Parser<char, (Option<String>, (String, String)), Error = Cheap<char>>
 {
-    choice((name_addr(), addr_spec().map(|addr| (None, addr)))).then_ignore(end())
+    choice((name_addr(), addr_spec().map(|addr| (None, addr))))
+        .padded()
+        .then_ignore(end())
 }
 
 // name-addr       =       [display-name] angle-addr

--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -557,9 +557,28 @@ mod test {
     }
 
     #[test]
+    fn parse_address_only_trim() {
+        assert_eq!(
+            " kayo@example.com ".parse(),
+            Ok(Mailbox::new(None, "kayo@example.com".parse().unwrap()))
+        );
+    }
+
+    #[test]
     fn parse_address_with_name() {
         assert_eq!(
             "K. <kayo@example.com>".parse(),
+            Ok(Mailbox::new(
+                Some("K.".into()),
+                "kayo@example.com".parse().unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_address_with_name_trim() {
+        assert_eq!(
+            " K. <kayo@example.com> ".parse(),
             Ok(Mailbox::new(
                 Some("K.".into()),
                 "kayo@example.com".parse().unwrap()
@@ -578,7 +597,7 @@ mod test {
     #[test]
     fn parse_address_with_empty_name_trim() {
         assert_eq!(
-            " <kayo@example.com>".parse(),
+            " <kayo@example.com> ".parse(),
             Ok(Mailbox::new(None, "kayo@example.com".parse().unwrap()))
         );
     }


### PR DESCRIPTION
Hi, I discovered that the new parser in 0.11 does not handle leading spaces correctly.

This PR fixes the bug, adds 2 tests and adjusts a 3rd test.

And then, please note that https://github.com/lettre/lettre/issues/838 seems fixed in 0.11 thanks to the new parser.