### PR TITLE
feat: make crypto and TLS certificate verify backends opt-in

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,12 +57,12 @@ jobs:
 
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
-      
+
       - name: Install cargo hack
         run: cargo install cargo-hack --debug
 
       - name: Check with cargo hack
-        run: cargo hack check --feature-powerset --depth 3
+        run: cargo hack check --feature-powerset --depth 3 --at-least-one-of aws-lc-rs,ring --at-least-one-of rustls-native-certs,webpki-roots
 
   test:
     name: test / ${{ matrix.name }}
@@ -90,7 +90,7 @@ jobs:
       - name: Setup cache
         uses: Swatinem/rust-cache@v2
 
-      - name: Install postfix  
+      - name: Install postfix
         run: |
           DEBIAN_FRONTEND=noninteractive sudo apt-get update
           DEBIAN_FRONTEND=noninteractive sudo apt-get -y install postfix
@@ -120,7 +120,7 @@ jobs:
 
       - name: Test with all features (-native-tls)
         run: cargo test --no-default-features --features async-std1,async-std1-rustls-tls,boring-tls,builder,dkim,file-transport,file-transport-envelope,hostname,mime03,pool,rustls-native-certs,rustls-tls,sendmail-transport,smtp-transport,tokio1,tokio1-boring-tls,tokio1-rustls-tls,tracing
