### PR TITLE
docs: replace `assert!` with `?` operator for `send` examples

### DIFF
--- a/src/transport/file/mod.rs
+++ b/src/transport/file/mod.rs
@@ -23,8 +23,7 @@
 //!     .header(ContentType::TEXT_PLAIN)
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let result = sender.send(&email);
-//! assert!(result.is_ok());
+//! sender.send(&email)?;
 //! # Ok(())
 //! # }
 //!
@@ -57,8 +56,7 @@
 //!     .header(ContentType::TEXT_PLAIN)
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let result = sender.send(&email);
-//! assert!(result.is_ok());
+//! sender.send(&email)?;
 //! # Ok(())
 //! # }
 //!
@@ -89,8 +87,7 @@
 //!     .header(ContentType::TEXT_PLAIN)
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let result = sender.send(email).await;
-//! assert!(result.is_ok());
+//! sender.send(email).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -119,8 +116,7 @@
 //!     .header(ContentType::TEXT_PLAIN)
 //!     .body(String::from("Be happy!"))?;
 //!
-//! let result = sender.send(email).await;
-//! assert!(result.is_ok());
+//! sender.send(email).await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/transport/sendmail/mod.rs
+++ b/src/transport/sendmail/mod.rs
@@ -18,8 +18,7 @@
 //!     .body(String::from("Be happy!"))?;
 //!
 //! let sender = SendmailTransport::new();
-//! let result = sender.send(&email);
-//! assert!(result.is_ok());
+//! sender.send(&email)?;
 //! # Ok(())
 //! # }
 //!
@@ -48,8 +47,7 @@
 //!     .body(String::from("Be happy!"))?;
 //!
 //! let sender = AsyncSendmailTransport::<Tokio1Executor>::new();
-//! let result = sender.send(email).await;
-//! assert!(result.is_ok());
+//! sender.send(email).await?;
 //! # Ok(())
 //! # }
 //! ```
@@ -71,8 +69,7 @@
 //!     .body(String::from("Be happy!"))?;
 //!
 //! let sender = AsyncSendmailTransport::<AsyncStd1Executor>::new();
-//! let result = sender.send(email).await;
-//! assert!(result.is_ok());
+//! sender.send(email).await?;
 //! # Ok(())
 //! # }
 //! ```

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -86,8 +86,7 @@ impl AsyncSmtpConnection {
     ///     Some(TlsParameters::new("example.com".to_owned())?),
     ///     None,
     /// )
-    /// .await
-    /// .unwrap();
+    /// .await?;
     /// # Ok(())
     /// # }
     /// ```

--- a/src/transport/stub/mod.rs
+++ b/src/transport/stub/mod.rs
@@ -26,8 +26,7 @@
 //!     .body(String::from("Be happy!"))?;
 //!
 //! let mut sender = StubTransport::new_ok();
-//! let result = sender.send(&email);
-//! assert!(result.is_ok());
+//! sender.send(&email)?;
 //! assert_eq!(
 //!     sender.messages(),
 //!     vec![(


### PR DESCRIPTION
`assert!` didn't make sense because this use in example usually explain that the return value is guaranteed to be equal to the expected value.