### PR TITLE
style: fix `rustls-native-tls` warnings when `tracing` is disabled

### DIFF
--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -433,6 +433,8 @@ impl TlsParametersBuilder {
             tracing::debug!(
                 "loaded platform certs with {errors_len} failing to load, {added} valid and {ignored} ignored (invalid) certs"
             );
+            #[cfg(not(feature = "tracing"))]
+            let _ = (errors_len, added, ignored);
         }
 
         #[cfg(feature = "rustls-tls")]


### PR DESCRIPTION
Fixes https://github.com/lettre/lettre/pull/1052#discussion_r1966557402