### PR TITLE
fix(builder): allow for duplicate trace and resent headers per RFC5322

### DIFF
--- a/src/message/header/mod.rs
+++ b/src/message/header/mod.rs
@@ -5,6 +5,7 @@ use std::{
     error::Error,
     fmt::{self, Display, Formatter, Write},
     ops::Deref,
+    sync::LazyLock,
 };
 
 use email_encoding::headers::writer::EmailWriter;
@@ -43,7 +44,30 @@ pub trait Header: Clone {
 #[derive(Debug, Clone, Default)]
 pub struct Headers {
     headers: Vec<HeaderValue>,
+    allow_duplicate_headers: bool,
 }
+
+/// Certain headers appear more than once in real emails. This is the subset that may only occur
+/// once.
+///
+/// (See [RFC5322 Section 3.6](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6))
+static UNIQUE_HEADERS: LazyLock<[HeaderName; 13]> = LazyLock::new(|| {
+    [
+        Bcc::name(),
+        Cc::name(),
+        ContentTransferEncoding::name(),
+        ContentType::name(),
+        From::name(),
+        InReplyTo::name(),
+        MessageId::name(),
+        MimeVersion::name(),
+        References::name(),
+        ReplyTo::name(),
+        Sender::name(),
+        Subject::name(),
+        To::name(),
+    ]
+});
 
 impl Headers {
     /// Create an empty `Headers`
@@ -53,6 +77,7 @@ impl Headers {
     pub const fn new() -> Self {
         Self {
             headers: Vec::new(),
+            allow_duplicate_headers: false,
         }
     }
 
@@ -63,6 +88,7 @@ impl Headers {
     pub fn with_capacity(capacity: usize) -> Self {
         Self {
             headers: Vec::with_capacity(capacity),
+            allow_duplicate_headers: false,
         }
     }
 
@@ -72,6 +98,16 @@ impl Headers {
     pub fn get<H: Header>(&self) -> Option<H> {
         self.get_raw(&H::name())
             .and_then(|raw_value| H::parse(raw_value).ok())
+    }
+
+    /// Returns all headers with a specific header name.
+    ///
+    /// Returns an empty Vec if no matches are found
+    pub fn get_all<H: Header>(&self) -> Vec<H> {
+        self.get_all_raw(&H::name())
+            .iter()
+            .filter_map(|header| H::parse(header).ok())
+            .collect()
     }
 
     /// Sets `Header` into `Headers`, overriding `Header` if it
@@ -103,10 +139,44 @@ impl Headers {
         self.find_header(name).map(|value| value.raw_value.as_str())
     }
 
+    /// Retrieve all raw headers from `Headers` that match
+    /// a key. (This is specifically meant for headers
+    /// that may be duplicated in mails).
+    ///
+    /// Returns a Vec<&str> for all headers matching name.
+    pub fn get_all_raw(&self, name: &str) -> Vec<&str> {
+        self.headers
+            .iter()
+            .filter_map(|header| {
+                if header.name == name {
+                    Some(header.raw_value.as_str())
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+
     /// Inserts a raw header into `Headers`, overriding `value` if it
     /// was already present in `Headers`.
+    ///
+    /// If `allow_duplicate_headers` is set and it is a header
+    /// that CAN be duplicated, it will be appended again.
     pub fn insert_raw(&mut self, value: HeaderValue) {
+        let allow_duplicate_headers = self.allow_duplicate_headers;
+
         match self.find_header_mut(&value.name) {
+            // If the header is found and it is allowed to be appear more than once
+            // in a mail it is appended otherwise it is replaced.
+            Some(current_value) if allow_duplicate_headers => {
+                if UNIQUE_HEADERS.contains(&value.name) {
+                    *current_value = value;
+                } else {
+                    self.headers.push(value);
+                }
+            }
+            // The old behaviour without the flag remains unchanged, a header that already
+            // exists is replaced.
             Some(current_value) => {
                 *current_value = value;
             }
@@ -123,8 +193,33 @@ impl Headers {
         self.find_header_index(name).map(|i| self.headers.remove(i))
     }
 
+    /// Remove all raw headers from `Headers` that match
+    /// a key. (This is specifically meant for headers
+    /// that may be duplicated in mails).
+    ///
+    /// Returns a Vec<HeaderValue> for all removed values.
+    pub fn remove_all_raw(&mut self, name: &str) -> Vec<HeaderValue> {
+        // Ideally here we would want to use Vec::extract_if(), but
+        // but it is only available on rust version > 1.87
+        // Instead we have to clone the headers out first and then
+        // remove them in the next step.
+        let extracted = self
+            .headers
+            .iter()
+            .filter(|header| header.name == name)
+            .cloned()
+            .collect();
+
+        self.headers.retain(|header| header.name != name);
+        extracted
+    }
+
     pub(crate) fn find_header(&self, name: &str) -> Option<&HeaderValue> {
         self.headers.iter().find(|value| name == value.name)
+    }
+
+    pub fn allow_duplicate_headers(&mut self) {
+        self.allow_duplicate_headers = true;
     }
 
     fn find_header_mut(&mut self, name: &str) -> Option<&mut HeaderValue> {

--- a/src/message/header/textual.rs
+++ b/src/message/header/textual.rs
@@ -82,6 +82,11 @@ text_header! {
     /// defined in [RFC2110](https://tools.ietf.org/html/rfc2110#section-4.3)
     Header(ContentLocation, "Content-Location")
 }
+text_header! {
+    /// `Received` header,
+    /// defined in [RFC5322](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6.7)
+    Header(Received, "Received")
+}
 
 #[cfg(test)]
 mod test {

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -247,6 +247,19 @@ impl MessageBuilder {
         }
     }
 
+    /// When building a mail from a parsed mail, you might encounter duplicate headers
+    ///
+    /// This method will allow Trace and Resent headers to be duplicated
+    /// See [RFC5422 section 3.6](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6)
+    ///
+    /// Due to how headers are handled while building mails, the least intrusive way to
+    /// handle this is to allow only duplicates of Trace and Resent fields ONLY and not
+    /// also to Optional-field headers, as the scope would be too wide to control.
+    pub fn allow_duplicate_headers(mut self) -> Self {
+        self.headers.allow_duplicate_headers();
+        self
+    }
+
     /// Set or add mailbox to `From` header
     ///
     /// Defined in [RFC5322](https://tools.ietf.org/html/rfc5322#section-3.6.2).
@@ -802,5 +815,46 @@ mod test {
         for id in ids {
             assert_eq!(36, id.len());
         }
+    }
+
+    #[test]
+    fn should_disallow_duplicate_trace_headers_when_config_unset() {
+        let header_one = header::Received::from(
+            "from node.example by x.y.test; 21 Nov 1997 10:01:22 -0600".to_owned(),
+        );
+        let header_two = header::Received::from(
+            "from apple.example by node.example; 21 Nov 1997 12:01:22 -0600".to_owned(),
+        );
+        let email = Message::builder()
+            .from("NoBody <nobody@domain.tld>".parse().unwrap())
+            .to("NoBody <nobody@domain.tld>".parse().unwrap())
+            .header(header_one)
+            // This header should overwrite the above header
+            .header(header_two.clone());
+
+        let received_headers = email.headers.get_all::<header::Received>();
+
+        assert_eq!(1, received_headers.len());
+        assert_eq!(Some(header_two), received_headers.into_iter().next());
+    }
+
+    #[test]
+    fn should_allow_duplicate_trace_headers_when_config_set() {
+        let email = Message::builder()
+            // The Received header should now be able to be duplicated.
+            // and From should not.
+            .allow_duplicate_headers()
+            .from("NoBody <nobody@domain.tld>".parse().unwrap())
+            .from("NoBody <somebody@domain.tld>".parse().unwrap())
+            .to("NoBody <nobody@domain.tld>".parse().unwrap())
+            .header(header::Received::from(
+                "from node.example by x.y.test; 21 Nov 1997 10:01:22 -0600".to_owned(),
+            ))
+            .header(header::Received::from(
+                "from apple.example by node.example; 21 Nov 1997 12:01:22 -0600".to_owned(),
+            ));
+
+        assert_eq!(email.headers.get_all::<header::Received>().len(), 2);
+        assert_eq!(email.headers.get_all::<header::From>().len(), 1);
     }
 }


### PR DESCRIPTION
In a use case where an existing mail is parsed using mail-parser, and then gets put back together using lettre, I am having an issue that headers are unintentionally being removed from emails when headers with duplicate names are encountered.

According to RFC5322, certain headers are able to occur more than once. This is mainly the `Trace` and `Resent` headers.

In this pull request I have added the ability to add headers with duplicate names after calling `.allow_duplicate_headers()` method on the mail builder. 

For convenience, here is the table from [RFC5322 3.6](https://datatracker.ietf.org/doc/html/rfc5322#section-3.6) describing the number of times each header is allowed.
```
   +----------------+--------+------------+----------------------------+
   | Field          | Min    | Max number | Notes                      |
   |                | number |            |                            |
   +----------------+--------+------------+----------------------------+
   | trace          | 0      | unlimited  | Block prepended - see      |
   |                |        |            | 3.6.7                      |
   | resent-date    | 0*     | unlimited* | One per block, required if |
   |                |        |            | other resent fields are    |
   |                |        |            | present - see 3.6.6        |
   | resent-from    | 0      | unlimited* | One per block - see 3.6.6  |
   | resent-sender  | 0*     | unlimited* | One per block, MUST occur  |
   |                |        |            | with multi-address         |
   |                |        |            | resent-from - see 3.6.6    |
   | resent-to      | 0      | unlimited* | One per block - see 3.6.6  |
   | resent-cc      | 0      | unlimited* | One per block - see 3.6.6  |
   | resent-bcc     | 0      | unlimited* | One per block - see 3.6.6  |
   | resent-msg-id  | 0      | unlimited* | One per block - see 3.6.6  |
   | orig-date      | 1      | 1          |                            |
   | from           | 1      | 1          | See sender and 3.6.2       |
   | sender         | 0*     | 1          | MUST occur with            |
   |                |        |            | multi-address from - see   |
   |                |        |            | 3.6.2                      |
   | reply-to       | 0      | 1          |                            |
   | to             | 0      | 1          |                            |
   | cc             | 0      | 1          |                            |
   | bcc            | 0      | 1          |                            |
   | message-id     | 0*     | 1          | SHOULD be present - see    |
   |                |        |            | 3.6.4                      |
   | in-reply-to    | 0*     | 1          | SHOULD occur in some       |
   |                |        |            | replies - see 3.6.4        |
   | references     | 0*     | 1          | SHOULD occur in some       |
   |                |        |            | replies - see 3.6.4        |
   | subject        | 0      | 1          |                            |
   | comments       | 0      | unlimited  |                            |
   | keywords       | 0      | unlimited  |                            |
   | optional-field | 0      | unlimited  |                            |
   +----------------+--------+------------+----------------------------+
```