### PR TITLE
Prepare v0.11.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+<a name="v0.11.22"></a>
+### v0.11.22 (2026-05-14)
+
+#### Security
+
+* Fix inverted TLS hostname verification flag in `boring-tls` backend that silently disabled hostname verification ([f5efffc])
+
+#### Bug Fixes
+
+* Cap `read_response` buffer to prevent unbounded memory growth ([#1143])
+
+#### Misc
+
+* Upgrade `rustls-platform-verifier` to v0.7 ([#1136])
+
+[f5efffc]: https://github.com/lettre/lettre/commit/f5efffc88360dbdbfcef80f465e42d5bce68ca35
+[#1136]: https://github.com/lettre/lettre/pull/1136
+[#1143]: https://github.com/lettre/lettre/pull/1143
+
 <a name="v0.11.21"></a>
 ### v0.11.21 (2026-04-04)
 
@@ -8,6 +27,8 @@
 
 [#1116]: https://github.com/lettre/lettre/pull/1116
 [#1134]: https://github.com/lettre/lettre/pull/1134
+[#1136]: https://github.com/lettre/lettre/pull/1136
+[#1143]: https://github.com/lettre/lettre/pull/1143
 
 <a name="v0.11.20"></a>
 ### v0.11.20 (2026-03-28)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.21"
+version = "0.11.22"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.21">
-    <img src="https://deps.rs/crate/lettre/0.11.21/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.22">
+    <img src="https://deps.rs/crate/lettre/0.11.22/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.21")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.22")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Security

* Fix inverted TLS hostname verification flag in `boring-tls` backend that silently disabled hostname verification [f5efffc]

#### Bug Fixes

* Cap `read_response` buffer to prevent unbounded memory growth [#1143]

#### Misc

* Upgrade `rustls-platform-verifier` to v0.7 [#1136]