### PR TITLE
Prepare v0.11.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+<a name="v0.11.10"></a>
+### v0.11.10 (2024-10-23)
+
+#### Bug fixes
+
+* Ignore disconnect errors when `pool` feature of SMTP transport is disabled ([#999])
+* Use case insensitive comparisons for matching login challenge requests ([#1000])
+
+[#999]: https://github.com/lettre/lettre/pull/999
+[#1000]: https://github.com/lettre/lettre/pull/1000
+
 <a name="v0.11.9"></a>
 ### v0.11.9 (2024-09-13)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1178,7 +1178,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.9"
+version = "0.11.10"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.9"
+version = "0.11.10"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.9">
-    <img src="https://deps.rs/crate/lettre/0.11.9/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.10">
+    <img src="https://deps.rs/crate/lettre/0.11.10/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.9")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.10")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### v0.11.10 (2024-10-23)

#### Bug fixes

* Ignore disconnect errors when `pool` feature of SMTP transport is disabled (#999)
* Use case insensitive comparisons for matching login challenge requests (#1000)