### PR TITLE
fix(message: fix address round-tripping

### DIFF
--- a/src/message/mailbox/parsers/rfc2822.rs
+++ b/src/message/mailbox/parsers/rfc2822.rs
@@ -143,12 +143,28 @@ fn quoted_string(input: &str) -> IResult<&str, String> {
     .parse(input)
 }
 
+// A raw `quoted-string`, quotes and escapes intact.
+//
+// `quoted_string` decodes, which is appropriate for a
+// display-name. `local-part` is the opposite: the quoting makes the
+// local part legal, and `Address` both stores and validates the
+// quoted text, so stripping the quotes there turns a valid address
+// into an invalid one.
+fn quoted_string_raw(input: &str) -> IResult<&str, String> {
+    map(recognize(quoted_string), str::to_owned).parse(input)
+}
+
 // 3.2.6. Miscellaneous tokens
 // https://datatracker.ietf.org/doc/html/rfc2822#section-3.2.6
 
 // word            =       atom / quoted-string
 fn word(input: &str) -> IResult<&str, String> {
     alt((quoted_string, atom)).parse(input)
+}
+
+// `word`, keeping a quoted-string's quoting — see `quoted_string_raw`.
+fn word_raw(input: &str) -> IResult<&str, String> {
+    alt((quoted_string_raw, atom)).parse(input)
 }
 
 // phrase          =       1*word / obs-phrase
@@ -211,13 +227,51 @@ pub(super) fn addr_spec(input: &str) -> IResult<&str, (String, String)> {
 
 // local-part      =       dot-atom / quoted-string / obs-local-part
 pub(super) fn local_part(input: &str) -> IResult<&str, String> {
-    alt((dot_atom, quoted_string, obs_local_part)).parse(input)
+    alt((dot_atom, quoted_string_raw, obs_local_part)).parse(input)
 }
 
 // domain          =       dot-atom / domain-literal / obs-domain
 pub(super) fn domain(input: &str) -> IResult<&str, String> {
-    // NOTE: omitting domain-literal since it may never be used
-    alt((dot_atom, obs_domain)).parse(input)
+    alt((dot_atom, domain_literal, obs_domain)).parse(input)
+}
+
+// 3.4.1 (cont.) Domain literals
+
+// dtext           =       NO-WS-CTL /     ; Non white space controls
+//
+//                         %d33-90 /       ; The rest of the US-ASCII
+//                         %d94-126        ;  characters not including "[",
+//                                         ;  "]", or "\"
+fn dtext(input: &str) -> IResult<&str, char> {
+    alt((
+        satisfy(|c| matches!(u32::from(c), 33..=90 | 94..=126)),
+        no_ws_ctl,
+    ))
+    .parse(input)
+}
+
+// dcontent        =       dtext / quoted-pair
+fn dcontent(input: &str) -> IResult<&str, char> {
+    alt((dtext, quoted_pair)).parse(input)
+}
+
+// domain-literal  =       [CFWS] "[" *([FWS] dcontent) [FWS] "]" [CFWS]
+//
+// The brackets are part of the domain, not delimiters to be stripped: `Address`
+// stores the domain text and validates it as an RFC 5321 `address-literal`.
+fn domain_literal(input: &str) -> IResult<&str, String> {
+    preceded(
+        cfws,
+        map(
+            recognize(delimited(
+                char('['),
+                many0(preceded(fws, dcontent)),
+                preceded(fws, char(']')),
+            )),
+            str::to_owned,
+        ),
+    )
+    .parse(input)
 }
 
 // 4.1. Miscellaneous obsolete tokens
@@ -252,7 +306,7 @@ fn obs_phrase(input: &str) -> IResult<&str, String> {
 // obs-local-part  =       word *("." word)
 pub(super) fn obs_local_part(input: &str) -> IResult<&str, String> {
     map(
-        pair(word, many0(pair(char('.'), word))),
+        pair(word_raw, many0(pair(char('.'), word_raw))),
         |(mut result, rest)| {
             for (_, word) in rest {
                 result.push('.');

--- a/src/message/mailbox/types.rs
+++ b/src/message/mailbox/types.rs
@@ -622,4 +622,85 @@ mod test {
             ))
         );
     }
+
+    // RFC 2822 3.4.1: `local-part = dot-atom / quoted-string / obs-local-part`.
+    // The quoting is what makes these local parts legal, so it is part of the
+    // address and must survive parsing.
+    #[test]
+    fn parse_quoted_local_part() {
+        for addr in [
+            r#""has space"@example.com"#,
+            r#""has@at"@example.com"#,
+            r#""a<b"@example.com"#,
+            r#""a,b"@example.com"#,
+        ] {
+            assert_eq!(
+                addr.parse(),
+                Ok(Mailbox::new(None, addr.parse().unwrap())),
+                "failed to parse {addr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_quoted_local_part_with_display_name() {
+        assert_eq!(
+            r#"K. <"has space"@example.com>"#.parse(),
+            Ok(Mailbox::new(
+                Some("K.".into()),
+                r#""has space"@example.com"#.parse().unwrap()
+            ))
+        );
+    }
+
+    // RFC 2822 3.4.1: `domain = dot-atom / domain-literal / obs-domain`.
+    #[test]
+    fn parse_domain_literal() {
+        for addr in [
+            "kayo@[192.0.2.1]",
+            "kayo@[127.0.0.1]",
+            "kayo@[IPv6:2001:db8::1]",
+        ] {
+            assert_eq!(
+                addr.parse(),
+                Ok(Mailbox::new(None, addr.parse().unwrap())),
+                "failed to parse {addr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_domain_literal_with_display_name() {
+        assert_eq!(
+            "K. <kayo@[192.0.2.1]>".parse(),
+            Ok(Mailbox::new(
+                Some("K.".into()),
+                "kayo@[192.0.2.1]".parse().unwrap()
+            ))
+        );
+    }
+
+    #[test]
+    fn display_round_trips_through_parse() {
+        for addr in [
+            "kayo@example.com",
+            r#""has space"@example.com"#,
+            r#""has@at"@example.com"#,
+            "kayo@[192.0.2.1]",
+            "kayo@[IPv6:2001:db8::1]",
+        ] {
+            let address: super::Address = addr.parse().unwrap();
+            for mailbox in [
+                Mailbox::new(None, address.clone()),
+                Mailbox::new(Some("K.".into()), address.clone()),
+            ] {
+                let rendered = mailbox.to_string();
+                assert_eq!(
+                    rendered.parse(),
+                    Ok(mailbox.clone()),
+                    "{mailbox} rendered as {rendered:?}, which did not parse back"
+                );
+            }
+        }
+    }
 }

--- a/src/message/mod.rs
+++ b/src/message/mod.rs
@@ -657,6 +657,34 @@ mod test {
         );
     }
 
+    // `Headers` stores each header as a string and re-parses it on
+    // `get`, so `build` can only produce a `Message` for an address
+    // that can round-trip. These addresses are accepted by `Address`,
+    // yet building the message failed with `MissingFrom`/`MissingTo`,
+    // naming the wrong problem entirely.
+    #[test]
+    fn email_with_quoted_local_part_or_domain_literal() {
+        for addr in [
+            r#""has space"@example.com"#,
+            r#""has@at"@example.com"#,
+            "nobody@[192.0.2.1]",
+            "nobody@[IPv6:2001:db8::1]",
+        ] {
+            let address: crate::Address = addr.parse().expect("Address accepts it");
+            let mailbox = Mailbox::new(None, address.clone());
+
+            let email = Message::builder()
+                .from(mailbox.clone())
+                .to(mailbox)
+                .body(String::from("Happy new year!"));
+
+            let email = email
+                .unwrap_or_else(|e| panic!("could not build a Message for {addr}: {e:?}"));
+            assert_eq!(email.envelope().to(), [address.clone()]);
+            assert_eq!(email.envelope().from(), Some(&address));
+        }
+    }
+
     #[test]
     fn email_missing_sender() {
         assert!(


### PR DESCRIPTION
An address using a quoted local part or a domain literal could not round-trip, which breaks the ability to send messages that use either of those constructs.  These changes add tests to demonstrate the problem, and then fix the problem.  All other tests stay green.