### PR TITLE
fix(transport-smtp): apply the configured timeout to async operations

### DIFF
--- a/src/transport/smtp/client/async_connection.rs
+++ b/src/transport/smtp/client/async_connection.rs
@@ -9,7 +9,7 @@ use super::escape_crlf;
 #[allow(deprecated)]
 use super::{
     ClientCodec, MAX_RESPONSE_BYTES, MAX_RESPONSE_LINE_BYTES, TlsParameters,
-    async_net::AsyncNetworkStream,
+    async_net::{AsyncNetworkStream, with_timeout},
 };
 use crate::{
     Envelope,
@@ -45,6 +45,8 @@ pub struct AsyncSmtpConnection {
     panic: bool,
     /// Information about the server
     server_info: ServerInfo,
+    /// Timeout applied to each read and write operation, if any
+    timeout: Option<Duration>,
 }
 
 impl AsyncSmtpConnection {
@@ -64,7 +66,7 @@ impl AsyncSmtpConnection {
     ) -> Result<AsyncSmtpConnection, Error> {
         #[allow(deprecated)]
         let stream = AsyncNetworkStream::use_existing_tokio1(stream);
-        Self::connect_impl(stream, hello_name).await
+        Self::connect_impl(stream, hello_name, None).await
     }
 
     /// Connects to the configured server
@@ -110,7 +112,7 @@ impl AsyncSmtpConnection {
         let stream =
             AsyncNetworkStream::connect_tokio1(server, timeout, tls_parameters, local_address)
                 .await?;
-        Self::connect_impl(stream, hello_name).await
+        Self::connect_impl(stream, hello_name, timeout).await
     }
 
     /// Connects to the configured server
@@ -126,19 +128,21 @@ impl AsyncSmtpConnection {
     ) -> Result<AsyncSmtpConnection, Error> {
         #[allow(deprecated)]
         let stream = AsyncNetworkStream::connect_asyncstd1(server, timeout, tls_parameters).await?;
-        Self::connect_impl(stream, hello_name).await
+        Self::connect_impl(stream, hello_name, timeout).await
     }
 
     #[allow(deprecated)]
     async fn connect_impl(
         stream: AsyncNetworkStream,
         hello_name: &ClientId,
+        timeout: Option<Duration>,
     ) -> Result<AsyncSmtpConnection, Error> {
         let stream = BufReader::new(stream);
         let mut conn = AsyncSmtpConnection {
             stream,
             panic: false,
             server_info: ServerInfo::default(),
+            timeout,
         };
         // TODO log
         let _response = conn.read_response().await?;
@@ -340,16 +344,15 @@ impl AsyncSmtpConnection {
 
     /// Writes a string to the server
     async fn write(&mut self, string: &[u8]) -> Result<(), Error> {
-        self.stream
-            .get_mut()
-            .write_all(string)
-            .await
-            .map_err(error::network)?;
-        self.stream
-            .get_mut()
-            .flush()
-            .await
-            .map_err(error::network)?;
+        let runtime = self.stream.get_ref().runtime();
+        let timeout = self.timeout;
+        let stream = self.stream.get_mut();
+        with_timeout(runtime, timeout, async {
+            stream.write_all(string).await?;
+            stream.flush().await
+        })
+        .await?
+        .map_err(error::network)?;
 
         #[cfg(feature = "tracing")]
         tracing::debug!("Wrote: {}", escape_crlf(&String::from_utf8_lossy(string)));
@@ -358,16 +361,18 @@ impl AsyncSmtpConnection {
 
     /// Gets the SMTP response
     pub async fn read_response(&mut self) -> Result<Response, Error> {
+        let runtime = self.stream.get_ref().runtime();
+        let timeout = self.timeout;
         let mut buffer = String::with_capacity(100);
         let mut pre = 0;
 
-        while self
-            .stream
-            .read_line(&mut buffer)
-            .await
-            .map_err(error::network)?
-            > 0
-        {
+        loop {
+            let read = with_timeout(runtime, timeout, self.stream.read_line(&mut buffer))
+                .await?
+                .map_err(error::network)?;
+            if read == 0 {
+                break;
+            }
             if buffer.len() - pre > MAX_RESPONSE_LINE_BYTES {
                 return Err(error::response("SMTP response line too long"));
             }

--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -93,6 +93,49 @@ enum InnerAsyncNetworkStream {
     None,
 }
 
+/// Which async runtime a stream is running on, used to pick the matching timer.
+#[derive(Clone, Copy)]
+pub(super) enum AsyncRuntime {
+    #[cfg(feature = "tokio1")]
+    Tokio1,
+    #[cfg(feature = "async-std1")]
+    AsyncStd1,
+}
+
+/// Runs `future`, giving up with a timeout error if it doesn't finish within `timeout`.
+///
+/// When `timeout` is `None` the future is awaited without any limit, so behavior is
+/// unchanged for callers that opted out of timeouts.
+pub(super) async fn with_timeout<F: std::future::Future>(
+    runtime: AsyncRuntime,
+    timeout: Option<Duration>,
+    future: F,
+) -> Result<F::Output, Error> {
+    let Some(timeout) = timeout else {
+        return Ok(future.await);
+    };
+
+    let timed_out = || {
+        error::network(io::Error::new(
+            io::ErrorKind::TimedOut,
+            "the SMTP operation timed out",
+        ))
+    };
+
+    match runtime {
+        #[cfg(feature = "tokio1")]
+        AsyncRuntime::Tokio1 => match tokio1_crate::time::timeout(timeout, future).await {
+            Ok(output) => Ok(output),
+            Err(_) => Err(timed_out()),
+        },
+        #[cfg(feature = "async-std1")]
+        AsyncRuntime::AsyncStd1 => match async_std::future::timeout(timeout, future).await {
+            Ok(output) => Ok(output),
+            Err(_) => Err(timed_out()),
+        },
+    }
+}
+
 #[allow(deprecated)]
 impl AsyncNetworkStream {
     fn new(inner: InnerAsyncNetworkStream) -> Self {
@@ -125,6 +168,35 @@ impl AsyncNetworkStream {
                 Err(IoError::other(
                     "InnerAsyncNetworkStream::None must never be built",
                 ))
+            }
+        }
+    }
+
+    /// Returns the async runtime the underlying stream belongs to.
+    pub(super) fn runtime(&self) -> AsyncRuntime {
+        match &self.inner {
+            #[cfg(feature = "tokio1")]
+            InnerAsyncNetworkStream::Tokio1Tcp(_) => AsyncRuntime::Tokio1,
+            #[cfg(feature = "tokio1-native-tls")]
+            InnerAsyncNetworkStream::Tokio1NativeTls(_) => AsyncRuntime::Tokio1,
+            #[cfg(feature = "tokio1-rustls")]
+            InnerAsyncNetworkStream::Tokio1Rustls(_) => AsyncRuntime::Tokio1,
+            #[cfg(feature = "tokio1-boring-tls")]
+            InnerAsyncNetworkStream::Tokio1BoringTls(_) => AsyncRuntime::Tokio1,
+            #[cfg(feature = "async-std1")]
+            InnerAsyncNetworkStream::AsyncStd1Tcp(_) => AsyncRuntime::AsyncStd1,
+            #[cfg(feature = "async-std1-rustls")]
+            InnerAsyncNetworkStream::AsyncStd1Rustls(_) => AsyncRuntime::AsyncStd1,
+            InnerAsyncNetworkStream::None => {
+                debug_assert!(false, "InnerAsyncNetworkStream::None must never be built");
+                #[cfg(feature = "tokio1")]
+                {
+                    AsyncRuntime::Tokio1
+                }
+                #[cfg(all(not(feature = "tokio1"), feature = "async-std1"))]
+                {
+                    AsyncRuntime::AsyncStd1
+                }
             }
         }
     }

--- a/tests/transport_smtp.rs
+++ b/tests/transport_smtp.rs
@@ -114,3 +114,47 @@ mod read_response_caps {
         );
     }
 }
+
+#[cfg(test)]
+#[cfg(all(feature = "smtp-transport", feature = "tokio1"))]
+mod operation_timeout {
+    use std::{net::TcpListener, thread, time::Duration};
+
+    use lettre::transport::smtp::{client::AsyncSmtpConnection, extension::ClientId};
+    use tokio1_crate as tokio;
+
+    // A server that accepts the connection but never speaks should not make the
+    // client hang forever: the configured timeout has to apply to reads too, not
+    // just to establishing the connection.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn silent_server_hits_the_timeout() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        thread::spawn(move || {
+            if let Ok((sock, _)) = listener.accept() {
+                // Hold the connection open without sending the greeting.
+                thread::sleep(Duration::from_secs(10));
+                drop(sock);
+            }
+        });
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(5),
+            AsyncSmtpConnection::connect_tokio1(
+                addr,
+                Some(Duration::from_millis(200)),
+                &ClientId::Domain("test".into()),
+                None,
+                None,
+            ),
+        )
+        .await
+        .expect("connect must return within 5s, not hang");
+
+        let err = match result {
+            Ok(_) => panic!("a silent server must not connect successfully"),
+            Err(e) => e,
+        };
+        assert!(err.is_timeout(), "expected a timeout error, got {err:?}");
+    }
+}


### PR DESCRIPTION
Right now the timeout on `AsyncSmtpTransport` only covers opening the connection. Once connected, the reads and writes during the SMTP conversation aren't bounded, so a server that stops responding mid-send makes the whole thing hang. The sync transport already sets socket read and write timeouts, so this wraps each async read and write in the same configured timeout to bring the two in line.

There's a small test that points a connection at a server which accepts but never sends the greeting and checks it returns a timeout error instead of hanging.

Closes #1027