### PR TITLE
build(deps): bump minimum supported serde to v1.0.110

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ email-encoding = { version = "0.3", optional = true }
 
 # file transport
 uuid = { version = "1", features = ["v4"], optional = true }
-serde = { version = "1", features = ["derive"], optional = true }
+serde = { version = "1.0.110", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
 # smtp-transport


### PR DESCRIPTION
While working on #1063 I've also realized our version of `serde` could be problematic.