### PR TITLE
feat: add controlled shutdown methods

### DIFF
--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -143,9 +143,7 @@ pub trait Transport {
 
     /// Shuts down the transport. Future calls to [`send`] and [`send_raw`] might
     /// fail.
-    fn shutdown(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    fn shutdown(&self) {}
 }
 
 /// Async Transport method for emails
@@ -175,7 +173,5 @@ pub trait AsyncTransport {
 
     /// Shuts down the transport. Future calls to [`send`] and [`send_raw`] might
     /// fail.
-    async fn shutdown(&self) -> Result<(), Self::Error> {
-        Ok(())
-    }
+    async fn shutdown(&self) {}
 }

--- a/src/transport/mod.rs
+++ b/src/transport/mod.rs
@@ -140,6 +140,12 @@ pub trait Transport {
     }
 
     fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
+
+    /// Shuts down the transport. Future calls to [`send`] and [`send_raw`] might
+    /// fail.
+    fn shutdown(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }
 
 /// Async Transport method for emails
@@ -166,4 +172,10 @@ pub trait AsyncTransport {
     }
 
     async fn send_raw(&self, envelope: &Envelope, email: &[u8]) -> Result<Self::Ok, Self::Error>;
+
+    /// Shuts down the transport. Future calls to [`send`] and [`send_raw`] might
+    /// fail.
+    async fn shutdown(&self) -> Result<(), Self::Error> {
+        Ok(())
+    }
 }

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -80,11 +80,9 @@ impl AsyncTransport for AsyncSmtpTransport<Tokio1Executor> {
         Ok(result)
     }
 
-    async fn shutdown(&self) -> Result<(), Self::Error> {
+    async fn shutdown(&self) {
         #[cfg(feature = "pool")]
-        self.inner.shutdown().await?;
-
-        Ok(())
+        self.inner.shutdown().await;
     }
 }
 
@@ -105,11 +103,9 @@ impl AsyncTransport for AsyncSmtpTransport<AsyncStd1Executor> {
         Ok(result)
     }
 
-    async fn shutdown(&self) -> Result<(), Self::Error> {
+    async fn shutdown(&self) {
         #[cfg(feature = "pool")]
-        self.inner.shutdown().await?;
-
-        Ok(())
+        self.inner.shutdown().await;
     }
 }
 

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -79,6 +79,13 @@ impl AsyncTransport for AsyncSmtpTransport<Tokio1Executor> {
 
         Ok(result)
     }
+
+    async fn shutdown(&self) -> Result<(), Self::Error> {
+        #[cfg(feature = "pool")]
+        self.inner.shutdown().await?;
+
+        Ok(())
+    }
 }
 
 #[cfg(feature = "async-std1")]
@@ -96,6 +103,13 @@ impl AsyncTransport for AsyncSmtpTransport<AsyncStd1Executor> {
         conn.quit().await?;
 
         Ok(result)
+    }
+
+    async fn shutdown(&self) -> Result<(), Self::Error> {
+        #[cfg(feature = "pool")]
+        self.inner.shutdown().await?;
+
+        Ok(())
     }
 }
 

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -157,7 +157,7 @@ impl<E: Executor> Pool<E> {
         }
 
         if let Some(handle) = self.handle.get() {
-            handle.shutdown().await
+            handle.shutdown().await;
         }
     }
 

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::{self, Debug},
-    mem,
     ops::{Deref, DerefMut},
     sync::{Arc, OnceLock},
     time::{Duration, Instant},
@@ -15,11 +14,15 @@ use super::{
     super::{client::AsyncSmtpConnection, Error},
     PoolConfig,
 };
-use crate::{executor::SpawnHandle, transport::smtp::async_transport::AsyncSmtpClient, Executor};
+use crate::{
+    executor::SpawnHandle,
+    transport::smtp::{async_transport::AsyncSmtpClient, error},
+    Executor,
+};
 
 pub(crate) struct Pool<E: Executor> {
     config: PoolConfig,
-    connections: Mutex<Vec<ParkedConnection>>,
+    connections: Mutex<Option<Vec<ParkedConnection>>>,
     client: AsyncSmtpClient<E>,
     handle: OnceLock<E::Handle>,
 }
