### PR TITLE
Prepare v0.11.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+<a name="v0.11.12"></a>
+### v0.11.12 (2025-02-02)
+
+#### Misc
+
+* Warn against manually configuring `port` and `tls` on SMTP transport builder ([#1014])
+* Document variants of `Tls` enum ([#1015])
+* Fix rustdoc warnings ([#1016])
+* Add `ContentType::TEXT_PLAIN` to `Message` builder examples ([#1017])
+* Document `SmtpTransport` and `AsyncSmtpTransport` ([#1018])
+* Fix typo in transport builder `credentials` method ([#1019])
+* Document required system dependencies for OpenSSL ([#1030])
+* Improve docs for the `transport::smtp` module ([#1031])
+* Improve docs for smtp transport builder `from_url` ([#1032])
+* Replace `assert!` with `?` on `send` examples ([#1033])
+* Warn on more pedantic clippy lints and fix them ([#1035], [#1036])
+
+[#1014]: https://github.com/lettre/lettre/pull/1014
+[#1015]: https://github.com/lettre/lettre/pull/1015
+[#1016]: https://github.com/lettre/lettre/pull/1016
+[#1017]: https://github.com/lettre/lettre/pull/1017
+[#1018]: https://github.com/lettre/lettre/pull/1018
+[#1019]: https://github.com/lettre/lettre/pull/1019
+[#1030]: https://github.com/lettre/lettre/pull/1030
+[#1031]: https://github.com/lettre/lettre/pull/1031
+[#1032]: https://github.com/lettre/lettre/pull/1032
+[#1033]: https://github.com/lettre/lettre/pull/1033
+[#1035]: https://github.com/lettre/lettre/pull/1035
+[#1036]: https://github.com/lettre/lettre/pull/1036
+
 <a name="v0.11.11"></a>
 ### v0.11.11 (2024-12-05)
 
@@ -540,6 +570,6 @@ Several breaking changes were made between 0.9 and 0.10, but changes should be s
 
 *  multipart support
 *  add non-consuming methods for Email builders
-* `add_header` does not return the builder anymore, 
+* `add_header` does not return the builder anymore,
   for consistency with other methods. Use the `header`
   method instead

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1189,7 +1189,7 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.11"
+version = "0.11.12"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.11"
+version = "0.11.12"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.11">
-    <img src="https://deps.rs/crate/lettre/0.11.11/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.12">
+    <img src="https://deps.rs/crate/lettre/0.11.12/status.svg"
       alt="dependency status" />
   </a>
 </div>
@@ -107,7 +107,7 @@ cargo run --example autoconfigure SMTP_HOST
 
 ## Testing
 
-The `lettre` tests require an open mail server listening locally on port 2525 and the `sendmail` command. If you have python installed 
+The `lettre` tests require an open mail server listening locally on port 2525 and the `sendmail` command. If you have python installed
 such a server can be launched with `python -m smtpd -n -c DebuggingServer 127.0.0.1:2525`
 
 Alternatively only unit tests can be run by doing `cargo test --lib`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.11")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.12")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
### v0.11.12 (2025-02-02)

#### Misc

* Warn against manually configuring `port` and `tls` on SMTP transport builder (#1014)
* Document variants of `Tls` enum (#1015)
* Fix rustdoc warnings (#1016)
* Add `ContentType::TEXT_PLAIN` to `Message` builder examples (#1017)
* Document `SmtpTransport` and `AsyncSmtpTransport` (#1018)
* Fix typo in transport builder `credentials` method (#1019)
* Document required system dependencies for OpenSSL (#1030)
* Improve docs for the `transport::smtp` module (#1031)
* Improve docs for smtp transport builder `from_url` (#1032)
* Replace `assert!` with `?` on `send` examples (#1033)
* Warn on more pedantic clippy lints and fix them (#1035, #1036)