### PR TITLE
feat(smtp): Add native SMTP Delivery Status Notification (DSN) support

### DIFF
--- a/src/address/envelope.rs
+++ b/src/address/envelope.rs
@@ -5,6 +5,50 @@ use crate::message::header::{self, Headers};
 #[cfg(feature = "builder")]
 use crate::message::{Mailbox, Mailboxes};
 
+/// The RET (Return) parameter for DSN
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum DsnRet {
+    /// Return the full message
+    Full,
+    /// Return only the headers
+    Hdrs,
+}
+
+impl std::fmt::Display for DsnRet {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DsnRet::Full => write!(f, "FULL"),
+            DsnRet::Hdrs => write!(f, "HDRS"),
+        }
+    }
+}
+
+/// The NOTIFY parameter for DSN
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub enum DsnNotify {
+    /// Never notify
+    Never,
+    /// Notify on success
+    Success,
+    /// Notify on failure
+    Failure,
+    /// Notify on delay
+    Delay,
+}
+
+impl std::fmt::Display for DsnNotify {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            DsnNotify::Never => write!(f, "NEVER"),
+            DsnNotify::Success => write!(f, "SUCCESS"),
+            DsnNotify::Failure => write!(f, "FAILURE"),
+            DsnNotify::Delay => write!(f, "DELAY"),
+        }
+    }
+}
+
 /// Simple email envelope representation
 ///
 /// We only accept mailboxes, and do not support source routes (as per RFC).
@@ -22,9 +66,9 @@ pub struct Envelope {
     /// The envelope sender address
     reverse_path: Option<Address>,
     /// SMTP DSN NOTIFY parameter
-    dsn_notify: Option<String>,
+    dsn_notify: Option<Vec<DsnNotify>>,
     /// SMTP DSN RET parameter
-    dsn_ret: Option<String>,
+    dsn_ret: Option<DsnRet>,
     /// SMTP DSN ENVID parameter
     dsn_envid: Option<String>,
 }
@@ -119,7 +163,12 @@ impl Envelope {
     }
 
     /// Builder method to add DSN parameters (NOTIFY, RET, and ENVID) to this envelope
