### PR TITLE
Prepare v0.11.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,39 @@
+<a name="v0.11.16"></a>
+### v0.11.16 (2025-05-12)
+
+#### Features
+
+* Always implement `Clone` for `AsyncFileTransport` ([#1075])
+
+#### Changes
+
+* `Tls`, `CertificateStore`, `TlsParameters`, `TlsParametersBuilder`, `Certificate` and `Identity`
+  are now marked as deprecated when no TLS backend is enabled. They will be properly feature gated
+  in lettre v0.12 ([#1084])
+
+#### Misc
+
+* Gate `web-time` behind `cfg(target_arch = "wasm32")]` ([#1086])
+* Add missing `#[doc(cfg(...))]` attributes ([#1086])
+* Upgrade `webpki-roots` to v1 ([#1088])
+* Cleanup internal `TlsParameters` and `(Async)NetworkStream` structures ([#1082])
+* Feature gate internal `TransportBuilder::tls` to avoid recursive call site warnings ([#1083])
+* Fix workaround for embedding cargo script in rustdoc output ([#1077])
+* Fix `clippy::io_other_error` warnings ([#1078])
+* Upgrade semver compatible dependencies ([#1076], [#1079], [#1080])
+
+[#1075]: https://github.com/lettre/lettre/pull/1075
+[#1076]: https://github.com/lettre/lettre/pull/1076
+[#1077]: https://github.com/lettre/lettre/pull/1077
+[#1078]: https://github.com/lettre/lettre/pull/1078
+[#1079]: https://github.com/lettre/lettre/pull/1079
+[#1080]: https://github.com/lettre/lettre/pull/1080
+[#1082]: https://github.com/lettre/lettre/pull/1082
+[#1083]: https://github.com/lettre/lettre/pull/1083
+[#1084]: https://github.com/lettre/lettre/pull/1084
+[#1086]: https://github.com/lettre/lettre/pull/1086
+[#1088]: https://github.com/lettre/lettre/pull/1088
+
 <a name="v0.11.15"></a>
 ### v0.11.15 (2025-03-10)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1287,7 +1287,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.15"
+version = "0.11.16"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.15"
+version = "0.11.16"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.15">
-    <img src="https://deps.rs/crate/lettre/0.11.15/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.16">
+    <img src="https://deps.rs/crate/lettre/0.11.16/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -158,7 +158,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.15")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.16")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Features

* Always implement `Clone` for `AsyncFileTransport` (#1075)

#### Changes

* `Tls`, `CertificateStore`, `TlsParameters`, `TlsParametersBuilder`, `Certificate` and `Identity`
  are now marked as deprecated when no TLS backend is enabled. They will be properly feature gated
  in lettre v0.12 (#1084)

#### Misc

* Gate `web-time` behind `cfg(target_arch = "wasm32")]` (#1086)
* Add missing `#[doc(cfg(...))]` attributes (#1086)
* Upgrade `webpki-roots` to v1 (#1088)
* Cleanup internal `TlsParameters` and `(Async)NetworkStream` structures (#1082)
* Feature gate internal `TransportBuilder::tls` to avoid recursive call site warnings (#1083)
* Fix workaround for embedding cargo script in rustdoc output ([#1077])
* Fix `clippy::io_other_error` warnings (#1078)
* Upgrade semver compatible dependencies (#1076, #1079, #1080)