### PR TITLE
Enable accept_invalid_hostnames for rustls

### DIFF
--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -197,7 +197,7 @@ impl TlsParametersBuilder {
     /// including those from other sites, are trusted.
     ///
     /// This method introduces significant vulnerabilities to man-in-the-middle attacks.
-    #[cfg(any(feature = "native-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
         doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))


### PR DESCRIPTION
With #977 dangerous_accept_invalid_hostnames is implemented for rustls. This add the config flag so that the feature can actually be used when rustls-tls is enabled.