### PR TITLE
feat(email): Better error handling of invalid input to MailBox FromStr

### DIFF
--- a/src/address/types.rs
+++ b/src/address/types.rs
@@ -226,9 +226,9 @@ fn check_address(val: &str) -> Result<usize, AddressError> {
     Ok(user.len())
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 #[non_exhaustive]
-/// Errors in email addresses parsing
+/// Errors in email address parsing
 pub enum AddressError {
     /// Missing domain or user
     MissingParts,
@@ -238,8 +238,8 @@ pub enum AddressError {
     InvalidUser,
     /// Invalid email domain
     InvalidDomain,
-    /// Invalid input found
-    InvalidInput,
+    /// Input is an invalid mailbox address
+    InvalidMailboxAddress(String),
 }
 
 impl Error for AddressError {}
@@ -251,7 +251,9 @@ impl Display for AddressError {
             AddressError::Unbalanced => f.write_str("Unbalanced angle bracket"),
             AddressError::InvalidUser => f.write_str("Invalid email user"),
             AddressError::InvalidDomain => f.write_str("Invalid email domain"),
-            AddressError::InvalidInput => f.write_str("Invalid input"),
+            AddressError::InvalidMailboxAddress(address) => {
+                f.write_fmt(format_args!("Invalid mailbox address: {address}"))
+            }
         }
     }
 }

--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -115,8 +115,8 @@ impl FromStr for Mailbox {
 
     fn from_str(src: &str) -> Result<Mailbox, Self::Err> {
         let (name, (user, domain)) = parsers::mailbox().parse(src).map_err(|_errs| {
-            // TODO: improve error management
-            AddressError::InvalidInput
+            // TODO: avoid allocation?
+            AddressError::InvalidMailboxAddress(src.to_owned())
         })?;
 
         let mailbox = Mailbox::new(name, Address::new(user, domain)?);
@@ -347,7 +347,7 @@ impl FromStr for Mailboxes {
 
         let parsed_mailboxes = parsers::mailbox_list().parse(src).map_err(|_errs| {
             // TODO: improve error management
-            AddressError::InvalidInput
+            AddressError::InvalidMailboxAddress(src.to_owned())
         })?;
 
         for (name, (user, domain)) in parsed_mailboxes {


### PR DESCRIPTION
The error variant "InvalidInput" does not describe why the input is invalid and currently requires digging down through the call stack to find out why. This makes it more clear that the address is itself invalid and the error stores that invalid value as context.