### PR TITLE
docs: document OpenSSL system dependencies

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,12 +34,24 @@
 //!
 //! _Secure SMTP connections using TLS from the `native-tls` crate_
 //!
-//! Uses schannel on Windows, Security-Framework on macOS, and OpenSSL on Linux.
+//! Uses schannel on Windows, Security-Framework on macOS, and OpenSSL
+//! on all other platforms.
 //!
 //! * **native-tls** 📫: TLS support for the synchronous version of the API
 //! * **tokio1-native-tls**: TLS support for the `tokio1` async version of the API
 //!
 //! NOTE: native-tls isn't supported with `async-std`
+//!
+//! ##### Building lettre with OpenSSL
+//!
+//! When building lettre with native-tls on a system that makes
+//! use of OpenSSL, the following packages will need to be installed
+//! in order for the build and the compiled program to run properly.
+//!
+//! | Distro       | Build-time packages        | Runtime packages             |
+//! | ------------ | -------------------------- | ---------------------------- |
+//! | Debian       | `pkg-config`, `libssl-dev` | `libssl3`, `ca-certificates` |
+//! | Alpine Linux | `pkgconf`, `openssl-dev`   | `libssl3`, `ca-certificates` |
 //!
 //! #### SMTP over TLS via the boring crate (Boring TLS)
 //!


### PR DESCRIPTION
Tested with:

## Debian

```dockerfile
FROM rust:1.84-slim-bookworm AS builder

WORKDIR /app

RUN apt update; apt install -y pkg-config libssl-dev

COPY . .

RUN cargo build --release


FROM debian:bookworm-slim

RUN apt update; apt install -y libssl3 ca-certificates

COPY --from=builder /app/target/release/test-app /usr/bin/test-app

CMD ["/usr/bin/test-app"]
```

## Alpine

```dockerfile
FROM rust:1.84-alpine3.21 AS builder

WORKDIR /app

RUN apk add --no-cache musl-dev pkgconf openssl-dev

COPY . .

RUN RUSTFLAGS=-Ctarget-feature=-crt-static cargo build --release


FROM alpine:3.21

RUN apk add --no-cache libgcc libssl3 ca-certificates

COPY --from=builder /app/target/release/test-app /usr/bin/test-app

CMD ["/usr/bin/test-app"]
```