### PR TITLE
style: deny `unreachable_pub` lint

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -75,8 +75,8 @@ jobs:
             rust: stable
           - name: beta
             rust: beta
-          - name: '1.71'
-            rust: '1.71'
+          - name: '1.74'
+            rust: '1.74'
 
     steps:
       - name: Checkout

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Alexis Mousset <contact@amousset.me>", "Paolo Barbolini <paolo@paolo
 categories = ["email", "network-programming"]
 keywords = ["email", "smtp", "mailer", "message", "sendmail"]
 edition = "2021"
-rust-version = "1.71"
+rust-version = "1.74"
 
 [badges]
 is-it-maintained-issue-resolution = { repository = "lettre/lettre" }

--- a/README.md
+++ b/README.md
@@ -53,12 +53,12 @@ Lettre does not provide (for now):
 ## Supported Rust Versions
 
 Lettre supports all Rust versions released in the last 6 months. At the time of writing
-the minimum supported Rust version is 1.71, but this could change at any time either from
+the minimum supported Rust version is 1.74, but this could change at any time either from
 one of our dependencies bumping their MSRV or by a new patch release of lettre.
 
 ## Example
 
-This library requires Rust 1.71 or newer.
+This library requires Rust 1.74 or newer.
 To use this library, add the following to your `Cargo.toml`:
 
 ```toml

--- a/src/address/envelope.rs
+++ b/src/address/envelope.rs
@@ -53,7 +53,7 @@ mod serde_forward_path {
             }
         }
     }
-    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Address>, D::Error>
+    pub(super) fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Address>, D::Error>
     where
         D: serde::Deserializer<'de>,
     {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -45,6 +45,7 @@ use crate::transport::smtp::Error;
 #[async_trait]
 pub trait Executor: Debug + Send + Sync + 'static + private::Sealed {
     #[cfg(feature = "smtp-transport")]
+    #[allow(private_bounds)]
     type Handle: SpawnHandle;
     #[cfg(feature = "smtp-transport")]
     type Sleep: Future<Output = ()> + Send + 'static;
@@ -82,7 +83,7 @@ pub trait Executor: Debug + Send + Sync + 'static + private::Sealed {
 #[doc(hidden)]
 #[cfg(feature = "smtp-transport")]
 #[async_trait]
-pub trait SpawnHandle: Debug + Send + Sync + 'static + private::Sealed {
+pub(crate) trait SpawnHandle: Debug + Send + Sync + 'static + private::Sealed {
     async fn shutdown(self);
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,7 @@
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]
 #![deny(
+    unreachable_pub,
     missing_copy_implementations,
     trivial_casts,
     trivial_numeric_casts,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,7 @@
 //! * Secure defaults
 //! * Async support
 //!
-//! Lettre requires Rust 1.71 or newer.
+//! Lettre requires Rust 1.74 or newer.
 //!
 //! ## Features
 //!

--- a/src/message/mailbox/parsers/rfc2822.rs
+++ b/src/message/mailbox/parsers/rfc2822.rs
@@ -41,14 +41,14 @@ fn quoted_pair() -> impl Parser<char, char, Error = Cheap<char>> {
 
 // FWS             =       ([*WSP CRLF] 1*WSP) /   ; Folding white space
 //                         obs-FWS
-pub fn fws() -> impl Parser<char, Option<char>, Error = Cheap<char>> {
+pub(super) fn fws() -> impl Parser<char, Option<char>, Error = Cheap<char>> {
     rfc2234::wsp()
         .or_not()
         .then_ignore(rfc2234::wsp().ignored().repeated())
 }
 
 // CFWS            =       *([FWS] comment) (([FWS] comment) / FWS)
-pub fn cfws() -> impl Parser<char, Option<char>, Error = Cheap<char>> {
+pub(super) fn cfws() -> impl Parser<char, Option<char>, Error = Cheap<char>> {
     // TODO: comment are not currently supported, so for now a cfws is
     // the same as a fws.
     fws()
@@ -106,12 +106,12 @@ pub(super) fn atom() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
 }
 
 // dot-atom        =       [CFWS] dot-atom-text [CFWS]
-pub fn dot_atom() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
+pub(super) fn dot_atom() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
     cfws().chain(dot_atom_text())
 }
 
 // dot-atom-text   =       1*atext *("." 1*atext)
-pub fn dot_atom_text() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
+pub(super) fn dot_atom_text() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
     atext().repeated().at_least(1).chain(
         just('.')
             .chain(atext().repeated().at_least(1))
@@ -204,7 +204,7 @@ pub(crate) fn mailbox_list(
 // https://datatracker.ietf.org/doc/html/rfc2822#section-3.4.1
 
 // addr-spec       =       local-part "@" domain
-pub fn addr_spec() -> impl Parser<char, (String, String), Error = Cheap<char>> {
+pub(super) fn addr_spec() -> impl Parser<char, (String, String), Error = Cheap<char>> {
     local_part()
         .collect()
         .then_ignore(just('@'))
@@ -212,12 +212,12 @@ pub fn addr_spec() -> impl Parser<char, (String, String), Error = Cheap<char>> {
 }
 
 // local-part      =       dot-atom / quoted-string / obs-local-part
-pub fn local_part() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
+pub(super) fn local_part() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
     choice((dot_atom(), quoted_string(), obs_local_part()))
 }
 
 // domain          =       dot-atom / domain-literal / obs-domain
-pub fn domain() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
+pub(super) fn domain() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
     // NOTE: omitting domain-literal since it may never be used
     choice((dot_atom(), obs_domain()))
 }
@@ -240,11 +240,11 @@ fn obs_phrase() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
 // https://datatracker.ietf.org/doc/html/rfc2822#section-4.4
 
 // obs-local-part  =       word *("." word)
-pub fn obs_local_part() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
+pub(super) fn obs_local_part() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
     word().chain(just('.').chain(word()).repeated().flatten())
 }
 
 // obs-domain      =       atom *("." atom)
-pub fn obs_domain() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
+pub(super) fn obs_domain() -> impl Parser<char, Vec<char>, Error = Cheap<char>> {
     atom().chain(just('.').chain(atom()).repeated().flatten())
 }

--- a/src/transport/smtp/async_transport.rs
+++ b/src/transport/smtp/async_transport.rs
@@ -460,7 +460,7 @@ impl AsyncSmtpTransportBuilder {
 }
 
 /// Build client
-pub struct AsyncSmtpClient<E> {
+pub(super) struct AsyncSmtpClient<E> {
     info: SmtpInfo,
     marker_: PhantomData<E>,
 }
@@ -472,7 +472,7 @@ where
     /// Creates a new connection directly usable to send emails
     ///
     /// Handles encryption and authentication
-    pub async fn connection(&self) -> Result<AsyncSmtpConnection, Error> {
+    pub(super) async fn connection(&self) -> Result<AsyncSmtpConnection, Error> {
         let mut conn = E::connect(
             &self.info.server,
             self.info.port,

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -58,7 +58,7 @@ struct ClientCodec {
 
 impl ClientCodec {
     /// Creates a new client codec
-    pub fn new() -> Self {
+    pub(crate) fn new() -> Self {
         Self {
             status: CodecStatus::StartOfNewLine,
         }

--- a/src/transport/smtp/client/tls.rs
+++ b/src/transport/smtp/client/tls.rs
@@ -490,7 +490,7 @@ impl TlsParametersBuilder {
 
 #[derive(Clone)]
 #[allow(clippy::enum_variant_names)]
-pub enum InnerTlsParameters {
+pub(crate) enum InnerTlsParameters {
     #[cfg(feature = "native-tls")]
     NativeTls(TlsConnector),
     #[cfg(feature = "rustls")]

--- a/src/transport/smtp/pool/async_impl.rs
+++ b/src/transport/smtp/pool/async_impl.rs
@@ -17,7 +17,7 @@ use super::{
 };
 use crate::{executor::SpawnHandle, transport::smtp::async_transport::AsyncSmtpClient, Executor};
 
-pub struct Pool<E: Executor> {
+pub(crate) struct Pool<E: Executor> {
     config: PoolConfig,
     connections: Mutex<Vec<ParkedConnection>>,
     client: AsyncSmtpClient<E>,
@@ -29,13 +29,13 @@ struct ParkedConnection {
     since: Instant,
 }
 
-pub struct PooledConnection<E: Executor> {
+pub(crate) struct PooledConnection<E: Executor> {
     conn: Option<AsyncSmtpConnection>,
     pool: Arc<Pool<E>>,
 }
 
 impl<E: Executor> Pool<E> {
-    pub fn new(config: PoolConfig, client: AsyncSmtpClient<E>) -> Arc<Self> {
+    pub(crate) fn new(config: PoolConfig, client: AsyncSmtpClient<E>) -> Arc<Self> {
         let pool = Arc::new(Self {
             config,
             connections: Mutex::new(Vec::new()),
@@ -134,7 +134,7 @@ impl<E: Executor> Pool<E> {
         pool
     }
 
-    pub async fn connection(self: &Arc<Self>) -> Result<PooledConnection<E>, Error> {
+    pub(crate) async fn connection(self: &Arc<Self>) -> Result<PooledConnection<E>, Error> {
         loop {
             let conn = {
                 let mut connections = self.connections.lock().await;

--- a/src/transport/smtp/pool/mod.rs
+++ b/src/transport/smtp/pool/mod.rs
@@ -1,8 +1,8 @@
 use std::time::Duration;
 
 #[cfg(any(feature = "tokio1", feature = "async-std1"))]
-pub mod async_impl;
-pub mod sync_impl;
+pub(super) mod async_impl;
+pub(super) mod sync_impl;
 
 /// Configuration for a connection pool
 #[derive(Debug, Clone)]

--- a/src/transport/smtp/pool/sync_impl.rs
+++ b/src/transport/smtp/pool/sync_impl.rs
@@ -13,7 +13,7 @@ use super::{
 };
 use crate::transport::smtp::transport::SmtpClient;
 
-pub struct Pool {
+pub(crate) struct Pool {
     config: PoolConfig,
     connections: Mutex<Vec<ParkedConnection>>,
     client: SmtpClient,
@@ -24,13 +24,13 @@ struct ParkedConnection {
     since: Instant,
 }
 
-pub struct PooledConnection {
+pub(crate) struct PooledConnection {
     conn: Option<SmtpConnection>,
     pool: Arc<Pool>,
 }
 
 impl Pool {
-    pub fn new(config: PoolConfig, client: SmtpClient) -> Arc<Self> {
+    pub(crate) fn new(config: PoolConfig, client: SmtpClient) -> Arc<Self> {
         let pool = Arc::new(Self {
             config,
             connections: Mutex::new(Vec::new()),
@@ -119,7 +119,7 @@ impl Pool {
         pool
     }
 
-    pub fn connection(self: &Arc<Self>) -> Result<PooledConnection, Error> {
+    pub(crate) fn connection(self: &Arc<Self>) -> Result<PooledConnection, Error> {
         loop {
             let conn = {
                 let mut connections = self.connections.lock().unwrap();

--- a/src/transport/smtp/transport.rs
+++ b/src/transport/smtp/transport.rs
@@ -369,7 +369,7 @@ impl SmtpTransportBuilder {
 
 /// Build client
 #[derive(Debug, Clone)]
-pub struct SmtpClient {
+pub(super) struct SmtpClient {
     info: SmtpInfo,
 }
 
@@ -377,7 +377,7 @@ impl SmtpClient {
     /// Creates a new connection directly usable to send emails
     ///
     /// Handles encryption and authentication
-    pub fn connection(&self) -> Result<SmtpConnection, Error> {
+    pub(super) fn connection(&self) -> Result<SmtpConnection, Error> {
         #[allow(clippy::match_single_binding)]
         let tls_parameters = match &self.info.tls {
             #[cfg(any(feature = "native-tls", feature = "rustls", feature = "boring-tls"))]

--- a/src/transport/smtp/util.rs
+++ b/src/transport/smtp/util.rs
@@ -4,7 +4,7 @@ use std::fmt::{Display, Formatter, Result as FmtResult};
 
 /// Encode a string as xtext
 #[derive(Debug)]
-pub struct XText<'a>(pub &'a str);
+pub(crate) struct XText<'a>(pub(crate) &'a str);
 
 impl Display for XText<'_> {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {


### PR DESCRIPTION
I've used this lint for other crates and I felt like it helped quickly understand what was part of the public API and what was not. Also I've found a bug while doing this https://github.com/rust-lang/rust/issues/137438.