### PR TITLE
Add serde support for Message struct

### DIFF
--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -40,6 +40,7 @@ pub trait Header: Clone {
 }
 
 /// A set of email headers
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, Default)]
 pub struct Headers {
     headers: Vec<HeaderValue>,
@@ -170,6 +171,7 @@ impl fmt::Display for InvalidHeaderName {
 impl Error for InvalidHeaderName {}
 
 /// A valid header name
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct HeaderName(Cow<'static, str>);
 
@@ -252,6 +254,7 @@ impl PartialEq<HeaderName> for &str {
 }
 
 /// A safe for use header value
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone, PartialEq)]
 pub struct HeaderValue {
     name: HeaderName,

--- a/src/message/mimebody.rs
+++ b/src/message/mimebody.rs
@@ -8,6 +8,7 @@ use crate::message::{
 };
 
 /// MIME part variants
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub(super) enum Part {
     /// Single part with content
@@ -98,6 +99,7 @@ impl Default for SinglePartBuilder {
 /// # }
 /// ```
 #[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct SinglePart {
     headers: Headers,
     body: Vec<u8>,
@@ -295,6 +297,7 @@ impl Default for MultiPartBuilder {
 }
 
 /// Multipart variant with parts
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Debug, Clone)]
 pub struct MultiPart {
     headers: Headers,

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -485,6 +485,7 @@ impl MessageBuilder {
 
 /// Email message which can be formatted
 #[cfg_attr(docsrs, doc(cfg(feature = "builder")))]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 pub struct Message {
     headers: Headers,
@@ -492,6 +493,7 @@ pub struct Message {
     envelope: Envelope,
 }
 
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Debug)]
 enum MessageBody {
     Mime(Part),


### PR DESCRIPTION
I require serde support for the Message struct in my project. Implementation was quite simple using derive gated behind the existing feature flag. Is there any reason against this?