### PR TITLE
perf(transport-smtp): set TCP_NODELAY on connections

### DIFF
--- a/src/transport/smtp/client/async_net.rs
+++ b/src/transport/smtp/client/async_net.rs
@@ -194,6 +194,8 @@ impl AsyncNetworkStream {
         }
 
         let tcp_stream = try_connect(server, timeout, local_addr).await?;
+        // Nagle would hold the `\r\n.\r\n` ending a message until the body is acked.
+        tcp_stream.set_nodelay(true).map_err(error::connection)?;
         let mut stream =
             AsyncNetworkStream::new(InnerAsyncNetworkStream::Tokio1Tcp(Box::new(tcp_stream)));
         if let Some(tls_parameters) = tls_parameters {
@@ -247,6 +249,8 @@ impl AsyncNetworkStream {
                 .map_err(error::connection)?,
         };
 
+        // Nagle would hold the `\r\n.\r\n` ending a message until the body is acked.
+        tcp_stream.set_nodelay(true).map_err(error::connection)?;
         let mut stream = AsyncNetworkStream::new(InnerAsyncNetworkStream::AsyncStd1Tcp(tcp_stream));
         if let Some(tls_parameters) = tls_parameters {
             stream.upgrade_tls(tls_parameters).await?;

--- a/src/transport/smtp/client/net.rs
+++ b/src/transport/smtp/client/net.rs
@@ -137,6 +137,8 @@ impl NetworkStream {
         }
 
         let tcp_stream = try_connect(server, timeout, local_addr)?;
+        // Nagle would hold the `\r\n.\r\n` ending a message until the body is acked.
+        tcp_stream.set_nodelay(true).map_err(error::connection)?;
         let mut stream = NetworkStream::new(InnerNetworkStream::Tcp(tcp_stream));
         if let Some(tls_parameters) = tls_parameters {
             stream.upgrade_tls(tls_parameters)?;


### PR DESCRIPTION
`TCP_NODELAY` and `set_nodelay` appear nowhere in the crate, so every SMTP
connection runs with Nagle on. That costs 40 ms on every message sent.

## The stall

`message_iter` writes the encoded body with `write_all` and flushes, then
writes `\r\n.\r\n` as a second `write_all` and flushes again. Nagle holds
that five byte write until the peer acknowledges the body, and the peer's
delayed ACK is 40 ms. Every step of an SMTP session is a write followed by
a wait for a reply, so Nagle never has a second write to coalesce with.

## Measured

At `master`, a 4,376 byte message to mailpit on loopback, sent down one
pooled connection. Per-message figures exclude the first send, which pays
for the connect.

|  | per message | one connection, 200 messages |
| --- | --- | --- |
| before | 42 to 44 ms | 22 messages/s |
| after | 1.2 to 2.0 ms | 462 messages/s |

A `python3 smtplib` session to the same mailpit costs 1.1 ms a message, so
1.2 ms is roughly what the exchange costs when nothing is waiting.

`tcpdump -i lo -n -ttt -q 'tcp port 1025'` around one message, before:

```
 00:00:00.000016 IP 127.0.0.1.1025 > 127.0.0.1.57110: tcp 50     250 for DATA
 00:00:00.000026 IP 127.0.0.1.57110 > 127.0.0.1.1025: tcp 4376   the body
 00:00:00.040722 IP 127.0.0.1.1025 > 127.0.0.1.57110: tcp 0      delayed ACK
 00:00:00.000026 IP 127.0.0.1.57110 > 127.0.0.1.1025: tcp 5      \r\n.\r\n
 00:00:00.004084 IP 127.0.0.1.1025 > 127.0.0.1.57110: tcp 48     250
```

and after, where the terminator follows the body in 89 us:

```
 00:00:00.000053 IP 127.0.0.1.1025 > 127.0.0.1.32936: tcp 50
 00:00:00.000052 IP 127.0.0.1.32936 > 127.0.0.1.1025: tcp 4376
 00:00:00.000089 IP 127.0.0.1.32936 > 127.0.0.1.1025: tcp 5
 00:00:00.001179 IP 127.0.0.1.1025 > 127.0.0.1.32936: tcp 48
```

To reproduce: `docker run --network host axllent/mailpit`, send one message
with `AsyncSmtpTransport` at 127.0.0.1:1025, and watch loopback with the
tcpdump line above.

## The blocking transport has the same gap

I measured it rather than assuming. `NetworkStream::connect` builds its
socket with socket2 and never sets the option either, and its capture shows
the same 40 ms between body and terminator, 43 ms a message.
`connect_asyncstd1` is the third copy of the same omission. This sets
`TCP_NODELAY` on all three, since fixing one and leaving the other two
stalling would be an odd place to stop.

The option is not readable through `NetworkStream` or `AsyncNetworkStream`,
and neither exposes its socket, so there is no test here and I checked it on
the wire instead. Happy to add an accessor and a test if you would prefer one.

`cargo fmt --all -- --check` and `cargo clippy --all-targets -- -D warnings`
are clean, and the suite passes on the default features and on the wide
feature set CI uses. The sendmail tests fail on my machine for want of a
`sendmail` binary, before and after the change alike.
