### PR TITLE
Prepare v0.11.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+<a name="v0.11.15"></a>
+### v0.11.15 (2025-03-10)
+
+#### Upgrade notes
+
+* MSRV is now 1.74 ([#1060])
+
+#### Features
+
+* Add controlled shutdown methods ([#1045], [#1068])
+
+#### Misc
+
+* Deny `unreachable_pub` lint ([#1058])
+* Bump minimum supported `rustls` ([#1063])
+* Bump minimum supported `serde` ([#1064])
+* Upgrade semver compatible dependencies ([#1067])
+* Upgrade `email-encoding` to v0.4 ([#1069])
+
+[#1045]: https://github.com/lettre/lettre/pull/1045
+[#1058]: https://github.com/lettre/lettre/pull/1058
+[#1060]: https://github.com/lettre/lettre/pull/1060
+[#1063]: https://github.com/lettre/lettre/pull/1063
+[#1064]: https://github.com/lettre/lettre/pull/1064
+[#1067]: https://github.com/lettre/lettre/pull/1067
+[#1068]: https://github.com/lettre/lettre/pull/1068
+[#1069]: https://github.com/lettre/lettre/pull/1069
+
 <a name="v0.11.14"></a>
 ### v0.11.14 (2025-02-23)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1298,7 +1298,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.14"
+version = "0.11.15"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.14"
+version = "0.11.15"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.14">
-    <img src="https://deps.rs/crate/lettre/0.11.14/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.15">
+    <img src="https://deps.rs/crate/lettre/0.11.15/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.14")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.15")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Upgrade notes

* MSRV is now 1.74 (#1060)

#### Features

* Add controlled shutdown methods (#1045, #1068)

#### Misc

* Deny `unreachable_pub` lint (#1058)
* Bump minimum supported `rustls` (#1063)
* Bump minimum supported `serde` (#1064)
* Upgrade semver compatible dependencies (#1067)
* Upgrade `email-encoding` to v0.4 (#1069)