### PR TITLE
replace std::time with web_time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1233,6 +1233,7 @@ dependencies = [
  "url",
  "uuid",
  "walkdir",
+ "web-time",
  "webpki-roots",
 ]
 
@@ -2439,6 +2440,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6488b90108c040df0fe62fa815cbdee25124641df01814dd7282749234c6112"
 dependencies = [
  "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2450,7 +2450,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
 dependencies = [
  "js-sys",
- "serde",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ ed25519-dalek = { version = "2", optional = true }
 email_address = { version = "0.2.1", default-features = false }
 
 # webtime for wasm support
-web-time = { version = "1.1.0" , features=["serde"]}
+web-time = { version = "1.1.0" }
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ tokio1-boring-tls = ["tokio1", "boring-tls", "dep:tokio1_boring"]
 dkim = ["dep:base64", "dep:sha2", "dep:rsa", "dep:ed25519-dalek"]
 
 # wasm support
-web = ["web-time"]
+web = ["dep:web-time"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(lettre_ignore_tls_mismatch)'] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,6 +75,9 @@ ed25519-dalek = { version = "2", optional = true }
 # email formats
 email_address = { version = "0.2.1", default-features = false }
 
+# webtime for wasm support
+web-time = { version = "1.1.0" , features=["serde"]}
+
 [dev-dependencies]
 pretty_assertions = "1"
 criterion = "0.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ ed25519-dalek = { version = "2", optional = true }
 email_address = { version = "0.2.1", default-features = false }
 
 # webtime for wasm support
-web-time = { version = "1.1.0" }
+web-time = { version = "1.1.0", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "1"
@@ -124,6 +124,9 @@ tokio1-rustls-tls = ["tokio1", "rustls-tls", "dep:tokio1_rustls"]
 tokio1-boring-tls = ["tokio1", "boring-tls", "dep:tokio1_boring"]
 
 dkim = ["dep:base64", "dep:sha2", "dep:rsa", "dep:ed25519-dalek"]
+
+# wasm support
+web = ["web-time"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(lettre_ignore_tls_mismatch)'] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,6 +107,7 @@
 //! * **tracing**: Logging using the `tracing` crate
 //! * **mime03**: Allow creating a [`ContentType`] from an existing [mime 0.3] `Mime` struct
 //! * **dkim**: Add support for signing email with DKIM
+//! * **web**: WebAssembly support using the `web-time` crate for time operations
 //!
 //! [`SMTP`]: crate::transport::smtp
 //! [`sendmail`]: crate::transport::sendmail

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -1,17 +1,16 @@
+#[cfg(not(feature = "web"))]
+use std::time::SystemTime;
 use std::{
     borrow::Cow,
     error::Error as StdError,
     fmt::{self, Display},
 };
 
-#[cfg(not(feature = "web"))]
-use std::time::SystemTime;
-#[cfg(feature = "web")]
-use web_time::SystemTime;
-
 use ed25519_dalek::Signer;
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs1v15::Pkcs1v15Sign, RsaPrivateKey};
 use sha2::{Digest, Sha256};
+#[cfg(feature = "web")]
+use web_time::SystemTime;
 
 use crate::message::{
     header::{HeaderName, HeaderValue},

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -1,4 +1,3 @@
-#[cfg(not(feature = "web"))]
 use std::time::SystemTime;
 use std::{
     borrow::Cow,
@@ -9,8 +8,6 @@ use std::{
 use ed25519_dalek::Signer;
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs1v15::Pkcs1v15Sign, RsaPrivateKey};
 use sha2::{Digest, Sha256};
-#[cfg(feature = "web")]
-use web_time::SystemTime;
 
 use crate::message::{
     header::{HeaderName, HeaderValue},
@@ -349,6 +346,13 @@ fn dkim_canonicalize_headers<'a>(
 /// Sign with Dkim a message by adding Dkim-Signature header created with configuration expressed by
 /// `dkim_config`
 pub fn dkim_sign(message: &mut Message, dkim_config: &DkimConfig) {
+    #[cfg(feature = "web")]
+    dkim_sign_fixed_time(
+        message,
+        dkim_config,
+        crate::message::to_std_systemtime(web_time::SystemTime::now()),
+    );
+    #[cfg(not(feature = "web"))]
     dkim_sign_fixed_time(message, dkim_config, SystemTime::now());
 }
 

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -3,6 +3,10 @@ use std::{
     error::Error as StdError,
     fmt::{self, Display},
 };
+
+#[cfg(not(feature = "web"))]
+use std::time::SystemTime;
+#[cfg(feature = "web")]
 use web_time::SystemTime;
 
 use ed25519_dalek::Signer;

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -1,8 +1,8 @@
-use std::time::SystemTime;
 use std::{
     borrow::Cow,
     error::Error as StdError,
     fmt::{self, Display},
+    time::SystemTime,
 };
 
 use ed25519_dalek::Signer;

--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -2,8 +2,8 @@ use std::{
     borrow::Cow,
     error::Error as StdError,
     fmt::{self, Display},
-    time::SystemTime,
 };
+use web_time::SystemTime;
 
 use ed25519_dalek::Signer;
 use rsa::{pkcs1::DecodeRsaPrivateKey, pkcs1v15::Pkcs1v15Sign, RsaPrivateKey};

--- a/src/message/header/date.rs
+++ b/src/message/header/date.rs
@@ -1,9 +1,23 @@
-use std::time::SystemTime;
+use web_time::SystemTime;
 
 use httpdate::HttpDate;
 
 use super::{Header, HeaderName, HeaderValue};
 use crate::BoxError;
+
+fn to_std_systemtime(time: web_time::SystemTime) -> std::time::SystemTime {
+    let duration = time
+        .duration_since(web_time::SystemTime::UNIX_EPOCH)
+        .unwrap();
+    std::time::SystemTime::UNIX_EPOCH + duration
+}
+
+fn from_std_systemtime(time: std::time::SystemTime) -> web_time::SystemTime {
+    let duration = time
+        .duration_since(std::time::SystemTime::UNIX_EPOCH)
+        .unwrap();
+    web_time::SystemTime::UNIX_EPOCH + duration
+}
 
 /// Message `Date` header
 ///
@@ -14,7 +28,7 @@ pub struct Date(HttpDate);
 impl Date {
     /// Build a `Date` from [`SystemTime`]
     pub fn new(st: SystemTime) -> Self {
-        Self(st.into())
+        Self(to_std_systemtime(st).into())
     }
 
     /// Get the current date
@@ -66,7 +80,7 @@ impl From<SystemTime> for Date {
 
 impl From<Date> for SystemTime {
     fn from(this: Date) -> SystemTime {
-        this.0.into()
+        from_std_systemtime(this.0.into())
     }
 }
 

--- a/src/message/header/date.rs
+++ b/src/message/header/date.rs
@@ -1,9 +1,9 @@
 #[cfg(not(feature = "web"))]
 use std::time::SystemTime;
-#[cfg(feature = "web")]
-use web_time::SystemTime;
 
 use httpdate::HttpDate;
+#[cfg(feature = "web")]
+use web_time::SystemTime;
 
 use super::{Header, HeaderName, HeaderValue};
 use crate::BoxError;

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -198,12 +198,9 @@
 //! ```
 //! </details>
 
-use std::{io::Write, iter};
-
 #[cfg(not(feature = "web"))]
 use std::time::SystemTime;
-#[cfg(feature = "web")]
-use web_time::SystemTime;
+use std::{io::Write, iter};
 
 pub use attachment::Attachment;
 pub use body::{Body, IntoBody, MaybeString};
@@ -211,6 +208,8 @@ pub use body::{Body, IntoBody, MaybeString};
 pub use dkim::*;
 pub use mailbox::*;
 pub use mimebody::*;
+#[cfg(feature = "web")]
+use web_time::SystemTime;
 
 mod attachment;
 mod body;
@@ -633,10 +632,10 @@ mod test {
 
     #[cfg(not(feature = "web"))]
     use std::time::{Duration, SystemTime};
-    #[cfg(feature = "web")]
-    use web_time::{Duration, SystemTime};
 
     use pretty_assertions::assert_eq;
+    #[cfg(feature = "web")]
+    use web_time::{Duration, SystemTime};
 
     use super::{header, mailbox::Mailbox, make_message_id, Message, MultiPart, SinglePart};
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -198,7 +198,8 @@
 //! ```
 //! </details>
 
-use std::{io::Write, iter, time::SystemTime};
+use std::{io::Write, iter};
+use web_time::SystemTime;
 
 pub use attachment::Attachment;
 pub use body::{Body, IntoBody, MaybeString};
@@ -625,7 +626,7 @@ fn make_message_id() -> String {
 
 #[cfg(test)]
 mod test {
-    use std::time::{Duration, SystemTime};
+    use web_time::{Duration, SystemTime};
 
     use pretty_assertions::assert_eq;
 

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -198,8 +198,7 @@
 //! ```
 //! </details>
 
-use std::time::SystemTime;
-use std::{io::Write, iter};
+use std::{io::Write, iter, time::SystemTime};
 
 pub use attachment::Attachment;
 pub use body::{Body, IntoBody, MaybeString};
@@ -640,8 +639,9 @@ mod test {
 
     use std::time::{Duration, SystemTime};
 
-    use super::{header, mailbox::Mailbox, make_message_id, Message, MultiPart, SinglePart};
     use pretty_assertions::assert_eq;
+
+    use super::{header, mailbox::Mailbox, make_message_id, Message, MultiPart, SinglePart};
 
     #[test]
     fn email_missing_originator() {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -199,6 +199,10 @@
 //! </details>
 
 use std::{io::Write, iter};
+
+#[cfg(not(feature = "web"))]
+use std::time::SystemTime;
+#[cfg(feature = "web")]
 use web_time::SystemTime;
 
 pub use attachment::Attachment;
@@ -626,6 +630,10 @@ fn make_message_id() -> String {
 
 #[cfg(test)]
 mod test {
+
+    #[cfg(not(feature = "web"))]
+    use std::time::{Duration, SystemTime};
+    #[cfg(feature = "web")]
     use web_time::{Duration, SystemTime};
 
     use pretty_assertions::assert_eq;


### PR DESCRIPTION
Support WASM environments by using web-time. This was tested on a Cloudflare worker environment.