### PR TITLE
Prepare v0.11.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+<a name="v0.11.17"></a>
+### v0.11.17 (2025-06-06)
+
+#### Features
+
+* Add support for `rustls-platform-verifier` ([#1081])
+
+#### Misc
+
+* Change readme example to use `Mailbox::new` instead of string parsing ([#1090])
+* Replace futures-util `Mutex` with std `Mutex` in `AsyncStubTransport` ([#1091])
+* Avoid duplicate `abort_concurrent` implementation ([#1092])
+
+[#1081]: https://github.com/lettre/lettre/pull/1081
+[#1090]: https://github.com/lettre/lettre/pull/1090
+[#1091]: https://github.com/lettre/lettre/pull/1091
+[#1092]: https://github.com/lettre/lettre/pull/1092
+
 <a name="v0.11.16"></a>
 ### v0.11.16 (2025-05-12)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1325,7 +1325,7 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "lettre"
-version = "0.11.16"
+version = "0.11.17"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.16"
+version = "0.11.17"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.16">
-    <img src="https://deps.rs/crate/lettre/0.11.16/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.17">
+    <img src="https://deps.rs/crate/lettre/0.11.17/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.16")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.17")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Features

* Add support for `rustls-platform-verifier` (#1081)

#### Misc

* Change readme example to use `Mailbox::new` instead of string parsing (#1090)
* Replace futures-util `Mutex` with std `Mutex` in `AsyncStubTransport` (#1091)
* Avoid duplicate `abort_concurrent` implementation (#1092)