### PR TITLE
fix(transport-smtp): cap read_response buffer

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -7,7 +7,10 @@ use super::async_net::AsyncTokioStream;
 #[cfg(feature = "tracing")]
 use super::escape_crlf;
 #[allow(deprecated)]
-use super::{ClientCodec, TlsParameters, async_net::AsyncNetworkStream};
+use super::{
+    ClientCodec, MAX_RESPONSE_BYTES, MAX_RESPONSE_LINE_BYTES, TlsParameters,
+    async_net::AsyncNetworkStream,
+};
 use crate::{
     Envelope,
     transport::smtp::{
@@ -356,6 +359,7 @@ impl AsyncSmtpConnection {
     /// Gets the SMTP response
     pub async fn read_response(&mut self) -> Result<Response, Error> {
         let mut buffer = String::with_capacity(100);
+        let mut pre = 0;
 
         while self
             .stream
@@ -364,6 +368,14 @@ impl AsyncSmtpConnection {
             .map_err(error::network)?
             > 0
         {
+            if buffer.len() - pre > MAX_RESPONSE_LINE_BYTES {
+                return Err(error::response("SMTP response line too long"));
+            }
+            if buffer.len() > MAX_RESPONSE_BYTES {
+                return Err(error::response("SMTP response too large"));
+            }
+            pre = buffer.len();
+
             #[cfg(feature = "tracing")]
             tracing::debug!("<< {}", escape_crlf(&buffer));
             match parse_response(&buffer) {

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -7,7 +7,9 @@ use std::{
 
 #[cfg(feature = "tracing")]
 use super::escape_crlf;
-use super::{ClientCodec, NetworkStream, TlsParameters};
+use super::{
+    ClientCodec, MAX_RESPONSE_BYTES, MAX_RESPONSE_LINE_BYTES, NetworkStream, TlsParameters,
+};
 use crate::{
     address::Envelope,
     transport::smtp::{
@@ -282,8 +284,17 @@ impl SmtpConnection {
     /// Gets the SMTP response
     pub fn read_response(&mut self) -> Result<Response, Error> {
         let mut buffer = String::with_capacity(100);
+        let mut pre = 0;
 
         while self.stream.read_line(&mut buffer).map_err(error::network)? > 0 {
+            if buffer.len() - pre > MAX_RESPONSE_LINE_BYTES {
+                return Err(error::response("SMTP response line too long"));
+            }
+            if buffer.len() > MAX_RESPONSE_BYTES {
+                return Err(error::response("SMTP response too large"));
+            }
+            pre = buffer.len();
+
             #[cfg(feature = "tracing")]
             tracing::debug!("<< {}", escape_crlf(&buffer));
             match parse_response(&buffer) {

--- a/src/transport/smtp/client/mod.rs
+++ b/src/transport/smtp/client/mod.rs
@@ -50,6 +50,12 @@ mod connection;
 mod net;
 mod tls;
 
+/// Total bytes cap on an SMTP response (Postfix `smtp_response_limit`).
+pub(super) const MAX_RESPONSE_BYTES: usize = 100_000;
+
+/// Single-line byte cap (Postfix `line_length_limit`).
+pub(super) const MAX_RESPONSE_LINE_BYTES: usize = 1000;
+
 /// The codec used for transparency
 #[derive(Debug)]
 struct ClientCodec {

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -70,3 +70,47 @@ mod asyncstd_1 {
         sender.send(email).await.unwrap();
     }
 }
+
+#[cfg(test)]
+#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+mod read_response_caps {
+    use std::{io::Write, net::TcpListener, thread, time::Duration};
+
+    use lettre::transport::smtp::{client::AsyncSmtpConnection, extension::ClientId};
+    use tokio1_crate as tokio;
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn oversized_line_is_bounded() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            if let Ok((mut sock, _)) = listener.accept() {
+                let mut line = vec![b'x'; 4096];
+                line.extend_from_slice(b"\r\n");
+                let _ = sock.write_all(&line);
+            }
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            AsyncSmtpConnection::connect_tokio1(
+                addr,
+                None,
+                &ClientId::Domain("test".into()),
+                None,
+                None,
+            ),
+        )
+        .await
+        .expect("connect must return within 5s, not hang");
+
+        let err = match result {
+            Ok(_) => panic!("oversized line must surface as an error"),
+            Err(e) => e,
+        };
+        assert!(
+            err.is_response(),
+            "expected response-kind error, got {err:?}"
+        );
+    }
+}


### PR DESCRIPTION
A peer that streams continuation lines (e.g. \`220-x\r\n\` forever)
drives \`read_response\` to grow its accumulator unboundedly and
re-parse the whole buffer on each line — O(n²) CPU and unbounded
heap, hanging the caller indefinitely.

Adds two defensive caps to \`read_response\` in both sync and async
paths, matching Postfix defaults:

  * \`MAX_RESPONSE_LINE_BYTES\` = 1000   (\`line_length_limit\`)
  * \`MAX_RESPONSE_BYTES\`      = 100000 (\`smtp_response_limit\`)

Exceeding either returns \`error::response\`. Closes the buffer-cap
half of #1027; the timeout/preemption half remains open.