### PR TITLE
DKIM : Directly use Rsa/Ed25519 objects. Option 2

### DIFF
--- a/src/message/dkim.rs
+++ b/src/message/dkim.rs
@@ -102,10 +102,10 @@ impl StdError for DkimSigningKeyError {
 
 /// Describe a signing key to be carried by [`DkimConfig`] struct
 #[derive(Debug)]
-pub struct DkimSigningKey(InnerDkimSigningKey);
+pub struct DkimSigningKey(pub InnerDkimSigningKey);
 
 #[derive(Debug)]
-enum InnerDkimSigningKey {
+pub enum InnerDkimSigningKey {
     Rsa(RsaPrivateKey),
     Ed25519(ed25519_dalek::SigningKey),
 }


### PR DESCRIPTION
We don't need to pass through base64.

Commit at least one of :
https://github.com/lettre/lettre/pull/1123
https://github.com/lettre/lettre/pull/1124