-  
+
       - name: Test with all features (-boring-tls)
         run: cargo test --no-default-features --features async-std1,async-std1-rustls-tls,builder,dkim,file-transport,file-transport-envelope,hostname,mime03,native-tls,pool,rustls-native-certs,rustls-tls,sendmail-transport,smtp-transport,tokio1,tokio1-native-tls,tokio1-rustls-tls,tracing
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,11 +242,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-fips-sys"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29003a681b2b9465c1139bfb726da452a841a8b025f35953f3bce71139f10b21"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "paste",
+ "regex",
+]
+
+[[package]]
 name = "aws-lc-rs"
 version = "1.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
 dependencies = [
+ "aws-lc-fips-sys",
  "aws-lc-sys",
  "paste",
  "zeroize",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd755adf9707cf671e31d944a189be3deaaeee11c8bc1d669bb8022ac90fbd0"
+dependencies = [
+ "aws-lc-sys",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9dd2e03ee80ca2822dd6ea431163d2ef259f2066a4d6ccaca6d9dcb386aa43"
+dependencies = [
+ "bindgen 0.69.5",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "paste",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -267,6 +292,29 @@ name = "base64ct"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c3c1a368f70d6cf7302d78f8f7093da241fb8e8807c05cc9e51a125895a6d5b"
+
+[[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.10.5",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.89",
+ "which",
+]
 
 [[package]]
 name = "bindgen"
@@ -335,7 +383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "777cf31ea10f7eb87d46b30848f8d7acbd65cb4a25cd51bee1808ef601de0416"
 dependencies = [
  "autocfg",
- "bindgen",
+ "bindgen 0.70.1",
  "cmake",
  "fs_extra",
  "fslock",
@@ -371,6 +419,8 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
 dependencies = [
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -663,6 +713,12 @@ dependencies = [
  "quote",
  "syn 2.0.89",
 ]
+
+[[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
 name = "ed25519"
@@ -970,6 +1026,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "hostname"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1161,6 +1226,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
+name = "jobserver"
+version = "0.1.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,6 +1260,12 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 dependencies = [
  "spin",
 ]
+
+[[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
@@ -1510,6 +1590,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1634,6 +1720,16 @@ checksum = "3ae130e2f271fbc2ac3a40fb1d07180839cdbbe443c7a27e1e3c13c5cac0116d"
 dependencies = [
  "diff",
  "yansi",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.89",
 ]
 
 [[package]]
@@ -1845,6 +1941,7 @@ version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1878,6 +1975,7 @@ version = "0.102.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2458,6 +2556,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,12 +60,12 @@ async-trait = { version = "0.1", optional = true }
 
 ## async-std
 async-std = { version = "1.8", optional = true }
-futures-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
+futures-rustls = { version = "0.26", default-features = false, features = ["logging", "tls12"], optional = true }
 
 ## tokio
 tokio1_crate = { package = "tokio", version = "1", optional = true }
 tokio1_native_tls_crate = { package = "tokio-native-tls", version = "0.3", optional = true }
-tokio1_rustls = { package = "tokio-rustls", version = "0.26", default-features = false, features = ["logging", "tls12", "ring"], optional = true }
+tokio1_rustls = { package = "tokio-rustls", version = "0.26", default-features = false, features = ["logging", "tls12"], optional = true }
 tokio1_boring = { package = "tokio-boring", version = "4", optional = true }
 
 ## dkim

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -111,6 +111,7 @@ pool = ["dep:futures-util"]
 
 rustls = ["dep:rustls"]
 aws-lc-rs = ["rustls?/aws-lc-rs"]
+fips = ["aws-lc-rs", "rustls?/fips"]
 ring = ["rustls?/ring"]
 webpki-roots = ["dep:webpki-roots"]
 # deprecated

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ percent-encoding = { version = "2.3", optional = true }
 
 ## tls
 native-tls = { version = "0.2.9", optional = true } # feature
-rustls = { version = "0.23.5", default-features = false, features = ["ring", "logging", "std", "tls12"], optional = true }
+rustls = { version = "0.23.5", default-features = false, features = ["logging", "std", "tls12"], optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 webpki-roots = { version = "0.26", optional = true }
 boring = { version = "4", optional = true }
@@ -109,16 +109,25 @@ smtp-transport = ["dep:base64", "dep:nom", "dep:socket2", "dep:url", "dep:percen
 
 pool = ["dep:futures-util"]
 
-rustls-tls = ["dep:webpki-roots", "dep:rustls"]
+rustls = ["dep:rustls"]
+aws-lc-rs = ["rustls?/aws-lc-rs"]
+ring = ["rustls?/ring"]
+webpki-roots = ["dep:webpki-roots"]
+# deprecated
+rustls-tls = ["webpki-roots", "rustls", "ring"]
 
 boring-tls = ["dep:boring"]
 
 # async
 async-std1 = ["dep:async-std", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
-async-std1-rustls-tls = ["async-std1", "rustls-tls", "dep:futures-rustls"]
+async-std1-rustls = ["async-std1", "rustls", "dep:futures-rustls"]
+# deprecated
+async-std1-rustls-tls = ["async-std1-rustls", "rustls-tls"]
 tokio1 = ["dep:tokio1_crate", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "dep:tokio1_native_tls_crate"]
-tokio1-rustls-tls = ["tokio1", "rustls-tls", "dep:tokio1_rustls"]
+tokio1-rustls = ["tokio1", "rustls", "dep:tokio1_rustls"]
+# deprecated
+tokio1-rustls-tls = ["tokio1-rustls", "rustls-tls"]
 tokio1-boring-tls = ["tokio1", "boring-tls", "dep:tokio1_boring"]
 
 dkim = ["dep:base64", "dep:sha2", "dep:rsa", "dep:ed25519-dalek"]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -133,7 +133,7 @@ impl Executor for Tokio1Executor {
     ) -> Result<AsyncSmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match tls {
-            #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
+            #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls"))]
             Tls::Wrapper(tls_parameters) => Some(tls_parameters.clone()),
             _ => None,
         };
@@ -147,7 +147,7 @@ impl Executor for Tokio1Executor {
         )
         .await?;
 
-        #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls-tls"))]
+        #[cfg(any(feature = "tokio1-native-tls", feature = "tokio1-rustls"))]
         match tls {
             Tls::Opportunistic(tls_parameters) => {
                 if conn.can_starttls() {
@@ -230,7 +230,7 @@ impl Executor for AsyncStd1Executor {
     ) -> Result<AsyncSmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match tls {
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             Tls::Wrapper(tls_parameters) => Some(tls_parameters.clone()),
             _ => None,
         };
@@ -243,7 +243,7 @@ impl Executor for AsyncStd1Executor {
         )
         .await?;
 
-        #[cfg(feature = "async-std1-rustls-tls")]
+        #[cfg(feature = "async-std1-rustls")]
         match tls {
             Tls::Opportunistic(tls_parameters) => {
                 if conn.can_starttls() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,8 +66,6 @@
 //!
 //! _Secure SMTP connections using TLS from the `rustls` crate_
 //!
-//! Rustls uses [ring] as the cryptography implementation. As a result, [not all Rust's targets are supported][ring-support].
-//!
 //! * **rustls**: TLS support for the synchronous version of the API
 //! * **tokio1-rustls**: TLS support for the `tokio1` async version of the API
 //! * **async-std1-rustls**: TLS support for the `async-std1` async version of the API
@@ -79,7 +77,7 @@
 //! When the `rustls` feature is enabled, one of the following crypto backends MUST also
 //! be enabled.
 //!
-//! * **aws-lc-rs**: use `aws-lc-rs` as the `rustls` crypto backend
+//! * **aws-lc-rs**: use AWS-LC (via `aws-lc-rs`) as the `rustls` crypto backend
 //! * **ring**: use `ring` as the `rustls` crypto backend
 //!
 //! ##### rustls certificate verification backend
@@ -98,8 +96,8 @@
 //!
 //! | Distro       | Build-time packages        | Runtime packages             |
 //! | ------------ | -------------------------- | ---------------------------- |
-//! | Debian       | `pkg-config`, `libssl-dev` | `libssl3`, `ca-certificates` |
-//! | Alpine Linux | `pkgconf`, `openssl-dev`   | `libssl3`, `ca-certificates` |
+//! | Debian       | none                       | `ca-certificates`            |
+//! | Alpine Linux | none                       | `ca-certificates`            |
 //!
 //! ### Sendmail transport
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,9 @@
 //! When enabling `aws-lc-rs`, the `fips` feature can also be enabled to have
 //! rustls use the FIPS certified module of AWS-LC.
 //!
+//! `aws-lc-rs` may require cmake on some platforms to compile.
+//! `fips` always requires cmake and the Go compiler to compile.
+//!
 //! ##### rustls certificate verification backend
 //!
 //! _The TLS certificate verification backend to use with rustls_

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,9 @@
 //! * **aws-lc-rs**: use AWS-LC (via `aws-lc-rs`) as the `rustls` crypto backend
 //! * **ring**: use `ring` as the `rustls` crypto backend
 //!
+//! When enabling `aws-lc-rs`, the `fips` feature can also be enabled to have
+//! rustls use the FIPS certified module of AWS-LC.
+//!
 //! ##### rustls certificate verification backend
 //!
 //! _The TLS certificate verification backend to use with rustls_

--- a/src/rustls_crypto.rs
+++ b/src/rustls_crypto.rs
@@ -1,0 +1,4 @@
+#[cfg(feature = "aws-lc-rs")]
+pub(crate) use rustls::crypto::aws_lc_rs::default_provider as crypto_provider;
+#[cfg(not(feature = "aws-lc-rs"))]
+pub(crate) use rustls::crypto::ring::default_provider as crypto_provider;

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -14,8 +14,8 @@ use super::pool::async_impl::Pool;
 use super::PoolConfig;
 #[cfg(any(
     feature = "tokio1-native-tls",
-    feature = "tokio1-rustls-tls",
-    feature = "async-std1-rustls-tls"
+    feature = "tokio1-rustls",
+    feature = "async-std1-rustls"
 ))]
 use super::Tls;
 use super::{
@@ -111,15 +111,15 @@ where
     /// to validate TLS certificates.
     #[cfg(any(
         feature = "tokio1-native-tls",
-        feature = "tokio1-rustls-tls",
-        feature = "async-std1-rustls-tls"
+        feature = "tokio1-rustls",
+        feature = "async-std1-rustls"
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(any(
             feature = "tokio1-native-tls",
-            feature = "tokio1-rustls-tls",
-            feature = "async-std1-rustls-tls"
+            feature = "tokio1-rustls",
+            feature = "async-std1-rustls"
         )))
     )]
     pub fn relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
@@ -145,15 +145,15 @@ where
     /// or emails will be sent to the server, protecting from downgrade attacks.
     #[cfg(any(
         feature = "tokio1-native-tls",
-        feature = "tokio1-rustls-tls",
-        feature = "async-std1-rustls-tls"
+        feature = "tokio1-rustls",
+        feature = "async-std1-rustls"
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(any(
             feature = "tokio1-native-tls",
-            feature = "tokio1-rustls-tls",
-            feature = "async-std1-rustls-tls"
+            feature = "tokio1-rustls",
+            feature = "async-std1-rustls"
         )))
     )]
     pub fn starttls_relay(relay: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
@@ -288,10 +288,10 @@ where
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn from_url(connection_url: &str) -> Result<AsyncSmtpTransportBuilder, Error> {
         super::connection_url::from_connection_url(connection_url)
@@ -416,15 +416,15 @@ impl AsyncSmtpTransportBuilder {
     /// lead to hard to debug IO errors coming from the TLS library.
     #[cfg(any(
         feature = "tokio1-native-tls",
-        feature = "tokio1-rustls-tls",
-        feature = "async-std1-rustls-tls"
+        feature = "tokio1-rustls",
+        feature = "async-std1-rustls"
     ))]
     #[cfg_attr(
         docsrs,
         doc(cfg(any(
             feature = "tokio1-native-tls",
-            feature = "tokio1-rustls-tls",
-            feature = "async-std1-rustls-tls"
+            feature = "tokio1-rustls",
+            feature = "async-std1-rustls"
         )))
     )]
     pub fn tls(mut self, tls: Tls) -> Self {

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -368,7 +368,7 @@ impl AsyncSmtpConnection {
     }
 
     /// The X509 certificate of the server (DER encoded)
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
         self.stream.get_ref().peer_certificate()
     }
@@ -390,7 +390,7 @@ impl AsyncSmtpConnection {
     }
 
     /// All the X509 certificates of the chain (DER encoded)
-    #[cfg(any(feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "rustls", feature = "boring-tls"))]
     pub fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, Error> {
         self.stream.get_ref().certificate_chain()
     }

--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -12,9 +12,9 @@ use futures_io::{
     AsyncRead as FuturesAsyncRead, AsyncWrite as FuturesAsyncWrite, Error as IoError, ErrorKind,
     Result as IoResult,
 };
-#[cfg(feature = "async-std1-rustls-tls")]
+#[cfg(feature = "async-std1-rustls")]
 use futures_rustls::client::TlsStream as AsyncStd1RustlsTlsStream;
-#[cfg(any(feature = "tokio1-rustls-tls", feature = "async-std1-rustls-tls"))]
+#[cfg(any(feature = "tokio1-rustls", feature = "async-std1-rustls"))]
 use rustls::pki_types::ServerName;
 #[cfg(feature = "tokio1-boring-tls")]
 use tokio1_boring::SslStream as Tokio1SslStream;
@@ -27,14 +27,14 @@ use tokio1_crate::net::{
 };
 #[cfg(feature = "tokio1-native-tls")]
 use tokio1_native_tls_crate::TlsStream as Tokio1TlsStream;
-#[cfg(feature = "tokio1-rustls-tls")]
+#[cfg(feature = "tokio1-rustls")]
 use tokio1_rustls::client::TlsStream as Tokio1RustlsTlsStream;
 
 #[cfg(any(
     feature = "tokio1-native-tls",
-    feature = "tokio1-rustls-tls",
+    feature = "tokio1-rustls",
     feature = "tokio1-boring-tls",
-    feature = "async-std1-rustls-tls"
+    feature = "async-std1-rustls"
 ))]
 use super::InnerTlsParameters;
 use super::TlsParameters;
@@ -74,7 +74,7 @@ enum InnerAsyncNetworkStream {
     #[cfg(feature = "tokio1-native-tls")]
     Tokio1NativeTls(Tokio1TlsStream<Box<dyn AsyncTokioStream>>),
     /// Encrypted Tokio 1.x TCP stream
-    #[cfg(feature = "tokio1-rustls-tls")]
+    #[cfg(feature = "tokio1-rustls")]
     Tokio1RustlsTls(Tokio1RustlsTlsStream<Box<dyn AsyncTokioStream>>),
     /// Encrypted Tokio 1.x TCP stream
     #[cfg(feature = "tokio1-boring-tls")]
@@ -83,7 +83,7 @@ enum InnerAsyncNetworkStream {
     #[cfg(feature = "async-std1")]
     AsyncStd1Tcp(AsyncStd1TcpStream),
     /// Encrypted Tokio 1.x TCP stream
-    #[cfg(feature = "async-std1-rustls-tls")]
+    #[cfg(feature = "async-std1-rustls")]
     AsyncStd1RustlsTls(AsyncStd1RustlsTlsStream<AsyncStd1TcpStream>),
     /// Can't be built
     None,
@@ -107,13 +107,13 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio1NativeTls(s) => {
                 s.get_ref().get_ref().get_ref().peer_addr()
             }
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(s) => s.get_ref().0.peer_addr(),
             #[cfg(feature = "tokio1-boring-tls")]
             InnerAsyncNetworkStream::Tokio1BoringTls(s) => s.get_ref().peer_addr(),
             #[cfg(feature = "async-std1")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(s) => s.peer_addr(),
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(s) => s.get_ref().0.peer_addr(),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
@@ -253,18 +253,18 @@ impl AsyncNetworkStream {
                 feature = "tokio1",
                 not(any(
                     feature = "tokio1-native-tls",
-                    feature = "tokio1-rustls-tls",
+                    feature = "tokio1-rustls",
                     feature = "tokio1-boring-tls"
                 ))
             ))]
             InnerAsyncNetworkStream::Tokio1Tcp(_) => {
                 let _ = tls_parameters;
-                panic!("Trying to upgrade an AsyncNetworkStream without having enabled either the tokio1-native-tls or the tokio1-rustls-tls feature");
+                panic!("Trying to upgrade an AsyncNetworkStream without having enabled either the tokio1-native-tls or the tokio1-rustls feature");
             }
 
             #[cfg(any(
                 feature = "tokio1-native-tls",
-                feature = "tokio1-rustls-tls",
+                feature = "tokio1-rustls",
                 feature = "tokio1-boring-tls"
             ))]
             InnerAsyncNetworkStream::Tokio1Tcp(_) => {
@@ -279,13 +279,13 @@ impl AsyncNetworkStream {
                     .map_err(error::connection)?;
                 Ok(())
             }
-            #[cfg(all(feature = "async-std1", not(feature = "async-std1-rustls-tls")))]
+            #[cfg(all(feature = "async-std1", not(feature = "async-std1-rustls")))]
             InnerAsyncNetworkStream::AsyncStd1Tcp(_) => {
                 let _ = tls_parameters;
-                panic!("Trying to upgrade an AsyncNetworkStream without having enabled the async-std1-rustls-tls feature");
+                panic!("Trying to upgrade an AsyncNetworkStream without having enabled the async-std1-rustls feature");
             }
 
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(_) => {
                 // get owned TcpStream
                 let tcp_stream = mem::replace(&mut self.inner, InnerAsyncNetworkStream::None);
@@ -305,7 +305,7 @@ impl AsyncNetworkStream {
     #[allow(unused_variables)]
     #[cfg(any(
         feature = "tokio1-native-tls",
-        feature = "tokio1-rustls-tls",
+        feature = "tokio1-rustls",
         feature = "tokio1-boring-tls"
     ))]
     async fn upgrade_tokio1_tls(
@@ -332,12 +332,12 @@ impl AsyncNetworkStream {
                     Ok(InnerAsyncNetworkStream::Tokio1NativeTls(stream))
                 };
             }
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "rustls")]
             InnerTlsParameters::RustlsTls(config) => {
-                #[cfg(not(feature = "tokio1-rustls-tls"))]
-                panic!("built without the tokio1-rustls-tls feature");
+                #[cfg(not(feature = "tokio1-rustls"))]
+                panic!("built without the tokio1-rustls feature");
 
-                #[cfg(feature = "tokio1-rustls-tls")]
+                #[cfg(feature = "tokio1-rustls")]
                 return {
                     use tokio1_rustls::TlsConnector;
 
@@ -372,7 +372,7 @@ impl AsyncNetworkStream {
     }
 
     #[allow(unused_variables)]
-    #[cfg(feature = "async-std1-rustls-tls")]
+    #[cfg(feature = "async-std1-rustls")]
     async fn upgrade_asyncstd1_tls(
         tcp_stream: AsyncStd1TcpStream,
         mut tls_parameters: TlsParameters,
@@ -384,12 +384,12 @@ impl AsyncNetworkStream {
             InnerTlsParameters::NativeTls(connector) => {
                 panic!("native-tls isn't supported with async-std yet. See https://github.com/lettre/lettre/pull/531#issuecomment-757893531");
             }
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "rustls")]
             InnerTlsParameters::RustlsTls(config) => {
-                #[cfg(not(feature = "async-std1-rustls-tls"))]
-                panic!("built without the async-std1-rustls-tls feature");
+                #[cfg(not(feature = "async-std1-rustls"))]
+                panic!("built without the async-std1-rustls feature");
 
-                #[cfg(feature = "async-std1-rustls-tls")]
+                #[cfg(feature = "async-std1-rustls")]
                 return {
                     use futures_rustls::TlsConnector;
 
@@ -417,13 +417,13 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio1Tcp(_) => false,
             #[cfg(feature = "tokio1-native-tls")]
             InnerAsyncNetworkStream::Tokio1NativeTls(_) => true,
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(_) => true,
             #[cfg(feature = "tokio1-boring-tls")]
             InnerAsyncNetworkStream::Tokio1BoringTls(_) => true,
             #[cfg(feature = "async-std1")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(_) => false,
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(_) => true,
             InnerAsyncNetworkStream::None => false,
         }
@@ -438,7 +438,7 @@ impl AsyncNetworkStream {
             }
             #[cfg(feature = "tokio1-native-tls")]
             InnerAsyncNetworkStream::Tokio1NativeTls(_) => panic!("Unsupported"),
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(_) => panic!("Unsupported"),
             #[cfg(feature = "tokio1-boring-tls")]
             InnerAsyncNetworkStream::Tokio1BoringTls(stream) => {
@@ -448,7 +448,7 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::AsyncStd1Tcp(_) => {
                 Err(error::client("Connection is not encrypted"))
             }
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(_) => panic!("Unsupported"),
             InnerAsyncNetworkStream::None => panic!("InnerNetworkStream::None must never be built"),
         }
@@ -461,7 +461,7 @@ impl AsyncNetworkStream {
             }
             #[cfg(feature = "tokio1-native-tls")]
             InnerAsyncNetworkStream::Tokio1NativeTls(_) => panic!("Unsupported"),
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(stream) => Ok(stream
                 .get_ref()
                 .1
@@ -482,7 +482,7 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::AsyncStd1Tcp(_) => {
                 Err(error::client("Connection is not encrypted"))
             }
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(stream) => Ok(stream
                 .get_ref()
                 .1
@@ -509,7 +509,7 @@ impl AsyncNetworkStream {
                 .unwrap()
                 .to_der()
                 .map_err(error::tls)?),
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(stream) => Ok(stream
                 .get_ref()
                 .1
@@ -529,7 +529,7 @@ impl AsyncNetworkStream {
             InnerAsyncNetworkStream::AsyncStd1Tcp(_) => {
                 Err(error::client("Connection is not encrypted"))
             }
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(stream) => Ok(stream
                 .get_ref()
                 .1
@@ -568,7 +568,7 @@ impl FuturesAsyncRead for AsyncNetworkStream {
                     Poll::Pending => Poll::Pending,
                 }
             }
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(s) => {
                 let mut b = Tokio1ReadBuf::new(buf);
                 match Pin::new(s).poll_read(cx, &mut b) {
@@ -588,7 +588,7 @@ impl FuturesAsyncRead for AsyncNetworkStream {
             }
             #[cfg(feature = "async-std1")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(s) => Pin::new(s).poll_read(cx, buf),
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(s) => Pin::new(s).poll_read(cx, buf),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
@@ -609,13 +609,13 @@ impl FuturesAsyncWrite for AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio1Tcp(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(feature = "tokio1-native-tls")]
             InnerAsyncNetworkStream::Tokio1NativeTls(s) => Pin::new(s).poll_write(cx, buf),
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(feature = "tokio1-boring-tls")]
             InnerAsyncNetworkStream::Tokio1BoringTls(s) => Pin::new(s).poll_write(cx, buf),
             #[cfg(feature = "async-std1")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(s) => Pin::new(s).poll_write(cx, buf),
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(s) => Pin::new(s).poll_write(cx, buf),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
@@ -630,13 +630,13 @@ impl FuturesAsyncWrite for AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio1Tcp(s) => Pin::new(s).poll_flush(cx),
             #[cfg(feature = "tokio1-native-tls")]
             InnerAsyncNetworkStream::Tokio1NativeTls(s) => Pin::new(s).poll_flush(cx),
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(s) => Pin::new(s).poll_flush(cx),
             #[cfg(feature = "tokio1-boring-tls")]
             InnerAsyncNetworkStream::Tokio1BoringTls(s) => Pin::new(s).poll_flush(cx),
             #[cfg(feature = "async-std1")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(s) => Pin::new(s).poll_flush(cx),
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(s) => Pin::new(s).poll_flush(cx),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
@@ -651,13 +651,13 @@ impl FuturesAsyncWrite for AsyncNetworkStream {
             InnerAsyncNetworkStream::Tokio1Tcp(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(feature = "tokio1-native-tls")]
             InnerAsyncNetworkStream::Tokio1NativeTls(s) => Pin::new(s).poll_shutdown(cx),
-            #[cfg(feature = "tokio1-rustls-tls")]
+            #[cfg(feature = "tokio1-rustls")]
             InnerAsyncNetworkStream::Tokio1RustlsTls(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(feature = "tokio1-boring-tls")]
             InnerAsyncNetworkStream::Tokio1BoringTls(s) => Pin::new(s).poll_shutdown(cx),
             #[cfg(feature = "async-std1")]
             InnerAsyncNetworkStream::AsyncStd1Tcp(s) => Pin::new(s).poll_close(cx),
-            #[cfg(feature = "async-std1-rustls-tls")]
+            #[cfg(feature = "async-std1-rustls")]
             InnerAsyncNetworkStream::AsyncStd1RustlsTls(s) => Pin::new(s).poll_close(cx),
             InnerAsyncNetworkStream::None => {
                 debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -143,7 +143,7 @@ impl SmtpConnection {
         hello_name: &ClientId,
     ) -> Result<(), Error> {
         if self.server_info.supports_feature(Extension::StartTls) {
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             {
                 try_smtp!(self.command(Starttls), self);
                 self.stream.get_mut().upgrade_tls(tls_parameters)?;
@@ -153,11 +153,7 @@ impl SmtpConnection {
                 try_smtp!(self.ehlo(hello_name), self);
                 Ok(())
             }
-            #[cfg(not(any(
-                feature = "native-tls",
-                feature = "rustls-tls",
-                feature = "boring-tls"
-            )))]
+            #[cfg(not(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))]
             // This should never happen as `Tls` can only be created
             // when a TLS library is enabled
             unreachable!("TLS support required but not supported");
@@ -303,7 +299,7 @@ impl SmtpConnection {
     }
 
     /// The X509 certificate of the server (DER encoded)
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     pub fn peer_certificate(&self) -> Result<Vec<u8>, Error> {
         self.stream.get_ref().peer_certificate()
     }
@@ -325,7 +321,7 @@ impl SmtpConnection {
     }
 
     /// All the X509 certificates of the chain (DER encoded)
-    #[cfg(any(feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "rustls", feature = "boring-tls"))]
     pub fn certificate_chain(&self) -> Result<Vec<Vec<u8>>, Error> {
         self.stream.get_ref().certificate_chain()
     }

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -32,9 +32,9 @@ pub use self::async_net::AsyncNetworkStream;
 #[cfg(feature = "tokio1")]
 pub use self::async_net::AsyncTokioStream;
 use self::net::NetworkStream;
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 pub(super) use self::tls::InnerTlsParameters;
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 pub use self::tls::TlsVersion;
 pub use self::{
     connection::SmtpConnection,

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -1,5 +1,5 @@
 use std::fmt::{self, Debug};
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "rustls")]
 use std::sync::Arc;
 
 #[cfg(feature = "boring-tls")]
@@ -10,7 +10,7 @@ use boring::{
 };
 #[cfg(feature = "native-tls")]
 use native_tls::{Protocol, TlsConnector};
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "rustls")]
 use rustls::{
     client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier},
     crypto::WebPkiSupportedAlgorithms,
@@ -20,13 +20,13 @@ use rustls::{
     ClientConfig, DigitallySignedStruct, Error as TlsError, RootCertStore, SignatureScheme,
 };
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 use crate::transport::smtp::{error, Error};
 
 /// TLS protocol versions.
 #[derive(Debug, Copy, Clone)]
 #[non_exhaustive]
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 pub enum TlsVersion {
     /// TLS 1.0
     ///
@@ -86,10 +86,10 @@ pub enum Tls {
     ///
     /// Warning: A malicious intermediary could intercept the `STARTTLS` flag,
     /// causing lettre to believe the server only supports plaintext connections.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     Opportunistic(TlsParameters),
     /// Begin with a plaintext connection and require `STARTTLS` for security.
@@ -101,10 +101,10 @@ pub enum Tls {
     /// Unlike [`Tls::Opportunistic`], this option is secure against MITM attacks.
     /// For optimal security and performance, consider using [`Tls::Wrapper`] instead,
     /// as it requires fewer roundtrips to establish a secure connection.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     Required(TlsParameters),
     /// Establish a connection wrapped in TLS from the start.
@@ -114,10 +114,10 @@ pub enum Tls {
     /// transmitting any sensitive data.
     ///
     /// This is the fastest and most secure option for establishing a connection.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     Wrapper(TlsParameters),
 }
@@ -126,11 +126,11 @@ impl Debug for Tls {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match &self {
             Self::None => f.pad("None"),
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             Self::Opportunistic(_) => f.pad("Opportunistic"),
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             Self::Required(_) => f.pad("Required"),
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             Self::Wrapper(_) => f.pad("Wrapper"),
         }
     }
@@ -154,7 +154,7 @@ pub enum CertificateStore {
     /// Use a hardcoded set of Mozilla roots via the `webpki-roots` crate.
     ///
     /// This option is only available in the rustls backend.
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(all(feature = "rustls", feature = "webpki-roots"))]
     WebpkiRoots,
     /// Don't use any system certificates.
     None,
@@ -179,7 +179,7 @@ pub struct TlsParametersBuilder {
     identity: Option<Identity>,
     accept_invalid_hostnames: bool,
     accept_invalid_certs: bool,
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     min_tls_version: TlsVersion,
 }
 
@@ -193,7 +193,7 @@ impl TlsParametersBuilder {
             identity: None,
             accept_invalid_hostnames: false,
             accept_invalid_certs: false,
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             min_tls_version: TlsVersion::Tlsv12,
         }
     }
@@ -231,10 +231,10 @@ impl TlsParametersBuilder {
     /// including those from other sites, are trusted.
     ///
     /// This method introduces significant vulnerabilities to man-in-the-middle attacks.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn dangerous_accept_invalid_hostnames(mut self, accept_invalid_hostnames: bool) -> Self {
         self.accept_invalid_hostnames = accept_invalid_hostnames;
@@ -244,7 +244,7 @@ impl TlsParametersBuilder {
     /// Controls which minimum TLS version is allowed
     ///
     /// Defaults to [`Tlsv12`][TlsVersion::Tlsv12].
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     pub fn set_min_tls_version(mut self, min_tls_version: TlsVersion) -> Self {
         self.min_tls_version = min_tls_version;
         self
@@ -273,17 +273,17 @@ impl TlsParametersBuilder {
 
     /// Creates a new `TlsParameters` using native-tls, boring-tls or rustls
     /// depending on which one is available
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn build(self) -> Result<TlsParameters, Error> {
-        #[cfg(feature = "rustls-tls")]
+        #[cfg(feature = "rustls")]
         return self.build_rustls();
-        #[cfg(all(not(feature = "rustls-tls"), feature = "native-tls"))]
+        #[cfg(all(not(feature = "rustls"), feature = "native-tls"))]
         return self.build_native();
-        #[cfg(all(not(feature = "rustls-tls"), feature = "boring-tls"))]
+        #[cfg(all(not(feature = "rustls"), feature = "boring-tls"))]
         return self.build_boring();
     }
 
@@ -397,8 +397,8 @@ impl TlsParametersBuilder {
     }
 
     /// Creates a new `TlsParameters` using rustls with the provided configuration
-    #[cfg(feature = "rustls-tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     pub fn build_rustls(self) -> Result<TlsParameters, Error> {
         let just_version3 = &[&rustls::version::TLS13];
         let supported_versions = match self.min_tls_version {
@@ -415,7 +415,7 @@ impl TlsParametersBuilder {
         let tls = ClientConfig::builder_with_protocol_versions(supported_versions);
         let provider = rustls::crypto::CryptoProvider::get_default()
             .cloned()
-            .unwrap_or_else(|| Arc::new(rustls::crypto::ring::default_provider()));
+            .unwrap_or_else(|| Arc::new(crate::rustls_crypto::crypto_provider()));
 
         // Build TLS config
         let signature_algorithms = provider.signature_verification_algorithms;
@@ -435,7 +435,7 @@ impl TlsParametersBuilder {
             );
         }
 
-        #[cfg(feature = "rustls-tls")]
+        #[cfg(all(feature = "rustls", feature = "webpki-roots"))]
         fn load_webpki_roots(store: &mut RootCertStore) {
             store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
         }
@@ -444,10 +444,10 @@ impl TlsParametersBuilder {
             CertificateStore::Default => {
                 #[cfg(feature = "rustls-native-certs")]
                 load_native_roots(&mut root_cert_store);
-                #[cfg(not(feature = "rustls-native-certs"))]
+                #[cfg(all(not(feature = "rustls-native-certs"), feature = "webpki-roots"))]
                 load_webpki_roots(&mut root_cert_store);
             }
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(all(feature = "rustls", feature = "webpki-roots"))]
             CertificateStore::WebpkiRoots => {
                 load_webpki_roots(&mut root_cert_store);
             }
@@ -494,7 +494,7 @@ impl TlsParametersBuilder {
 pub enum InnerTlsParameters {
     #[cfg(feature = "native-tls")]
     NativeTls(TlsConnector),
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "rustls")]
     RustlsTls(Arc<ClientConfig>),
     #[cfg(feature = "boring-tls")]
     BoringTls(SslConnector),
@@ -503,10 +503,10 @@ pub enum InnerTlsParameters {
 impl TlsParameters {
     /// Creates a new `TlsParameters` using native-tls or rustls
     /// depending on which one is available
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn new(domain: String) -> Result<Self, Error> {
         TlsParametersBuilder::new(domain).build()
@@ -525,8 +525,8 @@ impl TlsParameters {
     }
 
     /// Creates a new `TlsParameters` using rustls
-    #[cfg(feature = "rustls-tls")]
-    #[cfg_attr(docsrs, doc(cfg(feature = "rustls-tls")))]
+    #[cfg(feature = "rustls")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "rustls")))]
     pub fn new_rustls(domain: String) -> Result<Self, Error> {
         TlsParametersBuilder::new(domain).build_rustls()
     }
@@ -549,13 +549,13 @@ impl TlsParameters {
 pub struct Certificate {
     #[cfg(feature = "native-tls")]
     native_tls: native_tls::Certificate,
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "rustls")]
     rustls: Vec<CertificateDer<'static>>,
     #[cfg(feature = "boring-tls")]
     boring_tls: boring::x509::X509,
 }
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 impl Certificate {
     /// Create a `Certificate` from a DER encoded certificate
     pub fn from_der(der: Vec<u8>) -> Result<Self, Error> {
@@ -568,7 +568,7 @@ impl Certificate {
         Ok(Self {
             #[cfg(feature = "native-tls")]
             native_tls: native_tls_cert,
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "rustls")]
             rustls: vec![der.into()],
             #[cfg(feature = "boring-tls")]
             boring_tls: boring_tls_cert,
@@ -583,7 +583,7 @@ impl Certificate {
         #[cfg(feature = "boring-tls")]
         let boring_tls_cert = boring::x509::X509::from_pem(pem).map_err(error::tls)?;
 
-        #[cfg(feature = "rustls-tls")]
+        #[cfg(feature = "rustls")]
         let rustls_cert = {
             CertificateDer::pem_slice_iter(pem)
                 .collect::<Result<Vec<_>, pki_types::pem::Error>>()
@@ -593,7 +593,7 @@ impl Certificate {
         Ok(Self {
             #[cfg(feature = "native-tls")]
             native_tls: native_tls_cert,
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "rustls")]
             rustls: rustls_cert,
             #[cfg(feature = "boring-tls")]
             boring_tls: boring_tls_cert,
@@ -612,7 +612,7 @@ impl Debug for Certificate {
 pub struct Identity {
     #[cfg(feature = "native-tls")]
     native_tls: native_tls::Identity,
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "rustls")]
     rustls_tls: (Vec<CertificateDer<'static>>, PrivateKeyDer<'static>),
     #[cfg(feature = "boring-tls")]
     boring_tls: (boring::x509::X509, PKey<boring::pkey::Private>),
@@ -629,7 +629,7 @@ impl Clone for Identity {
         Identity {
             #[cfg(feature = "native-tls")]
             native_tls: self.native_tls.clone(),
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "rustls")]
             rustls_tls: (self.rustls_tls.0.clone(), self.rustls_tls.1.clone_key()),
             #[cfg(feature = "boring-tls")]
             boring_tls: (self.boring_tls.0.clone(), self.boring_tls.1.clone()),
@@ -637,13 +637,13 @@ impl Clone for Identity {
     }
 }
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 impl Identity {
     pub fn from_pem(pem: &[u8], key: &[u8]) -> Result<Self, Error> {
         Ok(Self {
             #[cfg(feature = "native-tls")]
             native_tls: Identity::from_pem_native_tls(pem, key)?,
-            #[cfg(feature = "rustls-tls")]
+            #[cfg(feature = "rustls")]
             rustls_tls: Identity::from_pem_rustls_tls(pem, key)?,
             #[cfg(feature = "boring-tls")]
             boring_tls: Identity::from_pem_boring_tls(pem, key)?,
@@ -655,7 +655,7 @@ impl Identity {
         native_tls::Identity::from_pkcs8(pem, key).map_err(error::tls)
     }
 
-    #[cfg(feature = "rustls-tls")]
+    #[cfg(feature = "rustls")]
     fn from_pem_rustls_tls(
         pem: &[u8],
         key: &[u8],
@@ -682,7 +682,7 @@ impl Identity {
     }
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "rustls")]
 #[derive(Debug)]
 struct InvalidCertsVerifier {
     ignore_invalid_hostnames: bool,
@@ -691,7 +691,7 @@ struct InvalidCertsVerifier {
     signature_algorithms: WebPkiSupportedAlgorithms,
 }
 
-#[cfg(feature = "rustls-tls")]
+#[cfg(feature = "rustls")]
 impl ServerCertVerifier for InvalidCertsVerifier {
     fn verify_server_cert(
         &self,
@@ -729,7 +729,7 @@ impl ServerCertVerifier for InvalidCertsVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &crate::rustls_crypto::crypto_provider().signature_verification_algorithms,
         )
     }
 
@@ -743,12 +743,12 @@ impl ServerCertVerifier for InvalidCertsVerifier {
             message,
             cert,
             dss,
-            &rustls::crypto::ring::default_provider().signature_verification_algorithms,
+            &crate::rustls_crypto::crypto_provider().signature_verification_algorithms,
         )
     }
 
     fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
-        rustls::crypto::ring::default_provider()
+        crate::rustls_crypto::crypto_provider()
             .signature_verification_algorithms
             .supported_schemes()
     }

--- a/src/transport/smtp/connection_url.rs
+++ b/src/transport/smtp/connection_url.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 
 use url::Url;
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 use super::client::{Tls, TlsParameters};
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
 use super::AsyncSmtpTransportBuilder;
@@ -82,19 +82,19 @@ pub(crate) fn from_connection_url<B: TransportBuilder>(connection_url: &str) -> 
         ("smtp", None) => {
             builder = builder.port(connection_url.port().unwrap_or(SMTP_PORT));
         }
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+        #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
         ("smtp", Some("required")) => {
             builder = builder
                 .port(connection_url.port().unwrap_or(SUBMISSION_PORT))
                 .tls(Tls::Required(TlsParameters::new(host.into())?));
         }
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+        #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
         ("smtp", Some("opportunistic")) => {
             builder = builder
                 .port(connection_url.port().unwrap_or(SUBMISSION_PORT))
                 .tls(Tls::Opportunistic(TlsParameters::new(host.into())?));
         }
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+        #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
         ("smtps", _) => {
             builder = builder
                 .port(connection_url.port().unwrap_or(SUBMISSIONS_PORT))

--- a/src/transport/smtp/error.rs
+++ b/src/transport/smtp/error.rs
@@ -68,10 +68,10 @@ impl Error {
     }
 
     /// Returns true if the error is from TLS
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn is_tls(&self) -> bool {
         matches!(self.inner.kind, Kind::Tls)
@@ -107,9 +107,9 @@ pub(crate) enum Kind {
     /// TLS error
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     Tls,
 }
 
@@ -134,7 +134,7 @@ impl fmt::Display for Error {
             Kind::Client => f.write_str("internal client error")?,
             Kind::Network => f.write_str("network error")?,
             Kind::Connection => f.write_str("Connection error")?,
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             Kind::Tls => f.write_str("tls error")?,
             Kind::Transient(code) => {
                 write!(f, "transient error ({code})")?;
@@ -185,7 +185,7 @@ pub(crate) fn connection<E: Into<BoxError>>(e: E) -> Error {
     Error::new(Kind::Connection, Some(e))
 }
 
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 pub(crate) fn tls<E: Into<BoxError>>(e: E) -> Error {
     Error::new(Kind::Tls, Some(e))
 }

--- a/src/transport/smtp/mod.rs
+++ b/src/transport/smtp/mod.rs
@@ -32,7 +32,7 @@
 //! do the following:
 //!
 //! ```rust,no_run
-//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls-tls")))]
+//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls")))]
 //! # fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! use lettre::{
 //!     message::header::ContentType,
@@ -73,7 +73,7 @@
 //! For more information take a look at [`SmtpTransport::from_url`] or [`AsyncSmtpTransport::from_url`].
 //!
 //! ```rust,no_run
-//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls-tls")))]
+//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls")))]
 //! # fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! use lettre::{
 //!     message::header::ContentType,
@@ -101,7 +101,7 @@
 //! #### Advanced configuration with custom TLS settings
 //!
 //! ```rust,no_run
-//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls-tls")))]
+//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls")))]
 //! # fn test() -> Result<(), Box<dyn std::error::Error>> {
 //! use std::fs;
 //!
@@ -146,7 +146,7 @@
 //! In a webserver context it may go about this:
 //!
 //! ```rust,no_run
-//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls-tls")))]
+//! # #[cfg(all(feature = "builder", any(feature = "native-tls", feature = "rustls")))]
 //! # fn test() {
 //! use lettre::{
 //!     message::header::ContentType,
@@ -199,7 +199,7 @@ pub use self::{
     error::Error,
     transport::{SmtpTransport, SmtpTransportBuilder},
 };
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 use crate::transport::smtp::client::TlsParameters;
 use crate::transport::smtp::{
     authentication::{Credentials, Mechanism, DEFAULT_MECHANISMS},

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -7,7 +7,7 @@ use super::pool::sync_impl::Pool;
 #[cfg(feature = "pool")]
 use super::PoolConfig;
 use super::{ClientId, Credentials, Error, Mechanism, Response, SmtpConnection, SmtpInfo};
-#[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+#[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
 use super::{Tls, TlsParameters, SUBMISSIONS_PORT, SUBMISSION_PORT};
 use crate::{address::Envelope, Transport};
 
@@ -77,10 +77,10 @@ impl SmtpTransport {
     ///
     /// Creates an encrypted transport over submissions port, using the provided domain
     /// to validate TLS certificates.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn relay(relay: &str) -> Result<SmtpTransportBuilder, Error> {
         let tls_parameters = TlsParameters::new(relay.into())?;
@@ -101,10 +101,10 @@ impl SmtpTransport {
     ///
     /// An error is returned if the connection can't be upgraded. No credentials
     /// or emails will be sent to the server, protecting from downgrade attacks.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn starttls_relay(relay: &str) -> Result<SmtpTransportBuilder, Error> {
         let tls_parameters = TlsParameters::new(relay.into())?;
@@ -230,10 +230,10 @@ impl SmtpTransport {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn from_url(connection_url: &str) -> Result<SmtpTransportBuilder, Error> {
         super::connection_url::from_connection_url(connection_url)
@@ -333,10 +333,10 @@ impl SmtpTransportBuilder {
     ///
     /// Using the wrong [`Tls`] and [`Self::port`] combination may
     /// lead to hard to debug IO errors coming from the TLS library.
-    #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+    #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
     #[cfg_attr(
         docsrs,
-        doc(cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls")))
+        doc(cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls")))
     )]
     pub fn tls(mut self, tls: Tls) -> Self {
         self.info.tls = tls;
@@ -380,7 +380,7 @@ impl SmtpClient {
     pub fn connection(&self) -> Result<SmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match &self.info.tls {
-            #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+            #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
             Tls::Wrapper(tls_parameters) => Some(tls_parameters),
             _ => None,
         };
@@ -394,7 +394,7 @@ impl SmtpClient {
             None,
         )?;
 
-        #[cfg(any(feature = "native-tls", feature = "rustls-tls", feature = "boring-tls"))]
+        #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]
         match &self.info.tls {
             Tls::Opportunistic(tls_parameters) => {
                 if conn.can_starttls() {


### PR DESCRIPTION
This adds the following features:

* `rustls`
* `tokio1-rustls`
* `async-std1-rustls`
* `aws-lc-rs`
* `ring`
* `webpki-roots`

And deprecates these features:

* `rustls-tls`
* `tokio1-rustls-tls`
* `async-std1-rustls-tls`

This makes it possible to opt-out of `ring` and `webpki-roots` and instead use `aws-lc-rs` and/or `rustls-native-roots` (the last one was already technically possible but it would keep `webpki-roots` as a possibility).

The deprecated features will enable the necessary newly added features to make this not be a breaking change.

Still left to do:

* [x] `fips` feature
* [ ] verify that everything is using the expected crypto backend
* [x] verify the list of packages in the table I've added to `src/lib.rs`
* [x] verify that it works

Closes #1021
Closed #1046