-    pub fn with_dsn(mut self, notify: Option<String>, ret: Option<String>, envid: Option<String>) -> Self {
+    pub fn with_dsn(
+        mut self,
+        notify: Option<Vec<DsnNotify>>,
+        ret: Option<DsnRet>,
+        envid: Option<String>,
+    ) -> Self {
         self.dsn_notify = notify;
         self.dsn_ret = ret;
         self.dsn_envid = envid;
@@ -127,12 +176,12 @@ impl Envelope {
     }
 
     /// Gets the DSN NOTIFY parameter
-    pub fn dsn_notify(&self) -> Option<&String> {
+    pub fn dsn_notify(&self) -> Option<&Vec<DsnNotify>> {
         self.dsn_notify.as_ref()
     }
 
     /// Gets the DSN RET parameter
-    pub fn dsn_ret(&self) -> Option<&String> {
+    pub fn dsn_ret(&self) -> Option<&DsnRet> {
         self.dsn_ret.as_ref()
     }
 

--- a/src/address/envelope.rs
+++ b/src/address/envelope.rs
@@ -21,6 +21,12 @@ pub struct Envelope {
     forward_path: Vec<Address>,
     /// The envelope sender address
     reverse_path: Option<Address>,
+    /// SMTP DSN NOTIFY parameter
+    dsn_notify: Option<String>,
+    /// SMTP DSN RET parameter
+    dsn_ret: Option<String>,
+    /// SMTP DSN ENVID parameter
+    dsn_envid: Option<String>,
 }
 
 /// just like the default implementation to deserialize `Vec<Address>` but it
@@ -106,7 +112,33 @@ impl Envelope {
         Ok(Envelope {
             forward_path: to,
             reverse_path: from,
+            dsn_notify: None,
+            dsn_ret: None,
+            dsn_envid: None,
         })
+    }
+
+    /// Builder method to add DSN parameters (NOTIFY, RET, and ENVID) to this envelope
+    pub fn with_dsn(mut self, notify: Option<String>, ret: Option<String>, envid: Option<String>) -> Self {
+        self.dsn_notify = notify;
+        self.dsn_ret = ret;
+        self.dsn_envid = envid;
+        self
+    }
+
+    /// Gets the DSN NOTIFY parameter
+    pub fn dsn_notify(&self) -> Option<&String> {
+        self.dsn_notify.as_ref()
+    }
+
+    /// Gets the DSN RET parameter
+    pub fn dsn_ret(&self) -> Option<&String> {
+        self.dsn_ret.as_ref()
+    }
+
+    /// Gets the DSN ENVID parameter
+    pub fn dsn_envid(&self) -> Option<&String> {
+        self.dsn_envid.as_ref()
     }
 
     /// Gets the destination addresses of the envelope.

--- a/src/address/mod.rs
+++ b/src/address/mod.rs
@@ -7,6 +7,6 @@ mod envelope;
 mod types;
 
 pub use self::{
-    envelope::Envelope,
+    envelope::{DsnNotify, DsnRet, Envelope},
     types::{Address, AddressError},
 };

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -16,10 +16,9 @@ use crate::{
     transport::smtp::{
         authentication::{Credentials, Mechanism},
         commands::{Auth, Data, Ehlo, Mail, Noop, Quit, Rcpt, Starttls},
-        error,
-        error::Error,
-        extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},
-        response::{Response, parse_response},
+        error::{self, Error},
+        extension::{ClientId, Extension, MailBodyParameter, MailParameter, RcptParameter, ServerInfo},
+        response::{parse_response, Response},
     },
 };
 
@@ -181,6 +180,20 @@ impl AsyncSmtpConnection {
             mail_options.push(MailParameter::Body(MailBodyParameter::EightBitMime));
         }
 
+        if let Some(ret) = envelope.dsn_ret() {
+            mail_options.push(MailParameter::Other {
+                keyword: "RET".into(),
+                value: Some(ret.clone()),
+            });
+        }
+
+        if let Some(envid) = envelope.dsn_envid() {
+            mail_options.push(MailParameter::Other {
+                keyword: "ENVID".into(),
+                value: Some(envid.clone()),
+            });
+        }
+
         try_smtp!(
             self.command(Mail::new(envelope.from().cloned(), mail_options))
                 .await,
@@ -189,8 +202,15 @@ impl AsyncSmtpConnection {
 
         // Recipient
         for to_address in envelope.to() {
+            let mut rcpt_options = vec![];
+            if let Some(notify) = envelope.dsn_notify() {
+                rcpt_options.push(RcptParameter::Other {
+                    keyword: "NOTIFY".into(),
+                    value: Some(notify.clone()),
+                });
+            }
             try_smtp!(
-                self.command(Rcpt::new(to_address.clone(), vec![])).await,
+                self.command(Rcpt::new(to_address.clone(), rcpt_options)).await,
                 self
             );
         }

--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -17,8 +17,10 @@ use crate::{
         authentication::{Credentials, Mechanism},
         commands::{Auth, Data, Ehlo, Mail, Noop, Quit, Rcpt, Starttls},
         error::{self, Error},
-        extension::{ClientId, Extension, MailBodyParameter, MailParameter, RcptParameter, ServerInfo},
-        response::{parse_response, Response},
+        extension::{
+            ClientId, Extension, MailBodyParameter, MailParameter, RcptParameter, ServerInfo,
+        },
+        response::{Response, parse_response},
     },
 };
 
@@ -183,7 +185,7 @@ impl AsyncSmtpConnection {
         if let Some(ret) = envelope.dsn_ret() {
             mail_options.push(MailParameter::Other {
                 keyword: "RET".into(),
-                value: Some(ret.clone()),
+                value: Some(ret.to_string()),
             });
         }
 
@@ -204,13 +206,19 @@ impl AsyncSmtpConnection {
         for to_address in envelope.to() {
             let mut rcpt_options = vec![];
             if let Some(notify) = envelope.dsn_notify() {
+                let notify_str = notify
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",");
                 rcpt_options.push(RcptParameter::Other {
                     keyword: "NOTIFY".into(),
-                    value: Some(notify.clone()),
+                    value: Some(notify_str),
                 });
             }
             try_smtp!(
-                self.command(Rcpt::new(to_address.clone(), rcpt_options)).await,
+                self.command(Rcpt::new(to_address.clone(), rcpt_options))
+                    .await,
                 self
             );
         }

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -17,7 +17,9 @@ use crate::{
         commands::{Auth, Data, Ehlo, Mail, Noop, Quit, Rcpt, Starttls},
         error,
         error::Error,
-        extension::{ClientId, Extension, MailBodyParameter, MailParameter, RcptParameter, ServerInfo},
+        extension::{
+            ClientId, Extension, MailBodyParameter, MailParameter, RcptParameter, ServerInfo,
+        },
         response::{Response, parse_response},
     },
 };
@@ -115,7 +117,7 @@ impl SmtpConnection {
         if let Some(ret) = envelope.dsn_ret() {
             mail_options.push(MailParameter::Other {
                 keyword: "RET".into(),
-                value: Some(ret.clone()),
+                value: Some(ret.to_string()),
             });
         }
 
@@ -135,12 +137,20 @@ impl SmtpConnection {
         for to_address in envelope.to() {
             let mut rcpt_options = vec![];
             if let Some(notify) = envelope.dsn_notify() {
+                let notify_str = notify
+                    .iter()
+                    .map(|n| n.to_string())
+                    .collect::<Vec<String>>()
+                    .join(",");
                 rcpt_options.push(RcptParameter::Other {
                     keyword: "NOTIFY".into(),
-                    value: Some(notify.clone()),
+                    value: Some(notify_str),
                 });
             }
-            try_smtp!(self.command(Rcpt::new(to_address.clone(), rcpt_options)), self);
+            try_smtp!(
+                self.command(Rcpt::new(to_address.clone(), rcpt_options)),
+                self
+            );
         }
 
         // Data

--- a/src/transport/smtp/client/connection.rs
+++ b/src/transport/smtp/client/connection.rs
@@ -17,7 +17,7 @@ use crate::{
         commands::{Auth, Data, Ehlo, Mail, Noop, Quit, Rcpt, Starttls},
         error,
         error::Error,
-        extension::{ClientId, Extension, MailBodyParameter, MailParameter, ServerInfo},
+        extension::{ClientId, Extension, MailBodyParameter, MailParameter, RcptParameter, ServerInfo},
         response::{Response, parse_response},
     },
 };
@@ -112,6 +112,20 @@ impl SmtpConnection {
             mail_options.push(MailParameter::Body(MailBodyParameter::EightBitMime));
         }
 
+        if let Some(ret) = envelope.dsn_ret() {
+            mail_options.push(MailParameter::Other {
+                keyword: "RET".into(),
+                value: Some(ret.clone()),
+            });
+        }
+
+        if let Some(envid) = envelope.dsn_envid() {
+            mail_options.push(MailParameter::Other {
+                keyword: "ENVID".into(),
+                value: Some(envid.clone()),
+            });
+        }
+
         try_smtp!(
             self.command(Mail::new(envelope.from().cloned(), mail_options)),
             self
@@ -119,7 +133,14 @@ impl SmtpConnection {
 
         // Recipient
         for to_address in envelope.to() {
-            try_smtp!(self.command(Rcpt::new(to_address.clone(), vec![])), self);
+            let mut rcpt_options = vec![];
+            if let Some(notify) = envelope.dsn_notify() {
+                rcpt_options.push(RcptParameter::Other {
+                    keyword: "NOTIFY".into(),
+                    value: Some(notify.clone()),
+                });
+            }
+            try_smtp!(self.command(Rcpt::new(to_address.clone(), rcpt_options)), self);
         }
 
         // Data


### PR DESCRIPTION
This PR implements native SMTP Delivery Status Notification (DSN) extensions (RFC 3461) to the SMTP transport. It extends the `Envelope` structure to accept optional DSN parameters (`NOTIFY`, `RET`, and `ENVID`) and injects them directly into the `RCPT TO` and `MAIL FROM` commands during the SMTP handshake.

**Changes:**
- Added `dsn_notify`, `dsn_ret`, and `dsn_envid` to `Envelope` alongside a `with_dsn` builder.
- Updated `SmtpConnection::send_message` and `AsyncSmtpConnection::send_message` to append these parameters to `MailParameter::Other` and `RcptParameter::Other`.

**Why:**
This allows developers to request standard delivery receipts (e.g. `NOTIFY=SUCCESS,FAILURE`) natively without having to bypass `lettre`'s MIME builder or write a custom transport layer.