### PR TITLE
Prepare v0.11.23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+<a name="v0.11.23"></a>
+### v0.11.23 (2026-08-03)
+
+#### Bug Fixes
+
+* Separate lines of multiline SMTP error replies ([#1153])
+
+#### Misc
+
+* Upgrade `base64` to v0.23 ([#1152])
+
+[#1152]: https://github.com/lettre/lettre/pull/1152
+[#1153]: https://github.com/lettre/lettre/pull/1153
+
 <a name="v0.11.22"></a>
 ### v0.11.22 (2026-05-14)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1168,7 +1168,7 @@ dependencies = [
 
 [[package]]
 name = "lettre"
-version = "0.11.22"
+version = "0.11.23"
 dependencies = [
  "async-std",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lettre"
 # remember to update html_root_url and README.md (Cargo.toml example and deps.rs badge)
-version = "0.11.22"
+version = "0.11.23"
 description = "Email client"
 readme = "README.md"
 homepage = "https://lettre.rs"

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@
 </div>
 
 <div align="center">
-  <a href="https://deps.rs/crate/lettre/0.11.22">
-    <img src="https://deps.rs/crate/lettre/0.11.22/status.svg"
+  <a href="https://deps.rs/crate/lettre/0.11.23">
+    <img src="https://deps.rs/crate/lettre/0.11.23/status.svg"
       alt="dependency status" />
   </a>
 </div>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@
 //! [mime 0.3]: https://docs.rs/mime/0.3
 //! [DKIM]: https://datatracker.ietf.org/doc/html/rfc6376
 
-#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.22")]
+#![doc(html_root_url = "https://docs.rs/crate/lettre/0.11.23")]
 #![doc(html_favicon_url = "https://lettre.rs/favicon.ico")]
 #![doc(html_logo_url = "https://avatars0.githubusercontent.com/u/15113230?v=4")]
 #![forbid(unsafe_code)]


### PR DESCRIPTION
#### Bug Fixes

* Separate lines of multiline SMTP error replies (#1153)

#### Misc

* Upgrade `base64` to v0.23 (#1152)