@@ -38,7 +41,7 @@ impl<E: Executor> Pool<E> {
     pub(crate) fn new(config: PoolConfig, client: AsyncSmtpClient<E>) -> Arc<Self> {
         let pool = Arc::new(Self {
             config,
-            connections: Mutex::new(Vec::new()),
+            connections: Mutex::new(Some(Vec::new())),
             client,
             handle: OnceLock::new(),
         });
@@ -60,6 +63,10 @@ impl<E: Executor> Pool<E> {
                             #[allow(clippy::needless_collect)]
                             let (count, dropped) = {
                                 let mut connections = pool.connections.lock().await;
+                                let Some(connections) = connections.as_mut() else {
+                                    // The transport was shut down
+                                    return;
+                                };
 
                                 let to_drop = connections
                                     .iter()
@@ -92,6 +99,11 @@ impl<E: Executor> Pool<E> {
                                 };
 
                                 let mut connections = pool.connections.lock().await;
+                                let Some(connections) = connections.as_mut() else {
+                                    // The transport was shut down
+                                    return;
+                                };
+
                                 connections.push(ParkedConnection::park(conn));
 
                                 #[cfg(feature = "tracing")]
@@ -134,10 +146,37 @@ impl<E: Executor> Pool<E> {
         pool
     }
 
+    pub(crate) async fn shutdown(&self) -> Result<(), Error> {
+        let connections = { self.connections.lock().await.take() };
+        let Some(connections) = connections else {
+            return Ok(());
+        };
+
+        // Return the first error we encounter, but still close all connections either way
+        let mut res = OnceLock::new();
+        let res_ref = &res;
+
+        stream::iter(connections)
+            .for_each_concurrent(8, |conn| async move {
+                let mut conn = conn.unpark();
+                if let Err(err) = conn.quit().await {
+                    conn.abort().await;
+                    _ = res_ref.set(Err(err));
+                }
+            })
+            .await;
+
+        res.take().unwrap_or(Ok(()))
+    }
+
     pub(crate) async fn connection(self: &Arc<Self>) -> Result<PooledConnection<E>, Error> {
         loop {
             let conn = {
                 let mut connections = self.connections.lock().await;
+                let Some(connections) = connections.as_mut() else {
+                    // The transport was shut down
+                    return Err(error::transport_shutdown());
+                };
                 connections.pop()
             };
 
@@ -181,13 +220,20 @@ impl<E: Executor> Pool<E> {
             #[cfg(feature = "tracing")]
             tracing::debug!("recycling connection");
 
-            let mut connections = self.connections.lock().await;
-            if connections.len() >= self.config.max_size as usize {
-                drop(connections);
-                conn.abort().await;
+            let mut connections_guard = self.connections.lock().await;
+
+            if let Some(connections) = connections_guard.as_mut() {
+                if connections.len() >= self.config.max_size as usize {
+                    drop(connections_guard);
+                    conn.abort().await;
+                } else {
+                    let conn = ParkedConnection::park(conn);
+                    connections.push(conn);
+                }
             } else {
-                let conn = ParkedConnection::park(conn);
-                connections.push(conn);
+                // The pool has already been shut down
+                drop(connections_guard);
+                conn.abort().await;
             }
         }
     }
@@ -200,7 +246,13 @@ impl<E: Executor> Debug for Pool<E> {
             .field(
                 "connections",
                 &match self.connections.try_lock() {
-                    Some(connections) => format!("{} connections", connections.len()),
+                    Some(connections) => {
+                        if let Some(connections) = connections.as_ref() {
+                            format!("{} connections", connections.len())
+                        } else {
+                            "SHUT DOWN".to_owned()
+                        }
+                    }
 
                     None => "LOCKED".to_owned(),
                 },
@@ -222,14 +274,16 @@ impl<E: Executor> Drop for Pool<E> {
         #[cfg(feature = "tracing")]
         tracing::debug!("dropping Pool");
 
-        let connections = mem::take(self.connections.get_mut());
+        let connections = self.connections.get_mut().take();
         let handle = self.handle.take();
         E::spawn(async move {
             if let Some(handle) = handle {
                 handle.shutdown().await;
             }
 
-            abort_concurrent(connections.into_iter().map(ParkedConnection::unpark)).await;
+            if let Some(connections) = connections {
+                abort_concurrent(connections.into_iter().map(ParkedConnection::unpark)).await;
+            }
         });
     }
 }

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -155,6 +155,10 @@ impl<E: Executor> Pool<E> {
                 })
                 .await;
         }
+
+        if let Some(handle) = self.handle.get() {
+            handle.shutdown().await
+        }
     }
 
     pub(crate) async fn connection(self: &Arc<Self>) -> Result<PooledConnection<E>, Error> {

--- a/src/transport/smtp/pool/sync_impl.rs
+++ b/src/transport/smtp/pool/sync_impl.rs
@@ -1,6 +1,5 @@
 use std::{
     fmt::{self, Debug},
-    mem,
     ops::{Deref, DerefMut},
     sync::{Arc, Mutex, TryLockError},
     thread,
@@ -11,11 +10,11 @@ use super::{
     super::{client::SmtpConnection, Error},
     PoolConfig,
 };
-use crate::transport::smtp::transport::SmtpClient;
+use crate::transport::smtp::{error, transport::SmtpClient};
 
 pub(crate) struct Pool {
     config: PoolConfig,
-    connections: Mutex<Vec<ParkedConnection>>,
+    connections: Mutex<Option<Vec<ParkedConnection>>>,
     client: SmtpClient,
 }
 
@@ -33,7 +32,7 @@ impl Pool {
     pub(crate) fn new(config: PoolConfig, client: SmtpClient) -> Arc<Self> {
         let pool = Arc::new(Self {
             config,
-            connections: Mutex::new(Vec::new()),
+            connections: Mutex::new(Some(Vec::new())),
             client,
         });
 
@@ -54,6 +53,10 @@ impl Pool {
                         #[allow(clippy::needless_collect)]
                         let (count, dropped) = {
                             let mut connections = pool.connections.lock().unwrap();
+                            let Some(connections) = connections.as_mut() else {
+                                // The transport was shut down
+                                return;
+                            };
 
                             let to_drop = connections
                                 .iter()
@@ -86,6 +89,11 @@ impl Pool {
                             };
 
                             let mut connections = pool.connections.lock().unwrap();
+                            let Some(connections) = connections.as_mut() else {
+                                // The transport was shut down
+                                return;
+                            };
+
                             connections.push(ParkedConnection::park(conn));
 
                             #[cfg(feature = "tracing")]
@@ -119,10 +127,35 @@ impl Pool {
         pool
     }
 
+    pub(crate) fn shutdown(&self) -> Result<(), Error> {
+        let connections = { self.connections.lock().unwrap().take() };
+        let Some(connections) = connections else {
+            return Ok(());
+        };
+
+        // Return the first error we encounter, but still close all connections either way
+        let mut res = Ok(());
+        for conn in connections {
+            let mut conn = conn.unpark();
+            if let Err(err) = conn.quit() {
+                conn.abort();
+
+                if res.is_ok() {
+                    res = Err(err);
+                }
+            }
+        }
+        res
+    }
+
     pub(crate) fn connection(self: &Arc<Self>) -> Result<PooledConnection, Error> {
         loop {
             let conn = {
                 let mut connections = self.connections.lock().unwrap();
+                let Some(connections) = connections.as_mut() else {
+                    // The transport was shut down
+                    return Err(error::transport_shutdown());
+                };
                 connections.pop()
             };
 
@@ -166,13 +199,20 @@ impl Pool {
             #[cfg(feature = "tracing")]
             tracing::debug!("recycling connection");
 
-            let mut connections = self.connections.lock().unwrap();
-            if connections.len() >= self.config.max_size as usize {
-                drop(connections);
-                conn.abort();
+            let mut connections_guard = self.connections.lock().unwrap();
+
+            if let Some(connections) = connections_guard.as_mut() {
+                if connections.len() >= self.config.max_size as usize {
+                    drop(connections_guard);
+                    conn.abort();
+                } else {
+                    let conn = ParkedConnection::park(conn);
+                    connections.push(conn);
+                }
             } else {
-                let conn = ParkedConnection::park(conn);
-                connections.push(conn);
+                // The pool has already been shut down
+                drop(connections_guard);
+                conn.abort();
             }
         }
     }
@@ -185,7 +225,13 @@ impl Debug for Pool {
             .field(
                 "connections",
                 &match self.connections.try_lock() {
-                    Ok(connections) => format!("{} connections", connections.len()),
+                    Ok(connections) => {
+                        if let Some(connections) = connections.as_ref() {
+                            format!("{} connections", connections.len())
+                        } else {
+                            "SHUT DOWN".to_owned()
+                        }
+                    }
 
                     Err(TryLockError::WouldBlock) => "LOCKED".to_owned(),
                     Err(TryLockError::Poisoned(_)) => "POISONED".to_owned(),
@@ -201,10 +247,11 @@ impl Drop for Pool {
         #[cfg(feature = "tracing")]
         tracing::debug!("dropping Pool");
 
-        let connections = mem::take(&mut *self.connections.get_mut().unwrap());
-        for conn in connections {
-            let mut conn = conn.unpark();
-            conn.abort();
+        if let Some(connections) = self.connections.get_mut().unwrap().take() {
+            for conn in connections {
+                let mut conn = conn.unpark();
+                conn.abort();
+            }
         }
     }
 }

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -61,11 +61,9 @@ impl Transport for SmtpTransport {
         Ok(result)
     }
 
-    fn shutdown(&self) -> Result<(), Self::Error> {
+    fn shutdown(&self) {
         #[cfg(feature = "pool")]
-        self.inner.shutdown()?;
-
-        Ok(())
+        self.inner.shutdown();
     }
 }
 

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -60,6 +60,13 @@ impl Transport for SmtpTransport {
 
         Ok(result)
     }
+
+    fn shutdown(&self) -> Result<(), Self::Error> {
+        #[cfg(feature = "pool")]
+        self.inner.shutdown()?;
+
+        Ok(())
+    }
 }
 
 impl Debug for SmtpTransport {


### PR DESCRIPTION
See prior discussion in #1041. This PR adds an `(async) fn shutdown(&self) -> Result<()>` method to the `(Async)Transport` traits which can be used to shut down the transport in a controlled manner. Currently, these are only implemented for the SMTP transports when the pool feature is enabled, since otherwise there's nothing to shut down. For these transports, `send_raw` will return an error after the transport has been shut down, however other transports will continue to function after a shutdown, since their shutdowns are simple noops (this could be changed to be more consistent by adding a shutdown flag to all transports, but I've decided not to do this for the initial PR).