### PR TITLE
docs: clarify that `Credentials::new` takes bearer token for xoauth2

### DIFF
--- a/src/transport/smtp/authentication.rs
+++ b/src/transport/smtp/authentication.rs
@@ -19,6 +19,9 @@ pub struct Credentials {
 
 impl Credentials {
     /// Create a `Credentials` struct from username and password
+    ///
+    /// When using [`Mechanism::Xoauth2`], `password` is the raw
+    /// bearer access token.
     pub fn new(username: String, password: String) -> Credentials {
         Credentials {
             authentication_identity: username,


### PR DESCRIPTION
Clarifies that in cases like https://matrix.to/#/!jZPOAKPWNeZkNemCEi:gitter.im/$NNndWurE4cG-KfLGcCeTApEQwWkT9xFnVSWgf_wk0bM?via=gitter.im&via=matrix.org&via=0x.badd.cafe the user doesn't need to build the XOAUTH2 string by themselves.