### PR TITLE
Prepare v0.11.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,24 @@
+<a name="v0.11.11"></a>
+### v0.11.11 (2024-12-05)
+
+#### Upgrade notes
+
+* MSRV is now 1.71 ([#1008])
+
+#### Bug fixes
+
+* Fix off-by-one error reaching the minimum number of configured pooled connections ([#1012])
+
+#### Misc
+
+* Fix clippy warnings ([#1009])
+* Fix `-Zminimal-versions` build ([#1007])
+
+[#1007]: https://github.com/lettre/lettre/pull/1007
+[#1008]: https://github.com/lettre/lettre/pull/1008
+[#1009]: https://github.com/lettre/lettre/pull/1009
+[#1012]: https://github.com/lettre/lettre/pull/1012
+
 <a name="v0.11.10"></a>
 ### v0.11.10 (2024-10-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.10"
+version = "0.11.11"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.10"
+version = "0.11.11"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.10">
-    <img src="https://deps.rs/crate/lettre/0.11.10/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.11">
+    <img src="https://deps.rs/crate/lettre/0.11.11/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -109,7 +109,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.10")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.11")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Upgrade notes

* MSRV is now 1.71 (#1008)

#### Bug fixes

* Fix off-by-one error reaching the minimum number of configured pooled connections (#1012)

#### Misc

* Fix clippy warnings (#1009)
* Fix `-Zminimal-versions` build (#1007)