### PR TITLE
Fix synchronous pool shutdowns being arbitrarly delayed

### DIFF
--- a/src/transport/smtp/pool/sync_impl.rs
+++ b/src/transport/smtp/pool/sync_impl.rs
@@ -109,6 +109,7 @@ impl Pool {
                             }
                         }
 
+                        drop(pool);
                         thread::sleep(idle_timeout);
                     }
                 })


### PR DESCRIPTION
Previously, the connection pool thread did not drop its upgraded `Arc` pool reference while sleeping until the next idle duration check. This causes a drop of the `SmtpTransport` to not shut down any connections until said thread wakes up again (since it still holds a reference to the pool), which can take up to 60s with default settings. In practice, this means that connections will most likely not be properly closed before the program exists, (since the `SmtpTransport` is most likely dropped when the program shuts down) which violates the SMTP specification which states that:
> The sender MUST NOT intentionally close the channel until it sends a QUIT command, and it SHOULD wait until it receives the reply (even if there was an error response to a command).

Ideally, lettre would offer an API which allows a user of the crate to properly shut down their transport, which allows them to ensure that all connections are closed before the program exists. This is especially relevant for `AsyncSmtpTransport`: it currently executes all cleanup work on a background task spawned using the executor, with no way to block on said task; as such the only thing a user can do to (try to) ensure that all connections are closed when the program shuts down is to insert an arbitrary delay into the shutdown sequence, which is a hack at best. However, I've decided to limit the scope of this PR to just fixing the more "obvious" flaw with the synchronous pooling implementation, leaving such an API up for future implementation.