### PR TITLE
executor: Derive `Clone` for `Tokio1Executor` and `AsyncStd1Executor`

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -98,7 +98,7 @@ pub trait SpawnHandle: Debug + Send + Sync + 'static + private::Sealed {
 #[non_exhaustive]
 #[cfg(feature = "tokio1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "tokio1")))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Tokio1Executor;
 
 #[async_trait]
@@ -194,7 +194,7 @@ impl SpawnHandle for tokio1_crate::task::JoinHandle<()> {
 #[non_exhaustive]
 #[cfg(feature = "async-std1")]
 #[cfg_attr(docsrs, doc(cfg(feature = "async-std1")))]
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct AsyncStd1Executor;
 
 #[async_trait]

--- a/tests/transport_file.rs
+++ b/tests/transport_file.rs
@@ -53,6 +53,12 @@ mod sync {
     }
 
     #[test]
+    fn file_transport_clone() {
+        let sender = FileTransport::new(temp_dir());
+        let _ = sender.clone();
+    }
+
+    #[test]
     #[cfg(feature = "file-transport-envelope")]
     fn file_transport_with_envelope() {
         let sender = FileTransport::with_envelope(temp_dir());
@@ -149,6 +155,12 @@ mod tokio_1 {
         );
         remove_file(eml_file).unwrap();
     }
+
+    #[tokio::test]
+    async fn file_transport_tokio1_clone() {
+        let sender = AsyncFileTransport::<Tokio1Executor>::new(temp_dir());
+        let _ = sender.clone();
+    }
 }
 
 #[cfg(test)]
@@ -199,5 +211,11 @@ mod asyncstd_1 {
             )
         );
         remove_file(eml_file).unwrap();
+    }
+
+    #[async_std::test]
+    async fn file_transport_asyncstd1_clone() {
+        let sender = AsyncFileTransport::<AsyncStd1Executor>::new(temp_dir());
+        let _ = sender.clone();
     }
 }

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -1,8 +1,9 @@
 #[cfg(test)]
-#[cfg(all(feature = "smtp-transport", feature = "builder"))]
+#[cfg(feature = "smtp-transport")]
 mod sync {
     use lettre::{Message, SmtpTransport, Transport};
 
+    #[cfg(feature = "builder")]
     #[test]
     fn smtp_transport_simple() {
         let email = Message::builder()
@@ -18,14 +19,24 @@ mod sync {
             .build();
         sender.send(&email).unwrap();
     }
+
+    #[test]
+    fn smtp_transport_clone() {
+        let sender = SmtpTransport::builder_dangerous("127.0.0.1")
+            .port(2525)
+            .build();
+
+        let _ = sender.clone();
+    }
 }
 
 #[cfg(test)]
-#[cfg(all(feature = "smtp-transport", feature = "builder", feature = "tokio1"))]
+#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
 mod tokio_1 {
     use lettre::{AsyncSmtpTransport, AsyncTransport, Message, Tokio1Executor};
     use tokio1_crate as tokio;
 
+    #[cfg(feature = "builder")]
     #[tokio::test]
     async fn smtp_transport_simple_tokio1() {
         let email = Message::builder()
@@ -42,17 +53,24 @@ mod tokio_1 {
                 .build();
         sender.send(email).await.unwrap();
     }
+
+    #[tokio::test]
+    async fn smtp_transport_clone() {
+        let sender: AsyncSmtpTransport<Tokio1Executor> =
+            AsyncSmtpTransport::<Tokio1Executor>::builder_dangerous("127.0.0.1")
+                .port(2525)
+                .build();
+
+        let _ = sender.clone();
+    }
 }
 
 #[cfg(test)]
-#[cfg(all(
-    feature = "smtp-transport",
-    feature = "builder",
-    feature = "async-std1"
-))]
+#[cfg(all(feature = "smtp-transport", feature = "async-std1"))]
 mod asyncstd_1 {
     use lettre::{AsyncSmtpTransport, AsyncStd1Executor, AsyncTransport, Message};
 
+    #[cfg(feature = "builder")]
     #[async_std::test]
     async fn smtp_transport_simple_asyncstd1() {
         let email = Message::builder()
@@ -68,5 +86,15 @@ mod asyncstd_1 {
                 .port(2525)
                 .build();
         sender.send(email).await.unwrap();
+    }
+
+    #[async_std::test]
+    async fn smtp_transport_clone() {
+        let sender: AsyncSmtpTransport<AsyncStd1Executor> =
+            AsyncSmtpTransport::<AsyncStd1Executor>::builder_dangerous("127.0.0.1")
+                .port(2525)
+                .build();
+
+        let _ = sender.clone();
     }
 }


### PR DESCRIPTION
Without this things like `AsyncFileTransport` can't be cloned either, which kinda defeats the purpose of implementing `Clone` for it :D

/cc @paolobarbolini 