### PR TITLE
Replace `quit` with `abort` in transport connection drop code

### DIFF
--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -45,7 +45,7 @@ impl AsyncTransport for AsyncSmtpTransport<Tokio1Executor> {
         let result = conn.send(envelope, email).await?;
 
         #[cfg(not(feature = "pool"))]
-        conn.quit().await?;
+        conn.abort().await;
 
         Ok(result)
     }

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -32,7 +32,7 @@ impl Transport for SmtpTransport {
         let result = conn.send(envelope, email)?;
 
         #[cfg(not(feature = "pool"))]
-        conn.quit()?;
+        conn.abort();
 
         Ok(result)
     }


### PR DESCRIPTION
In https://github.com/dani-garcia/vaultwarden/discussions/4996#discussioncomment-10764893 / https://matrix.to/#/!jZPOAKPWNeZkNemCEi:gitter.im/$hTxrNpVLYWtAM9a2OciwiGDDGDY3LlZKdnA50cHzc8A?via=gitter.im&via=matrix.org&via=0x.badd.cafe we found out that when the `pool` feature is disabled, connections are closed with `quit`, causing errors to be propagated through the mail sending function even though the error is not about sending the mail. This changes it to use `abort`, which already ignores any errors and has the added benefit of closing the connection instead of just sending the QUIT command.

Pooled connections already use `abort`.