### PR TITLE
fix(deps) sendmail-transport was adding async-std and tokio to lockfile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -140,9 +140,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -105,7 +105,7 @@ mime03 = ["dep:mime"]
 # transports
 file-transport = ["dep:uuid", "tokio1_crate?/fs", "tokio1_crate?/io-util"]
 file-transport-envelope = ["serde", "dep:serde_json", "file-transport"]
-sendmail-transport = ["tokio1_crate?/process", "tokio1_crate?/io-util", "async-std?/unstable"]
+sendmail-transport = []
 smtp-transport = ["dep:base64", "dep:socket2", "dep:url", "dep:percent-encoding", "tokio1_crate?/rt", "tokio1_crate?/time", "tokio1_crate?/net"]
 
 pool = ["dep:futures-util"]
@@ -122,11 +122,11 @@ rustls-tls = ["webpki-roots", "rustls", "ring"]
 boring-tls = ["dep:boring"]
 
 # async
-async-std1 = ["dep:async-std", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
+async-std1 = ["dep:async-std", "dep:async-trait", "dep:futures-io", "dep:futures-util", "async-std?/unstable"]
 async-std1-rustls = ["async-std1", "rustls", "dep:futures-rustls"]
 # deprecated
 async-std1-rustls-tls = ["async-std1-rustls", "rustls-tls"]
-tokio1 = ["dep:tokio1_crate", "dep:async-trait", "dep:futures-io", "dep:futures-util"]
+tokio1 = ["dep:tokio1_crate", "dep:async-trait", "dep:futures-io", "dep:futures-util", "tokio1_crate?/process", "tokio1_crate?/io-util"]
 tokio1-native-tls = ["tokio1", "native-tls", "dep:tokio1_native_tls_crate"]
 tokio1-rustls = ["tokio1", "rustls", "dep:tokio1_rustls"]
 # deprecated


### PR DESCRIPTION
Investigated https://github.com/lettre/lettre/issues/1138 and found that the `sendmail-transport` feature was more eagerly adding `async-std` and `tokio` to the lockfile. My solution is to move the dependencies that are being compiled currently in `sendmail-transport` to their respective runtime features (`async-std1` and `tokio1`).

It appears that there is proper feature gating in the `src/transport/sendmail/mod.rs` file that should make this change safe to implement