### PR TITLE
build(deps): bump minimum supported rustls to v0.23.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ percent-encoding = { version = "2.3", optional = true }
 
 ## tls
 native-tls = { version = "0.2.9", optional = true } # feature
-rustls = { version = "0.23.5", default-features = false, features = ["logging", "std", "tls12"], optional = true }
+rustls = { version = "0.23.18", default-features = false, features = ["logging", "std", "tls12"], optional = true }
 rustls-native-certs = { version = "0.8", optional = true }
 webpki-roots = { version = "0.26", optional = true }
 boring = { version = "4", optional = true }


### PR DESCRIPTION
Fixes #1062 - rustls v0.23.18 has a high enough `rustls-pki-types` dependency requirement.

Also makes deps.rs happy by using a version not vulnerable to RUSTSEC-2024-0399.