### PR TITLE
DKIM : Directly use Rsa/Ed25519 objects. Option 1

### DIFF
--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -110,6 +110,17 @@ enum InnerDkimSigningKey {
     Ed25519(ed25519_dalek::SigningKey),
 }
 
+impl From<RsaPrivateKey> for DkimSigningKey {
+    fn from(value: RsaPrivateKey) -> Self {
+        Self(InnerDkimSigningKey::Rsa(value))
+    }
+}
+impl From<ed25519_dalek::SigningKey> for DkimSigningKey {
+    fn from(value: ed25519_dalek::SigningKey) -> Self {
+        Self(InnerDkimSigningKey::Ed25519(value))
+    }
+}
+
 impl DkimSigningKey {
     pub fn new(
         private_key: &str,


### PR DESCRIPTION
We don't need to pass through base64.


Commit at least one of :
https://github.com/lettre/lettre/pull/1123
https://github.com/lettre/lettre/pull/1124